### PR TITLE
Remove no-commit-to-branch pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,8 +11,6 @@ repos:
       - id: mixed-line-ending
         args: [--fix=lf]
       - id: end-of-file-fixer
-      - id: no-commit-to-branch
-        args: ['--branch=main']
       - id: check-added-large-files
         args: ['--maxkb=1000']
 


### PR DESCRIPTION
This hook is useful in general, but it cannot work in our current ShipIt setup since ShipIt always commits to the `main` branch (instead of merging PRs in there). The CI checks have been failing on the past 3 commits to `main`  because of that

![image](https://github.com/pytorch-labs/torchcodec/assets/1190450/d72417f4-26cb-4001-8f1d-9390e5a652fa)
