### PR TITLE
[torchcodec] Revert register_fake back to imply_abstract

### DIFF
--- a/src/torchcodec/decoders/_core/video_decoder_ops.py
+++ b/src/torchcodec/decoders/_core/video_decoder_ops.py
@@ -1,11 +1,19 @@
 import json
+import warnings
 from typing import List, Optional, Tuple
 
 import torch
-from torch.library import get_ctx, register_fake
+from torch.library import get_ctx, impl_abstract
 
 from torchcodec._internally_replaced_utils import (  # @manual=//pytorch/torchcodec/src:internally_replaced_utils
     _get_extension_path,
+)
+
+# TODO: Remove this warning filter and use @register_fake once pytorch 2.4 is released
+warnings.filterwarnings(
+    "ignore",
+    category=FutureWarning,
+    message="`torch.library.impl_abstract` was renamed to `torch.library.register_fake`. Please use that instead; we will remove `torch.library.impl_abstract` in a future version of PyTorch",
 )
 
 
@@ -85,17 +93,17 @@ def create_from_bytes(video_bytes: bytes) -> torch.Tensor:
 # ==============================
 # Abstract impl for the operators. Needed by torch.compile.
 # ==============================
-@register_fake("torchcodec_ns::create_from_file")
+@impl_abstract("torchcodec_ns::create_from_file")
 def create_from_file_abstract(filename: str) -> torch.Tensor:
     return torch.empty([], dtype=torch.long)
 
 
-@register_fake("torchcodec_ns::create_from_tensor")
+@impl_abstract("torchcodec_ns::create_from_tensor")
 def create_from_tensor_abstract(video_tensor: torch.Tensor) -> torch.Tensor:
     return torch.empty([], dtype=torch.long)
 
 
-@register_fake("torchcodec_ns::add_video_stream")
+@impl_abstract("torchcodec_ns::add_video_stream")
 def add_video_stream_abstract(
     decoder: torch.Tensor,
     *,
@@ -108,12 +116,12 @@ def add_video_stream_abstract(
     return
 
 
-@register_fake("torchcodec_ns::seek_to_pts")
+@impl_abstract("torchcodec_ns::seek_to_pts")
 def seek_abstract(decoder: torch.Tensor, seconds: float) -> None:
     return
 
 
-@register_fake("torchcodec_ns::get_next_frame")
+@impl_abstract("torchcodec_ns::get_next_frame")
 def get_next_frame_abstract(decoder: torch.Tensor) -> torch.Tensor:
     # Images are 3 dimensions: height, width, channels.
     # The exact permutation depends on the constructor options passed in.
@@ -121,13 +129,13 @@ def get_next_frame_abstract(decoder: torch.Tensor) -> torch.Tensor:
     return torch.empty(image_size)
 
 
-@register_fake("torchcodec_ns::get_frame_at_pts")
+@impl_abstract("torchcodec_ns::get_frame_at_pts")
 def get_frame_at_pts_abstract(decoder: torch.Tensor, seconds: float) -> torch.Tensor:
     image_size = [get_ctx().new_dynamic_size() for _ in range(3)]
     return torch.empty(image_size)
 
 
-@register_fake("torchcodec_ns::get_frame_at_index")
+@impl_abstract("torchcodec_ns::get_frame_at_index")
 def get_frame_at_index_abstract(
     decoder: torch.Tensor, *, stream_index: int, frame_index: int
 ) -> torch.Tensor:
@@ -135,7 +143,7 @@ def get_frame_at_index_abstract(
     return torch.empty(image_size)
 
 
-@register_fake("torchcodec_ns::get_frame_with_info_at_index")
+@impl_abstract("torchcodec_ns::get_frame_with_info_at_index")
 def get_frame_with_info_at_index_abstract(
     decoder: torch.Tensor, *, stream_index: int, frame_index: int
 ) -> Tuple[torch.Tensor, float, float]:
@@ -143,7 +151,7 @@ def get_frame_with_info_at_index_abstract(
     return (torch.empty(image_size), 0, 0)
 
 
-@register_fake("torchcodec_ns::get_frames_at_indices")
+@impl_abstract("torchcodec_ns::get_frames_at_indices")
 def get_frames_at_indices_abstract(
     decoder: torch.Tensor,
     *,
@@ -154,7 +162,7 @@ def get_frames_at_indices_abstract(
     return torch.empty(image_size)
 
 
-@register_fake("torchcodec_ns::get_frames_in_range")
+@impl_abstract("torchcodec_ns::get_frames_in_range")
 def get_frames_in_range_abstract(
     decoder: torch.Tensor,
     *,
@@ -167,27 +175,27 @@ def get_frames_in_range_abstract(
     return torch.empty(image_size)
 
 
-@register_fake("torchcodec_ns::get_json_metadata")
+@impl_abstract("torchcodec_ns::get_json_metadata")
 def get_json_metadata_abstract(decoder: torch.Tensor) -> str:
     return torch.empty_like("")
 
 
-@register_fake("torchcodec_ns::get_container_json_metadata")
+@impl_abstract("torchcodec_ns::get_container_json_metadata")
 def get_container_json_metadata_abstract(decoder: torch.Tensor) -> str:
     return torch.empty_like("")
 
 
-@register_fake("torchcodec_ns::get_stream_json_metadata")
+@impl_abstract("torchcodec_ns::get_stream_json_metadata")
 def get_stream_json_metadata_abstract(decoder: torch.Tensor, stream_idx: int) -> str:
     return torch.empty_like("")
 
 
-@register_fake("torchcodec_ns::_get_json_ffmpeg_library_versions")
+@impl_abstract("torchcodec_ns::_get_json_ffmpeg_library_versions")
 def _get_json_ffmpeg_library_versions_abstract() -> str:
     return torch.empty_like("")
 
 
-@register_fake("torchcodec_ns::scan_all_streams_to_update_metadata")
+@impl_abstract("torchcodec_ns::scan_all_streams_to_update_metadata")
 def scan_all_streams_to_update_metadata_abstract(decoder: torch.Tensor) -> None:
     return
 


### PR DESCRIPTION
Summary:
`register_fake` is only available after Pytorch 2.4, which will be available in late July. We don't want to break user experience if they on old pytorch versions. It is also possible when we release torchcodec, pytorch 2.4 not yet released. 

Note: it's expected that reverting back will trigger a lot of logging.

Differential Revision: D59018191


