### PR TITLE
[torchcodec] add get_frame_at, get_frame_displayed_at to SimpleVideoDecoder

### DIFF
--- a/src/torchcodec/decoders/__init__.py
+++ b/src/torchcodec/decoders/__init__.py
@@ -1,1 +1,1 @@
-from ._simple_video_decoder import SimpleVideoDecoder  # noqa
+from ._simple_video_decoder import Frame, SimpleVideoDecoder  # noqa

--- a/src/torchcodec/decoders/_simple_video_decoder.py
+++ b/src/torchcodec/decoders/_simple_video_decoder.py
@@ -1,22 +1,37 @@
+import dataclasses
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Union
+from typing import Iterable, Iterator, Union
 
-import torch
+from torch import Tensor
 
 from torchcodec.decoders import _core as core
+
+
+# TODO: we want to add index as well, but we need
+#       the core operations to return it.
+@dataclass
+class Frame(Iterable):
+    data: Tensor
+    pts_seconds: float
+    duration_seconds: float
+
+    def __iter__(self) -> Iterator[Union[Tensor, float]]:
+        for field in dataclasses.fields(self):
+            yield getattr(self, field.name)
 
 
 class SimpleVideoDecoder:
     """TODO: Add docstring."""
 
-    def __init__(self, source: Union[str, Path, bytes, torch.Tensor]):
+    def __init__(self, source: Union[str, Path, bytes, Tensor]):
         if isinstance(source, str):
             self._decoder = core.create_from_file(source)
         elif isinstance(source, Path):
             self._decoder = core.create_from_file(str(source))
         elif isinstance(source, bytes):
             self._decoder = core.create_from_bytes(source)
-        elif isinstance(source, torch.Tensor):
+        elif isinstance(source, Tensor):
             self._decoder = core.create_from_tensor(source)
         else:
             raise TypeError(
@@ -29,11 +44,13 @@ class SimpleVideoDecoder:
         self.stream_metadata = _get_and_validate_stream_metadata(self._decoder)
         self._num_frames: int = self.stream_metadata.num_frames_computed  # type: ignore[assignment]
         self._stream_index = self.stream_metadata.stream_index
+        self._min_pts_seconds: float = self.stream_metadata.min_pts_seconds  # type: ignore[assignment]
+        self._max_pts_seconds: float = self.stream_metadata.max_pts_seconds  # type: ignore[assignment]
 
     def __len__(self) -> int:
         return self._num_frames
 
-    def _getitem_int(self, key: int) -> torch.Tensor:
+    def _getitem_int(self, key: int) -> Tensor:
         assert isinstance(key, int)
 
         if key < 0:
@@ -43,11 +60,12 @@ class SimpleVideoDecoder:
                 f"Index {key} is out of bounds; length is {self._num_frames}"
             )
 
-        return core.get_frame_at_index(
+        frame_data, *_ = core.get_frame_at_index(
             self._decoder, frame_index=key, stream_index=self._stream_index
-        )[0]
+        )
+        return frame_data
 
-    def _getitem_slice(self, key: slice) -> torch.Tensor:
+    def _getitem_slice(self, key: slice) -> Tensor:
         assert isinstance(key, slice)
 
         start, stop, step = key.indices(len(self))
@@ -59,7 +77,7 @@ class SimpleVideoDecoder:
             step=step,
         )
 
-    def __getitem__(self, key: Union[int, slice]) -> torch.Tensor:
+    def __getitem__(self, key: Union[int, slice]) -> Tensor:
         if isinstance(key, int):
             return self._getitem_int(key)
         elif isinstance(key, slice):
@@ -69,8 +87,28 @@ class SimpleVideoDecoder:
             f"Unsupported key type: {type(key)}. Supported types are int and slice."
         )
 
+    def get_frame_at(self, index: int) -> Frame:
+        if not 0 <= index < self._num_frames:
+            raise IndexError(
+                f"Index {index} is out of bounds; must be in the range [0, {self._num_frames})."
+            )
+        frame = core.get_frame_at_index(
+            self._decoder, frame_index=index, stream_index=self._stream_index
+        )
+        return Frame(*frame)
 
