### PR TITLE
[torchcodec] Add a core function to get the frame along with metadata like pts and duration

### DIFF
--- a/src/torchcodec/decoders/_core/VideoDecoder.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoder.cpp
@@ -713,6 +713,9 @@ VideoDecoder::DecodedOutput VideoDecoder::convertAVFrameToDecodedOutput(
   output.pts = frame->pts;
   output.ptsSeconds =
       1.0 * frame->pts / formatContext_->streams[streamIndex]->time_base.den;
+  output.duration = getDuration(frame);
+  output.durationSeconds = 1.0 * getDuration(frame) /
+      formatContext_->streams[streamIndex]->time_base.den;
   if (output.streamType == AVMEDIA_TYPE_VIDEO) {
     output.frame =
         convertFrameToTensorUsingFilterGraph(streamIndex, frame.get());

--- a/src/torchcodec/decoders/_core/VideoDecoder.h
+++ b/src/torchcodec/decoders/_core/VideoDecoder.h
@@ -164,6 +164,10 @@ class VideoDecoder {
     int64_t pts;
     // The presentation timestamp of the decoded frame in seconds.
     double ptsSeconds;
+    // The duration of the decoded frame in time base.
+    int64_t duration;
+    // The duration of the decoded frame in seconds.
+    double durationSeconds;
   };
   // Decodes the frame where the current cursor position is. It also advances
   // the cursor to the next frame.

--- a/src/torchcodec/decoders/_core/VideoDecoderOps.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoderOps.cpp
@@ -38,6 +38,8 @@ TORCH_LIBRARY(torchcodec_ns, m) {
   m.def(
       "get_stream_json_metadata(Tensor(a!) decoder, int stream_index) -> str");
   m.def("_get_json_ffmpeg_library_versions() -> str");
+  m.def(
+      "get_frame_with_info_at_index(Tensor(a!) decoder, *, int stream_index, int frame_index) -> (Tensor, float, float)");
 }
 
 // ==============================
@@ -132,6 +134,16 @@ at::Tensor get_frame_at_index(
   auto videoDecoder = static_cast<VideoDecoder*>(decoder.mutable_data_ptr());
   auto result = videoDecoder->getFrameAtIndex(stream_index, frame_index);
   return result.frame;
+}
+
+std::tuple<at::Tensor, double, double> get_frame_with_info_at_index(
+    at::Tensor& decoder,
+    int64_t stream_index,
+    int64_t frame_index) {
+  auto videoDecoder = static_cast<VideoDecoder*>(decoder.mutable_data_ptr());
+  auto result = videoDecoder->getFrameAtIndex(stream_index, frame_index);
+  return std::make_tuple(
+      result.frame, result.ptsSeconds, result.durationSeconds);
 }
 
 at::Tensor get_frames_at_indices(
@@ -370,6 +382,7 @@ TORCH_LIBRARY_IMPL(torchcodec_ns, CPU, m) {
   m.impl("get_stream_json_metadata", &get_stream_json_metadata);
   m.impl("get_frame_at_pts", &get_frame_at_pts);
   m.impl("get_frame_at_index", &get_frame_at_index);
+  m.impl("get_frame_with_info_at_index", &get_frame_with_info_at_index);
   m.impl("get_frames_at_indices", &get_frames_at_indices);
   m.impl("get_frames_in_range", &get_frames_in_range);
 }

--- a/src/torchcodec/decoders/_core/VideoDecoderOps.h
+++ b/src/torchcodec/decoders/_core/VideoDecoderOps.h
@@ -47,6 +47,13 @@ at::Tensor get_frame_at_index(
     int64_t stream_index,
     int64_t frame_index);
 
+// Return the frame along with pts and duration that is visible at a given index
+// in the video.
+std::tuple<at::Tensor, double, double> get_frame_with_info_at_index(
+    at::Tensor& decoder,
+    int64_t stream_index,
+    int64_t frame_index);
+
 // Return the frames at a given index for a given stream as a single stacked
 // Tensor.
 at::Tensor get_frames_at_indices(

--- a/src/torchcodec/decoders/_core/video_decoder_ops.py
+++ b/src/torchcodec/decoders/_core/video_decoder_ops.py
@@ -1,5 +1,5 @@
 import json
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 import torch
 from torch.library import get_ctx, register_fake
@@ -57,6 +57,9 @@ seek_to_pts = torch.ops.torchcodec_ns.seek_to_pts.default
 get_next_frame = torch.ops.torchcodec_ns.get_next_frame.default
 get_frame_at_pts = torch.ops.torchcodec_ns.get_frame_at_pts.default
 get_frame_at_index = torch.ops.torchcodec_ns.get_frame_at_index.default
+get_frame_with_info_at_index = (
+    torch.ops.torchcodec_ns.get_frame_with_info_at_index.default
+)
 get_frames_at_indices = torch.ops.torchcodec_ns.get_frames_at_indices.default
 get_frames_in_range = torch.ops.torchcodec_ns.get_frames_in_range.default
 get_json_metadata = torch.ops.torchcodec_ns.get_json_metadata.default
@@ -127,6 +130,14 @@ def get_frame_at_index_abstract(
 ) -> torch.Tensor:
     image_size = [get_ctx().new_dynamic_size() for _ in range(3)]
     return torch.empty(image_size)
+
+
+@register_fake("torchcodec_ns::get_frame_with_info_at_index")
+def get_frame_with_info_at_index_abstract(
+    decoder: torch.Tensor, *, stream_index: int, frame_index: int
+) -> Tuple[torch.Tensor, float, float]:
+    image_size = [get_ctx().new_dynamic_size() for _ in range(3)]
+    return (torch.empty(image_size), 0, 0)
 
 
 @register_fake("torchcodec_ns::get_frames_at_indices")

--- a/test/decoders/video_decoder_ops_test.py
+++ b/test/decoders/video_decoder_ops_test.py
@@ -17,6 +17,7 @@ from torchcodec.decoders._core import (
     get_ffmpeg_library_versions,
     get_frame_at_index,
     get_frame_at_pts,
+    get_frame_with_info_at_index,
     get_frames_at_indices,
     get_frames_in_range,
     get_json_metadata,
@@ -88,6 +89,17 @@ class TestOps:
         frame6 = get_frame_at_index(decoder, stream_index=3, frame_index=180)
         reference_frame6 = NASA_VIDEO.get_tensor_by_name("time6.000000")
         assert_tensor_equal(frame6, reference_frame6)
+
+    def test_get_frame_with_info_at_index(self):
+        decoder = create_from_file(str(NASA_VIDEO.path))
+        add_video_stream(decoder)
+        frame6, pts, duration = get_frame_with_info_at_index(
+            decoder, stream_index=3, frame_index=180
+        )
+        reference_frame6 = NASA_VIDEO.get_tensor_by_name("time6.000000")
+        assert_tensor_equal(frame6, reference_frame6)
+        assert pts == 6.006
+        assert duration == pytest.approx(0.03337, rel=1e-3)
 
     def test_get_frames_at_indices(self):
         decoder = create_from_file(str(NASA_VIDEO.path))


### PR DESCRIPTION
Summary:
Before this diff there wasn't a way for python users to get the frame metadata like pts and duration.

This diff adds a function to get the frame, pts and duration for a frame at a given index.

TODO: Add similar functions for get_next_frame and get_frame_at_pts.

Differential Revision: D59328760
