### PR TITLE
Add empty CI job in preparation for unit tests

### DIFF
--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -34,8 +34,3 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install torch
-          python -m pip install -e ".[dev]" --no-build-isolation -vvv
-      - name: Run unit tests with coverage
-        run: pytest test --cov=. --cov-report=xml --durations=20 -vv
-      - name: Upload Coverage to Codecov
-        uses: codecov/codecov-action@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,3 @@ version = "0.0.1"
 [build-system]
 requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
-
-[project.optional-dependencies]
-dev = [
-    "pytest",
-    "pytest-cov",
-]


### PR DESCRIPTION
This PR just adds a basic CI job that does nothing apart from installing pytorch. We need to merge it first for the CI job to actually trigger on subsequent PRs, at which point I'll be able to start adding the actual package build and running the tests.