### PR TITLE
Add pre-commit hooks

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+max-line-length = 120
+ignore = E203, E402, W503, W504, F821, E501, B, C4, EXE
+per-file-ignores =
+    __init__.py: F401, F403, F405

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,31 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: check-docstring-first
+      - id: trailing-whitespace
+      - id: check-toml
+      - id: check-yaml
+        args:
+          - --allow-multiple-documents
+      - id: mixed-line-ending
+        args: [--fix=lf]
+      - id: end-of-file-fixer
+      - id: no-commit-to-branch
+        args: ['--branch=main']
+      - id: check-added-large-files
+        args: ['--maxkb=1000']
+
+  # - repo: https://github.com/omnilib/ufmt
+  #   rev: v2.3.0
+  #   hooks:
+  #   -   id: ufmt
+  #       additional_dependencies:
+  #         - black == 22.12.0
+  #         - usort == 1.0.5
+
+  - repo: https://github.com/PyCQA/flake8
+    rev: 7.1.0
+    hooks:
+      - id: flake8
+        args: [--config=.flake8]

--- a/benchmarks/decoders/memprofile_decoders.py
+++ b/benchmarks/decoders/memprofile_decoders.py
@@ -1,7 +1,6 @@
 # (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 import argparse
 import importlib
-import os
 
 import torch
 from memory_profiler import profile

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,3 @@
-import os
-import subprocess
-from pathlib import Path
-
-import torch
-from setuptools import Extension, setup
-from setuptools.command.build_ext import build_ext
-
 """
 Build / install instructions:
 
@@ -42,6 +34,14 @@ found. That's why we're passing `--no-build-isolation`: this tells pip to build
 the package within the current virtual env, where torch would have already been
 installed.
 """
+
+import os
+import subprocess
+from pathlib import Path
+
+import torch
+from setuptools import Extension, setup
+from setuptools.command.build_ext import build_ext
 
 
 _ROOT_DIR = Path(__file__).parent.resolve()

--- a/test/decoders/video_decoder_ops_test.py
+++ b/test/decoders/video_decoder_ops_test.py
@@ -10,8 +10,6 @@ import numpy as np
 import pytest
 
 import torch
-import torchvision.transforms as transforms
-from PIL import Image
 
 from torchcodec.decoders._core import (
     add_video_stream,


### PR DESCRIPTION
This PR adds [pre-commit hooks](https://pre-commit.com/index.html) - a largely accepted way of running automatic linters and other checks externally. The configs were taken from torchvision/torchtune.

I also slightly updated some parts of the code for the linters to pass (mostly just deleting unused imports).

I commented-out the ufmt/black linter for now as I don't want to introduce too many changes. Don't worry, that formatter was specifically designed to be in sync with the internal linter: https://fburl.com/wiki/e3v9t6zb.

Later I will also add a linter CI job.

-----

 I'll write more detailed instructions in the readme but the basics are just:

```
pip install pre-commit
pre-commit install
```

Now before each commit you should see the hooks being run:

```
check docstring is first.................................................Passed
trim trailing whitespace.................................................Passed
check toml...............................................................Passed
check yaml...............................................................Passed
mixed line ending........................................................Passed
fix end of files.........................................................Passed
don't commit to branch...................................................Passed
check for added large files..............................................Passed
flake8...................................................................Passed
```

Personally, I tend to not run `pre-commit install` and instead just trigger the hooks manually with `pre-commit run --all-files`.