### PR TITLE
[torchcodec] make getting frame duration work across ffmpeg versions

### DIFF
--- a/src/torchcodec/decoders/_core/FFMPEGCommon.cpp
+++ b/src/torchcodec/decoders/_core/FFMPEGCommon.cpp
@@ -10,6 +10,18 @@ std::string getFFMPEGErrorStringFromErrorCode(int errorCode) {
   return std::string(errorBuffer);
 }
 
+int64_t getDuration(const UniqueAVFrame& frame) {
+  return getDuration(frame.get());
+}
+
+int64_t getDuration(const AVFrame* frame) {
+#if LIBAVUTIL_VERSION_MAJOR < 59
+  return frame->pkt_duration;
+#else
+  return frame->duration;
+#endif
+}
+
 AVIOBytesContext::AVIOBytesContext(
     const void* data,
     size_t data_size,

--- a/src/torchcodec/decoders/_core/FFMPEGCommon.h
+++ b/src/torchcodec/decoders/_core/FFMPEGCommon.h
@@ -73,6 +73,12 @@ const int AVSUCCESS = 0;
 // Returns the FFMPEG error as a string using the provided `errorCode`.
 std::string getFFMPEGErrorStringFromErrorCode(int errorCode);
 
+// Returns duration from the frame. Abstracted into a function because the
+// struct member representing duration has changed across the versions we
+// support.
+int64_t getDuration(const UniqueAVFrame& frame);
+int64_t getDuration(const AVFrame* frame);
+
 // A struct that holds state for reading bytes from an IO context.
 // We give this to FFMPEG and it will pass it back to us when it needs to read
 // or seek in the memory buffer.

--- a/src/torchcodec/decoders/_core/VideoDecoder.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoder.cpp
@@ -694,7 +694,7 @@ VideoDecoder::DecodedOutput VideoDecoder::getDecodedOutputWithFilter(
   // the file and that will flush the decoder.
   StreamInfo& activeStream = streams_[frameStreamIndex];
   activeStream.currentPts = frame->pts;
-  activeStream.currentDuration = frame->pkt_duration;
+  activeStream.currentDuration = getDuration(frame);
   VLOG(3) << "Got frame: stream_index=" << activeStream.stream->index
           << " pts=" << frame->pts << " stats=" << decodeStats_;
   // Convert the frame to tensor.
@@ -741,7 +741,7 @@ VideoDecoder::DecodedOutput VideoDecoder::getFrameDisplayedAtTimestamp(
         StreamInfo& stream = streams_[frameStreamIndex];
         double frameStartTime = 1.0 * frame->pts / stream.timeBase.den;
         double frameEndTime =
-            1.0 * (frame->pts + frame->pkt_duration) / stream.timeBase.den;
+            1.0 * (frame->pts + getDuration(frame)) / stream.timeBase.den;
         return seconds >= frameStartTime && seconds < frameEndTime;
       });
 }


### PR DESCRIPTION
Summary:
Versions 5 and later of FFMPEG have the `duration` field in the `AVFrame` struct: https://ffmpeg.org/doxygen/trunk/structAVFrame.html#ab90bd20a44c79c144045916b00c50e0d. Version 4 only has `pkt_duration`. Version 7 and later removes `pkt_duration` in favor of `duration`.

This diff abstracts getting the duration from a frame so that we can check the FFMPEG version in a utility function and do the right thing.

Differential Revision: D58188968


