### PR TITLE
[torchcodec] fix type annotations on constructor

### DIFF
--- a/src/torchcodec/decoders/_simple_video_decoder.py
+++ b/src/torchcodec/decoders/_simple_video_decoder.py
@@ -9,7 +9,7 @@ from torchcodec.decoders import _core as core
 class SimpleVideoDecoder:
     """TODO: Add docstring."""
 
-    def __init__(self, source: Union[str, bytes, torch.Tensor]):
+    def __init__(self, source: Union[str, Path, bytes, torch.Tensor]):
         if isinstance(source, str):
             self._decoder = core.create_from_file(source)
         elif isinstance(source, Path):


### PR DESCRIPTION
Summary: Adds `Path` to type annotation of accepted types for `SimpleVideoDecoder` constructor. We should probably incorporate automated pyre checking into the repo.

Reviewed By: ahmadsharif1

Differential Revision: D59463820
