### PR TITLE
[torchcodec] refactor SimpleVideoDecoder typing

### DIFF
--- a/test/decoders/test_simple_video_decoder.py
+++ b/test/decoders/test_simple_video_decoder.py
@@ -23,14 +23,14 @@ class TestSimpleDecoder:
             raise ValueError("Oops, double check the parametrization of this test!")
 
         decoder = SimpleVideoDecoder(source)
-        assert isinstance(decoder.stream_metadata, _core.StreamMetadata)
+        assert isinstance(decoder.metadata, _core.StreamMetadata)
         assert (
             len(decoder)
             == decoder._num_frames
-            == decoder.stream_metadata.num_frames_computed
+            == decoder.metadata.num_frames_computed
             == 390
         )
-        assert decoder._stream_index == decoder.stream_metadata.stream_index == 3
+        assert decoder._stream_index == decoder.metadata.stream_index == 3
 
     def test_create_fails(self):
         with pytest.raises(TypeError, match="Unknown source type"):


### PR DESCRIPTION
Summary:
Mostly typing refactors on `SimpleVideoDecoder`:

1. During initialization, each value we retrieve from the metadata has its own validate function that returns a non-optional value. That enables the type checker to track what's going on, so we don't need to turn it off for those lines. I do also find this cleaner.
2. Renamed `stream_metadata` to `metadata`. This member is a part of the public API. The concept of a "stream" is not exposed by `SimpleVideoDecoder`, so users should just be able to think of this as "The metadata for my decoder."
3. Use the modern syntax for type unions: https://docs.python.org/3/library/stdtypes.html#types-union

Differential Revision: D59682560
