### PR TITLE
[torchcodec] Update functions that return a single frame to return frame and metadata

### DIFF
--- a/benchmarks/decoders/BenchmarkDecodersMain.cpp
+++ b/benchmarks/decoders/BenchmarkDecodersMain.cpp
@@ -145,7 +145,8 @@ void runNDecodeIterationsWithCustomOps(
 
     for (double pts : ptsList) {
       seekFrameOp.call(decoderTensor, pts);
-      torch::Tensor tensor = getNextFrameOp.call(decoderTensor);
+      auto result = getNextFrameOp.call(decoderTensor);
+      torch::Tensor tensor = std::get<0>(result);
     }
     if (i + 1 == warmupIterations) {
       start = std::chrono::high_resolution_clock::now();

--- a/src/torchcodec/decoders/_core/VideoDecoderOps.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoderOps.cpp
@@ -1,5 +1,6 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
+#include "src/torchcodec/decoders/_core/VideoDecoderOps.h"
 #include <cstdint>
 #include <sstream>
 #include <string>
@@ -25,10 +26,11 @@ TORCH_LIBRARY(torchcodec_ns, m) {
   m.def(
       "add_video_stream(Tensor(a!) decoder, *, int? width=None, int? height=None, int? num_threads=None, str? shape=None, int? stream_index=None) -> ()");
   m.def("seek_to_pts(Tensor(a!) decoder, float seconds) -> ()");
-  m.def("get_next_frame(Tensor(a!) decoder) -> Tensor");
-  m.def("get_frame_at_pts(Tensor(a!) decoder, float seconds) -> Tensor");
+  m.def("get_next_frame(Tensor(a!) decoder) -> (Tensor, Tensor, Tensor)");
   m.def(
-      "get_frame_at_index(Tensor(a!) decoder, *, int stream_index, int frame_index) -> Tensor");
+      "get_frame_at_pts(Tensor(a!) decoder, float seconds) -> (Tensor, Tensor, Tensor)");
+  m.def(
+      "get_frame_at_index(Tensor(a!) decoder, *, int stream_index, int frame_index) -> (Tensor, Tensor, Tensor)");
   m.def(
       "get_frames_at_indices(Tensor(a!) decoder, *, int stream_index, int[] frame_indices) -> Tensor");
   m.def(
@@ -38,8 +40,6 @@ TORCH_LIBRARY(torchcodec_ns, m) {
   m.def(
       "get_stream_json_metadata(Tensor(a!) decoder, int stream_index) -> str");
   m.def("_get_json_ffmpeg_library_versions() -> str");
-  m.def(
-      "get_frame_with_info_at_index(Tensor(a!) decoder, *, int stream_index, int frame_index) -> (Tensor, float, float)");
   m.def("scan_all_streams_to_update_metadata(Tensor(a!) decoder) -> ()");
 }
 
@@ -61,6 +61,13 @@ VideoDecoder* unwrapTensorToGetDecoder(at::Tensor& tensor) {
   void* buffer = tensor.mutable_data_ptr();
   VideoDecoder* decoder = static_cast<VideoDecoder*>(buffer);
   return decoder;
+}
+
+TensorPtsDuration getTensorTupleFromFrame(VideoDecoder::DecodedOutput& frame) {
+  return std::make_tuple(
+      frame.frame,
+      torch::tensor(frame.ptsSeconds),
+      torch::tensor(frame.durationSeconds));
 }
 } // namespace
 
@@ -92,11 +99,11 @@ at::Tensor create_from_buffer(const void* buffer, size_t length) {
 
 void add_video_stream(
     at::Tensor& decoder,
-    std::optional<int64_t> width = std::nullopt,
-    std::optional<int64_t> height = std::nullopt,
-    std::optional<int64_t> num_threads = std::nullopt,
-    std::optional<c10::string_view> shape = std::nullopt,
-    std::optional<int64_t> stream_index = std::nullopt) {
+    std::optional<int64_t> width,
+    std::optional<int64_t> height,
+    std::optional<int64_t> num_threads,
+    std::optional<c10::string_view> shape,
+    std::optional<int64_t> stream_index) {
   VideoDecoder::VideoStreamDecoderOptions options;
   options.width = width;
   options.height = height;
@@ -117,40 +124,30 @@ void seek_to_pts(at::Tensor& decoder, double seconds) {
   videoDecoder->setCursorPtsInSeconds(seconds);
 }
 
-at::Tensor get_next_frame(at::Tensor& decoder) {
+TensorPtsDuration get_next_frame(at::Tensor& decoder) {
   auto videoDecoder = unwrapTensorToGetDecoder(decoder);
-  auto result = videoDecoder->getNextDecodedOutput().frame;
-  if (result.sizes().size() != 3) {
+  auto result = videoDecoder->getNextDecodedOutput();
+  if (result.frame.sizes().size() != 3) {
     throw std::runtime_error(
         "image_size is unexpected. Expected 3, got: " +
-        std::to_string(result.sizes().size()));
+        std::to_string(result.frame.sizes().size()));
   }
-  return result;
+  return getTensorTupleFromFrame(result);
 }
 
-at::Tensor get_frame_at_pts(at::Tensor& decoder, double seconds) {
+TensorPtsDuration get_frame_at_pts(at::Tensor& decoder, double seconds) {
   auto videoDecoder = unwrapTensorToGetDecoder(decoder);
   auto result = videoDecoder->getFrameDisplayedAtTimestamp(seconds);
-  return result.frame;
+  return getTensorTupleFromFrame(result);
 }
 
-at::Tensor get_frame_at_index(
+TensorPtsDuration get_frame_at_index(
     at::Tensor& decoder,
     int64_t stream_index,
     int64_t frame_index) {
   auto videoDecoder = unwrapTensorToGetDecoder(decoder);
   auto result = videoDecoder->getFrameAtIndex(stream_index, frame_index);
-  return result.frame;
-}
-
-std::tuple<at::Tensor, double, double> get_frame_with_info_at_index(
-    at::Tensor& decoder,
-    int64_t stream_index,
-    int64_t frame_index) {
-  auto videoDecoder = static_cast<VideoDecoder*>(decoder.mutable_data_ptr());
-  auto result = videoDecoder->getFrameAtIndex(stream_index, frame_index);
-  return std::make_tuple(
-      result.frame, result.ptsSeconds, result.durationSeconds);
+  return getTensorTupleFromFrame(result);
 }
 
 at::Tensor get_frames_at_indices(
@@ -169,7 +166,7 @@ at::Tensor get_frames_in_range(
     int64_t stream_index,
     int64_t start,
     int64_t stop,
-    std::optional<int64_t> step = std::nullopt) {
+    std::optional<int64_t> step) {
   auto videoDecoder = unwrapTensorToGetDecoder(decoder);
   auto result = videoDecoder->getFramesInRange(
       stream_index, start, stop, step.value_or(1));
@@ -394,7 +391,6 @@ TORCH_LIBRARY_IMPL(torchcodec_ns, CPU, m) {
   m.impl("get_stream_json_metadata", &get_stream_json_metadata);
   m.impl("get_frame_at_pts", &get_frame_at_pts);
   m.impl("get_frame_at_index", &get_frame_at_index);
-  m.impl("get_frame_with_info_at_index", &get_frame_with_info_at_index);
   m.impl("get_frames_at_indices", &get_frames_at_indices);
   m.impl("get_frames_in_range", &get_frames_in_range);
   m.impl(

--- a/src/torchcodec/decoders/_core/VideoDecoderOps.h
+++ b/src/torchcodec/decoders/_core/VideoDecoderOps.h
@@ -36,23 +36,26 @@ void add_video_stream(
 // Seek to a particular presentation timestamp in the video in seconds.
 void seek_to_pts(at::Tensor& decoder, double seconds);
 
+// The first element of this tuple has the frame data. The second element is a
+// Tensor that has a single float value for the PTS and the third element is a
+// Tensor that has a single value for the duration.
+// The reason we use Tensors for the second and third value is so we can run
+// under torch.compile().
+using TensorPtsDuration = std::tuple<at::Tensor, at::Tensor, at::Tensor>;
+
 // Return the frame that is visible at a given timestamp in seconds. Each frame
 // in FFMPEG has a presentation timestamp and a duration. The frame visible at a
 // given timestamp T has T >= PTS and T < PTS + Duration.
-at::Tensor get_frame_at_pts(at::Tensor& decoder, double seconds);
+TensorPtsDuration get_frame_at_pts(at::Tensor& decoder, double seconds);
 
 // Return the frame that is visible at a given index in the video.
-at::Tensor get_frame_at_index(
+TensorPtsDuration get_frame_at_index(
     at::Tensor& decoder,
     int64_t stream_index,
     int64_t frame_index);
 
-// Return the frame along with pts and duration that is visible at a given index
-// in the video.
-std::tuple<at::Tensor, double, double> get_frame_with_info_at_index(
-    at::Tensor& decoder,
-    int64_t stream_index,
-    int64_t frame_index);
+// Get the next frame from the video as a tensor.
+TensorPtsDuration get_next_frame(at::Tensor& decoder);
 
 // Return the frames at a given index for a given stream as a single stacked
 // Tensor.
@@ -70,9 +73,6 @@ at::Tensor get_frames_in_range(
     int64_t stop,
     std::optional<int64_t> step = std::nullopt);
 
-// Get the next frame from the video as a tensor.
-at::Tensor get_next_frame(at::Tensor& decoder);
-
 // Get the metadata from the video as a string.
 std::string get_json_metadata(at::Tensor& decoder);
 
@@ -80,7 +80,7 @@ std::string get_json_metadata(at::Tensor& decoder);
 std::string get_container_json_metadata(at::Tensor& decoder);
 
 // Get the stream metadata as a string.
-std::string get_stream_json_metadata(at::Tensor& decoder);
+std::string get_stream_json_metadata(at::Tensor& decoder, int64_t stream_index);
 
 // Returns version information about the various FFMPEG libraries that are
 // loaded in the program's address space.

--- a/src/torchcodec/decoders/_core/video_decoder_ops.py
+++ b/src/torchcodec/decoders/_core/video_decoder_ops.py
@@ -65,9 +65,6 @@ seek_to_pts = torch.ops.torchcodec_ns.seek_to_pts.default
 get_next_frame = torch.ops.torchcodec_ns.get_next_frame.default
 get_frame_at_pts = torch.ops.torchcodec_ns.get_frame_at_pts.default
 get_frame_at_index = torch.ops.torchcodec_ns.get_frame_at_index.default
-get_frame_with_info_at_index = (
-    torch.ops.torchcodec_ns.get_frame_with_info_at_index.default
-)
 get_frames_at_indices = torch.ops.torchcodec_ns.get_frames_at_indices.default
 get_frames_in_range = torch.ops.torchcodec_ns.get_frames_in_range.default
 get_json_metadata = torch.ops.torchcodec_ns.get_json_metadata.default
@@ -122,33 +119,41 @@ def seek_abstract(decoder: torch.Tensor, seconds: float) -> None:
 
 
 @impl_abstract("torchcodec_ns::get_next_frame")
-def get_next_frame_abstract(decoder: torch.Tensor) -> torch.Tensor:
+def get_next_frame_abstract(
+    decoder: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     # Images are 3 dimensions: height, width, channels.
     # The exact permutation depends on the constructor options passed in.
     image_size = [get_ctx().new_dynamic_size() for _ in range(3)]
-    return torch.empty(image_size)
+    return (
+        torch.empty(image_size),
+        torch.empty([], dtype=torch.float),
+        torch.empty([], dtype=torch.float),
+    )
 
 
 @impl_abstract("torchcodec_ns::get_frame_at_pts")
-def get_frame_at_pts_abstract(decoder: torch.Tensor, seconds: float) -> torch.Tensor:
+def get_frame_at_pts_abstract(
+    decoder: torch.Tensor, seconds: float
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     image_size = [get_ctx().new_dynamic_size() for _ in range(3)]
-    return torch.empty(image_size)
+    return (
+        torch.empty(image_size),
+        torch.empty([], dtype=torch.float),
+        torch.empty([], dtype=torch.float),
+    )
 
 
 @impl_abstract("torchcodec_ns::get_frame_at_index")
 def get_frame_at_index_abstract(
     decoder: torch.Tensor, *, stream_index: int, frame_index: int
-) -> torch.Tensor:
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     image_size = [get_ctx().new_dynamic_size() for _ in range(3)]
-    return torch.empty(image_size)
-
-
-@impl_abstract("torchcodec_ns::get_frame_with_info_at_index")
-def get_frame_with_info_at_index_abstract(
-    decoder: torch.Tensor, *, stream_index: int, frame_index: int
-) -> Tuple[torch.Tensor, float, float]:
-    image_size = [get_ctx().new_dynamic_size() for _ in range(3)]
-    return (torch.empty(image_size), 0, 0)
+    return (
+        torch.empty(image_size),
+        torch.empty([], dtype=torch.float),
+        torch.empty([], dtype=torch.float),
+    )
 
 
 @impl_abstract("torchcodec_ns::get_frames_at_indices")

--- a/src/torchcodec/decoders/_simple_video_decoder.py
+++ b/src/torchcodec/decoders/_simple_video_decoder.py
@@ -45,7 +45,7 @@ class SimpleVideoDecoder:
 
         return core.get_frame_at_index(
             self._decoder, frame_index=key, stream_index=self._stream_index
-        )
+        )[0]
 
     def _getitem_slice(self, key: slice) -> torch.Tensor:
         assert isinstance(key, slice)

--- a/src/torchcodec/samplers/video_clip_sampler.py
+++ b/src/torchcodec/samplers/video_clip_sampler.py
@@ -334,7 +334,7 @@ class VideoClipSampler(nn.Module):
         ) * video_frame_dilation + 1
         clip = []
         for _ in range(frames_needed_per_clip):
-            frame = get_next_frame(video_decoder)
+            frame, _, _ = get_next_frame(video_decoder)
             clip.append(frame)
 
         # slice the list of tensor with frame_dilation and stack to tensor

--- a/test/decoders/VideoDecoderOpsTest.cpp
+++ b/test/decoders/VideoDecoderOpsTest.cpp
@@ -37,8 +37,11 @@ TEST(VideoDecoderOpsTest, TestCreateDecoderFromBuffer) {
   size_t length = outputStringStream.str().length();
   at::Tensor decoder = create_from_buffer(buffer, length);
   add_video_stream(decoder);
-  at::Tensor tensor1 = get_next_frame(decoder);
+  auto result = get_next_frame(decoder);
+  at::Tensor tensor1 = std::get<0>(result);
   EXPECT_EQ(tensor1.sizes(), std::vector<long>({270, 480, 3}));
+  EXPECT_EQ(std::get<1>(result).item<double>(), 0);
+  EXPECT_NEAR(std::get<2>(result).item<double>(), 0.033367, 1e-6);
 }
 
 } // namespace facebook::torchcodec


### PR DESCRIPTION
Summary:
We now return the frame tensor, frame pts and frame duration for these functions.

Users who use the sampler or SimpleVideoDecoder are not affected.

Note that the pts and duration are returned as Tensors. This is due to a limitation of torch.compile() where it will not accept tuples of non-Tensors:

https://fb.workplace.com/groups/1075192433118967/posts/1461960124442194/?comment_id=1461971881107685

I also removed the `get_frame_with_info_at_index` because now that's redundant with `get_frame_at_index`.

In the proceses I also included VideoDecoderOps.h in VideoDecoderOps.cpp and fixed some inconsistencies between the two that were causing compilation failures.

TODO: I will handle the batch API functions in a subsequent diff.

Reviewed By: scotts

Differential Revision: D59542194
