### PR TITLE
Remove obsolete Python tests CI job

### DIFF
--- a/.github/workflows/cpp_tests.yaml
+++ b/.github/workflows/cpp_tests.yaml
@@ -1,4 +1,4 @@
-name: Unit Test
+name: CPP tests
 
 on:
   push:
@@ -14,49 +14,7 @@ defaults:
     shell: bash -l -eo pipefail {0}
 
 jobs:
-  python:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ['3.8', '3.12']
-        ffmpeg-version-for-tests: ['4.4.2', '5.1.2', '6.1.1', '7.0.1']
-    steps:
-      - name: Check out repo
-        uses: actions/checkout@v3
-      - name: Setup conda env
-        uses: conda-incubator/setup-miniconda@v2
-        with:
-          auto-update-conda: true
-          miniconda-version: "latest"
-          activate-environment: test
-          python-version: ${{ matrix.python-version }}
-      - name: Update pip
-        run: python -m pip install --upgrade pip
-      - name: Install dependencies
-        run: |
-          python -m pip install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu
-      - name: Build and install torchcodec
-        run: |
-          .github/scripts/assert_ffmpeg_not_installed.sh
-          # TODO: should we pass -DCMAKE_BUILD_TYPE=Debug here? That's what we
-          # do for the C++ tests.
-          BUILD_AGAINST_ALL_FFMPEG_FROM_S3=1 python -m pip install -e ".[dev]" --no-build-isolation -vvv
-
-          # list the built so files, for debugging.
-          find src | grep ".so"
-      - name: Install ffmpeg, post build
-        run: |
-          conda install "ffmpeg=${{ matrix.ffmpeg-version-for-tests }}" -c conda-forge
-          ffmpeg -version
-      - name: Smoke test
-        run: |
-          python test/decoders/manual_smoke_test.py
-          # TODO: diff the output frame with its expeceted value
-      - name: Run Python tests
-        run: |
-          pytest test
-  Cpp:
+  Cpp-tests:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
This PR removes the previous testing job that are now obsolete. The Python tests are now being run in the "Build wheel / install-and-test" jobs. This is more robust as it simulate a user-installed torchcodec rather than a torchcodec built from source.

