### PR TITLE
Remove opencv dependency

### DIFF
--- a/.github/workflows/wheel.yaml
+++ b/.github/workflows/wheel.yaml
@@ -115,7 +115,7 @@ jobs:
         run: |
           python -m pip install --pre torchvision --index-url https://download.pytorch.org/whl/nightly/cpu
           # TODO: Find a way to get those dependencies from pyproject.toml
-          python -m pip install numpy pytest pillow opencv-python
+          python -m pip install numpy pytest pillow
 
       - name: Delete the src/ folder just for fun
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,5 +11,4 @@ dev = [
     "numpy",
     "pytest",
     "pillow",
-    "opencv-python",
 ]


### PR DESCRIPTION
Usage of opencv was removed in D58980922 but we forgot to remove it from the dependency lists.