### PR TITLE
Test Python{3.8, 3.12} X ffmpeg{4, 5, 6, 7}

### DIFF
--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -18,7 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.12']
+        ffmpeg-version: ['4.4.2', '5.1.2', '6.1.1', '7.0.1']
     steps:
       - name: Check out repo
         uses: actions/checkout@v3
@@ -34,12 +35,11 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu
-          # TODO: This is installing ffmpeg with 6 GPL stuff enabled. That's just
+          # TODO: This is installing ffmpeg with GPL stuff enabled. That's just
           # for testing for now so it's OK. But before we release we should make
-          # sure it's not using GPL stuff by e.g. building from source like
-          # in torchaudio.
-          # TODO: Make this work with ffmpeg 4 to 7 inclusive.
-          conda install "ffmpeg<7.0" pkg-config -c conda-forge
+          # sure it's not using GPL stuff by e.g. building from source like in
+          # torchaudio.
+          conda install "ffmpeg=${{ matrix.ffmpeg-version }}" pkg-config -c conda-forge
           ffmpeg -version
       - name: Build and install torchcodec
         run: |


### PR DESCRIPTION
Now that we support ffmpeg 4 to 6 this PR let the GitHub CI run the tests on all of these ffmpeg versions. We are restricting the Python versions to 3.8 and 3.12 (at least for now) to avoid too many jobs. Closer to the release we might want to increase coverage.