### PR TITLE
[TorchCodec] Use correct type for impl_abstract functions

### DIFF
--- a/src/torchcodec/decoders/_core/video_decoder_ops.py
+++ b/src/torchcodec/decoders/_core/video_decoder_ops.py
@@ -176,25 +176,23 @@ def get_frames_in_range_abstract(
 
 
 @impl_abstract("torchcodec_ns::get_json_metadata")
-def get_json_metadata_abstract(decoder: torch.Tensor) -> torch.Tensor:
-    return torch.empty_like("")  # type: ignore[arg-type]
+def get_json_metadata_abstract(decoder: torch.Tensor) -> str:
+    return ""
 
 
 @impl_abstract("torchcodec_ns::get_container_json_metadata")
-def get_container_json_metadata_abstract(decoder: torch.Tensor) -> torch.Tensor:
-    return torch.empty_like("")  # type: ignore[arg-type]
+def get_container_json_metadata_abstract(decoder: torch.Tensor) -> str:
+    return ""
 
 
 @impl_abstract("torchcodec_ns::get_stream_json_metadata")
-def get_stream_json_metadata_abstract(
-    decoder: torch.Tensor, stream_idx: int
-) -> torch.Tensor:
-    return torch.empty_like("")  # type: ignore[arg-type]
+def get_stream_json_metadata_abstract(decoder: torch.Tensor, stream_idx: int) -> str:
+    return ""
 
 
 @impl_abstract("torchcodec_ns::_get_json_ffmpeg_library_versions")
-def _get_json_ffmpeg_library_versions_abstract() -> torch.Tensor:
-    return torch.empty_like("")  # type: ignore[arg-type]
+def _get_json_ffmpeg_library_versions_abstract() -> str:
+    return ""
 
 
 @impl_abstract("torchcodec_ns::scan_all_streams_to_update_metadata")


### PR DESCRIPTION
Summary: All the metadata functions return value are strings not tensors, plus torch.empty_like can't apply to an empty string.

Reviewed By: scotts, NicolasHug, ahmadsharif1

Differential Revision: D59609638