-def _get_and_validate_stream_metadata(decoder: torch.Tensor) -> core.StreamMetadata:
+    def get_frame_displayed_at(self, pts_seconds: float) -> Frame:
+        if not self._min_pts_seconds <= pts_seconds < self._max_pts_seconds:
+            raise IndexError(
+                f"Invalid pts in seconds: {pts_seconds}. "
+                f"It must be greater than or equal to {self._min_pts_seconds} "
+                f"and less than or equal to {self._max_pts_seconds}."
+            )
+        frame = core.get_frame_at_pts(self._decoder, pts_seconds)
+        return Frame(*frame)
+
+
+def _get_and_validate_stream_metadata(decoder: Tensor) -> core.StreamMetadata:
     video_metadata = core.get_video_metadata(decoder)
 
     if video_metadata.best_video_stream_index is None:
@@ -85,6 +123,18 @@ def _get_and_validate_stream_metadata(decoder: torch.Tensor) -> core.StreamMetad
     if best_stream_metadata.num_frames_computed is None:
         raise ValueError(
             "The number of frames is unknown. This should never happen. "
+            "Please report an issue following the steps in <TODO>"
+        )
+
+    if best_stream_metadata.min_pts_seconds is None:
+        raise ValueError(
+            "The minimum pts value in seconds is unknown. This should never happen. "
+            "Please report an issue following the steps in <TODO>"
+        )
+
+    if best_stream_metadata.max_pts_seconds is None:
+        raise ValueError(
+            "The maximum pts value in seconds is unknown. This should never happen. "
             "Please report an issue following the steps in <TODO>"
         )
 

--- a/test/decoders/test_simple_video_decoder.py
+++ b/test/decoders/test_simple_video_decoder.py
@@ -229,7 +229,7 @@ class TestSimpleDecoder:
                 assert_tensor_equal(ref_frame_last, frame)
 
     def test_iteration_slow(self):
-        decoder = SimpleVideoDecoder(str(NASA_VIDEO.path))
+        decoder = SimpleVideoDecoder(NASA_VIDEO.path)
         ref_frame_last = NASA_VIDEO.get_tensor_by_index(389)
 
         # Force the decoder to seek around a lot while iterating; this will
@@ -241,6 +241,52 @@ class TestSimpleDecoder:
             iterations += 1
 
         assert iterations == len(decoder) == 390
+
+    def test_get_frame_at(self):
+        decoder = SimpleVideoDecoder(NASA_VIDEO.path)
+
+        ref_frame9 = NASA_VIDEO.get_tensor_by_index(9)
+        frame9 = decoder.get_frame_at(9)
+
+        assert_tensor_equal(ref_frame9, frame9.data)
+        assert frame9.pts_seconds == 0.3003
+        assert frame9.duration_seconds == pytest.approx(0.03337, rel=1e-3)
+
+    def test_get_frame_at_tuple_unpacking(self):
+        decoder = SimpleVideoDecoder(NASA_VIDEO.path)
+
+        frame = decoder.get_frame_at(50)
+        data, pts, duration = decoder.get_frame_at(50)
+
+        assert_tensor_equal(frame.data, data)
+        assert frame.pts_seconds == pts
+        assert frame.duration_seconds == duration
+
+    def test_get_frame_at_fails(self):
+        decoder = SimpleVideoDecoder(NASA_VIDEO.path)
+
+        with pytest.raises(IndexError, match="out of bounds"):
+            frame = decoder.get_frame_at(-1)  # noqa
+
+        with pytest.raises(IndexError, match="out of bounds"):
+            frame = decoder.get_frame_at(10000)  # noqa
+
+    def test_get_frame_displayed_at(self):
+        decoder = SimpleVideoDecoder(NASA_VIDEO.path)
+
+        ref_frame6 = NASA_VIDEO.get_tensor_by_name("time6.000000")
+        assert_tensor_equal(ref_frame6, decoder.get_frame_displayed_at(6.006).data)
+        assert_tensor_equal(ref_frame6, decoder.get_frame_displayed_at(6.02).data)
+        assert_tensor_equal(ref_frame6, decoder.get_frame_displayed_at(6.039366).data)
+
+    def test_get_frame_displayed_at_fails(self):
+        decoder = SimpleVideoDecoder(NASA_VIDEO.path)
+
+        with pytest.raises(IndexError, match="Invalid pts in seconds"):
+            frame = decoder.get_frame_displayed_at(-1.0)  # noqa
+
+        with pytest.raises(IndexError, match="Invalid pts in seconds"):
+            frame = decoder.get_frame_displayed_at(100.0)  # noqa
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
Adds `get_frame_at()` and `get_frame_displayed_at()` to `SimpleVideoDecoder`. Both return a newly defined `Frame` dataclass that contains the frame data, pts in seconds and duration in seconds.

Partial implementation of the design doc: https://fburl.com/gdoc/vthnst5t

Differential Revision: D59619216
