### PR TITLE
Fix return type of seek_to_pts() op

### DIFF
--- a/src/torchcodec/decoders/_core/video_decoder_ops.py
+++ b/src/torchcodec/decoders/_core/video_decoder_ops.py
@@ -94,7 +94,7 @@ def add_video_stream_abstract(
 
 
 @register_fake("torchcodec_ns::seek_to_pts")
-def seek_abstract(decoder: torch.Tensor, seconds: float) -> torch.Tensor:
+def seek_abstract(decoder: torch.Tensor, seconds: float) -> None:
     return
 
 


### PR DESCRIPTION
The seek operation returns `void` in C++ and `None` in Python. This PR fixes the return type of the abstract implem for `seek_to_pts()` which previously stated the return type as `Tensor`.