### PR TITLE
[torchcodec] Fix bug where we were not finding the best audio stream

### DIFF
--- a/src/torchcodec/decoders/_core/VideoDecoder.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoder.cpp
@@ -176,7 +176,7 @@ void VideoDecoder::initializeDecoder() {
   if (bestVideoStream >= 0) {
     containerMetadata_.bestVideoStreamIndex = bestVideoStream;
   }
-  int bestAudioStream = getBestStreamIndex(AVMEDIA_TYPE_VIDEO);
+  int bestAudioStream = getBestStreamIndex(AVMEDIA_TYPE_AUDIO);
   if (bestAudioStream >= 0) {
     containerMetadata_.bestAudioStreamIndex = bestAudioStream;
   }

--- a/test/decoders/test_metadata.py
+++ b/test/decoders/test_metadata.py
@@ -16,7 +16,7 @@ def test_get_video_metadata():
     metadata = get_video_metadata(decoder)
     assert len(metadata.streams) == 6
     assert metadata.best_video_stream_index == 3
-    assert metadata.best_audio_stream_index == 3
+    assert metadata.best_audio_stream_index == 4
 
     with pytest.raises(NotImplementedError, match="TODO: decide on logic"):
         metadata.duration_seconds


### PR DESCRIPTION
Summary: Previous we were using the best video stream for the best audio stream. This diff fixes that and updates the tests.

Differential Revision: D59460206
