### PR TITLE
Run Python unittests on GitHub Actions with ffmpeg 4

### DIFF
--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -33,4 +33,21 @@ jobs:
         run: python -m pip install --upgrade pip
       - name: Install dependencies
         run: |
-          python -m pip install torch
+          python -m pip install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu
+          # TODO: This is installing ffmpeg with GPL stuff enabled. That's just
+          # for testing for now so it's OK. But before we release we should make
+          # sure it's not using GPL stuff by e.g. building from source like
+          # in torchaudio.
+          # TODO: Make this work with ffmpeg > 4. The default conda-forge ffmpeg version is 7 ATM.
+          conda install "ffmpeg<5.0" pkg-config -c conda-forge
+          ffmpeg -version
+      - name: Build and install torchcodec
+        run: |
+          python -m pip install -e ".[dev]" --no-build-isolation -vvv
+      - name: Smoke test
+        run: |
+          python test/decoders/manual_smoke_test.py
+          # TODO: diff the output frame with its expeceted value
+      - name: Run tests
+        run: |
+          pytest test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,10 @@ add_library(${LIBRARY_NAME}
 
 set_property(TARGET ${LIBRARY_NAME} PROPERTY CXX_STANDARD 17)
 
+# TODO: This should eventually be removed when we support more ffmpeg versions
+# or determined within CMake.
+target_compile_definitions(${LIBRARY_NAME} PRIVATE FFMPEG_VERSION_4)
+
 target_include_directories(${LIBRARY_NAME} PRIVATE ./)
 
 target_link_libraries(${LIBRARY_NAME}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,11 @@ version = "0.0.1"
 [build-system]
 requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
+
+[project.optional-dependencies]
+dev = [
+    "numpy",
+    "pytest",
+    "pillow",
+    "opencv-python",
+]

--- a/test/decoders/video_decoder_ops_test.py
+++ b/test/decoders/video_decoder_ops_test.py
@@ -27,6 +27,7 @@ from torchcodec.decoders._core import (
 )
 
 torch._dynamo.config.capture_dynamic_output_shape_ops = True
+IN_FBCODE = os.environ.get("IN_FBCODE_TORCHCODEC") == "1"
 
 
 # TODO: Eventually move that as a common test util
@@ -34,12 +35,18 @@ def assert_equal(*args, **kwargs):
     torch.testing.assert_close(*args, **kwargs, atol=0, rtol=0)
 
 
+# TODO: Eventually move that as a common test util
 def get_video_path(filename: str) -> pathlib.Path:
-    resource = (
-        importlib.resources.files(__package__).joinpath("resources").joinpath(filename)
-    )
-    with importlib.resources.as_file(resource) as path:
-        return path
+    if IN_FBCODE:
+        resource = (
+            importlib.resources.files(__package__)
+            .joinpath("resources")
+            .joinpath(filename)
+        )
+        with importlib.resources.as_file(resource) as path:
+            return path
+    else:
+        return pathlib.Path(__file__).parent / "resources" / filename
 
 
 # TODO: make this a fixture or wrap with @functools.lru_cache to avoid

--- a/test/samplers/video_clip_sampler_test.py
+++ b/test/samplers/video_clip_sampler_test.py
@@ -2,6 +2,8 @@
 
 
 import importlib
+import os
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -14,9 +16,19 @@ from torchcodec.samplers import (
 )
 
 
+# TODO: move this to a common util
+IN_FBCODE = os.environ.get("IN_FBCODE_TORCHCODEC") == "1"
+
+
+# TODO: Eventually rely on common util for this
 @pytest.fixture()
 def nasa_13013() -> torch.Tensor:
-    video_path = importlib.resources.path(__package__, "nasa_13013.mp4")
+    if IN_FBCODE:
+        video_path = importlib.resources.path(__package__, "nasa_13013.mp4")
+    else:
+        video_path = (
+            Path(__file__).parent.parent / "decoders" / "resources" / "nasa_13013.mp4"
+        )
     arr = np.fromfile(video_path, dtype=np.uint8)
     video_tensor = torch.from_numpy(arr)
     return video_tensor


### PR DESCRIPTION
This PR lets the GitHub CI run the Python unittests on Python 3.8 to 3.12. We're enforcing ffmpeg4 for now. There is fair amount of TODOs left to be addressed later, in particular regarding unifying the test utils.

We now have to distinguish whether the tests are being run on fbcode or externally. For that we are using a newly defined `IN_FBCODE_TORCHCODEC` env variable which will be set within the internal TARGET files. This is similar to the [torchvision setup](https://www.internalfb.com/code/fbsource/[40a4afadd468]/fbcode/pytorch/vision/test/defs.bzl?lines=38), which I took form the pytorch setup itself. (It's fine to leak the name "fbcode" externally, you'll find it absolutely everywhere in most pytorch-related code-bases).

Test Plan: GitHub CI.