### PR TITLE
Remove old references to `MOD_NAME` and slightly udpate comments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,23 +7,6 @@ find_package(PkgConfig REQUIRED)
 
 set(LIBRARY_NAME "torchcodec")
 
-# We want .so file to be named "module.so", not "libmodule.so". This removes
-# the "lib" prefix.
-set_target_properties(${MOD_NAME} PROPERTIES PREFIX "")
-
-# The install step is invoked within CMakeBuild.build_extension() and just
-# copies the built .so files from the temp cmake/setuptools build folder into
-# where those .so files are supposed to be within the package, for example in
-# `.../src/torchcodec/module.so` if `module` is meant to be imported from
-# `torchcodec`.
-# That CMAKE_INSTALL_PREFIX variable is set in build_extension(), and utlimately
-# originates from the Extension instance's "name" parameter (e.g.
-# "torchcodec.module").
-# We still need to manually pass "DESTINATION ..." for cmake to copy those files
-# in CMAKE_INSTALL_PREFIX instead of CMAKE_INSTALL_PREFIX/lib.
-install(TARGETS ${MOD_NAME} DESTINATION ${CMAKE_INSTALL_PREFIX})
-
-
 pkg_check_modules(LIBAV REQUIRED IMPORTED_TARGET
     libavdevice
     libavfilter
@@ -60,4 +43,9 @@ target_link_libraries(${LIBRARY_NAME}
     "${TORCH_LIBRARIES}"
 )
 
+# The install step is invoked within CMakeBuild.build_extension() and just
+# copies the built .so files from the temp cmake/setuptools build folder into
+# the CMAKE_INSTALL_PREFIX folder.
+# We still need to manually pass "DESTINATION ..." for cmake to copy those files
+# in CMAKE_INSTALL_PREFIX instead of CMAKE_INSTALL_PREFIX/lib.
 install(TARGETS ${LIBRARY_NAME} DESTINATION ${CMAKE_INSTALL_PREFIX})


### PR DESCRIPTION
That module was previously used as a place-holder to illustrate how to build a pytorch C extension but now that we properly build `libtorchcodec` it's been removed. This PR cleans up some last references to this module, and also slightly updates some related build comments to hopefully be a bit clearer.

Test plan: `pip install -e . --no-build-isolation` still works