### PR TITLE
Print ffmpeg error if createAVFormatContextFromFilePath fails

### DIFF
--- a/src/torchcodec/decoders/_core/VideoDecoder.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoder.cpp
@@ -28,9 +28,14 @@ struct AVInput {
 
 AVInput createAVFormatContextFromFilePath(const std::string& videoFilePath) {
   AVFormatContext* formatContext = nullptr;
-  if (avformat_open_input(
-          &formatContext, videoFilePath.c_str(), nullptr, nullptr) != 0) {
-    throw std::invalid_argument("Could not open input file: " + videoFilePath);
+  int open_ret = avformat_open_input(
+      &formatContext, videoFilePath.c_str(), nullptr, nullptr);
+  if (open_ret != 0) {
+
+    throw std::invalid_argument(
+        "Could not open input file: " + videoFilePath + " " +
+        getFFMPEGErrorStringFromErrorCode(open_ret));
+
   }
   TORCH_CHECK(formatContext != nullptr);
   AVInput toReturn;


### PR DESCRIPTION
It took me a while to debug the x264 issue related to https://github.com/pytorch-labs/torchcodec/pull/18. Having the ffmpeg string error ("Protocol not found") would have helped figuring out the problem sooner.