### PR TITLE
Separate Python and C++ tests in different CI jobs

### DIFF
--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -14,7 +14,7 @@ defaults:
     shell: bash -l -eo pipefail {0}
 
 jobs:
-  unit_tests:
+  python:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -60,10 +60,33 @@ jobs:
       - name: Run Python tests
         run: |
           pytest test
-
+  Cpp:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ffmpeg-version-for-tests: ['4.4.2', '5.1.2', '6.1.1', '7.0.1']
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v3
+      - name: Setup conda env
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          miniconda-version: "latest"
+          activate-environment: test
+          python-version: '3.12'
+      - name: Update pip
+        run: python -m pip install --upgrade pip
+      - name: Install dependencies
+        run: |
+          python -m pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cpu
+      - name: Install ffmpeg and pkg-config
+        run: |
+          conda install "ffmpeg=${{ matrix.ffmpeg-version-for-tests }}" pkg-config -c conda-forge
+          ffmpeg -version
       - name: Build and run C++ tests
         run: |
-          conda install pkg-config -c conda-forge
           export BUILD_AGAINST_INSTALLED_FFMPEG=1
 
           # Why we need BUILD_AGAINST_INSTALLED_FFMPEG and pkg-config:


### PR DESCRIPTION
This PR separates the Python tests from the C++ tests which provides 2 benefits:

- The OSS CI runs faster as it's more parallelized
- There is zero risk of the Python build/tests influencing the C++ tests, so that's something we don't have to worry about anymore.