### PR TITLE
[torchcodec] Throw StopIteration when trying to read past the EOF

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -105,11 +105,13 @@ class CMakeBuild(build_ext):
         # python setup.py build_ext --debug install
         torch_dir = Path(torch.utils.cmake_prefix_path) / "Torch"
         cmake_build_type = os.environ.get("CMAKE_BUILD_TYPE", "Release")
+        python_version = sys.version_info
         cmake_args = [
             f"-DCMAKE_INSTALL_PREFIX={self._install_prefix}",
             f"-DTorch_DIR={torch_dir}",
             "-DCMAKE_VERBOSE_MAKEFILE=ON",
             f"-DCMAKE_BUILD_TYPE={cmake_build_type}",
+            f"-DPYTHON_VERSION={python_version.major}.{python_version.minor}",
         ]
 
         Path(self.build_temp).mkdir(parents=True, exist_ok=True)

--- a/src/torchcodec/decoders/_core/CMakeLists.txt
+++ b/src/torchcodec/decoders/_core/CMakeLists.txt
@@ -5,6 +5,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(Torch REQUIRED)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${TORCH_CXX_FLAGS}")
+find_package(Python3 ${PYTHON_VERSION} EXACT COMPONENTS Development)
 
 function(make_torchcodec_library library_name ffmpeg_target)
     set(
@@ -24,12 +25,15 @@ function(make_torchcodec_library library_name ffmpeg_target)
         PRIVATE
         ./../../../../
         "${TORCH_INSTALL_PREFIX}/include"
+        ${Python3_INCLUDE_DIRS}
     )
 
     target_link_libraries(
         ${library_name}
+        PUBLIC
         ${ffmpeg_target}
         ${TORCH_LIBRARIES}
+        ${Python3_LIBRARIES}
     )
 
     # We already set the library_name to be libtorchcodecN, so we don't want

--- a/src/torchcodec/decoders/_core/VideoDecoder.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoder.cpp
@@ -688,6 +688,10 @@ VideoDecoder::DecodedOutput VideoDecoder::getDecodedOutputWithFilter(
     }
   }
   if (ffmpegStatus < AVSUCCESS) {
+    if (reachedEOF || ffmpegStatus == AVERROR_EOF) {
+      throw VideoDecoder::EndOfFileException(
+          "Requested next frame while there are no more frames left to decode.");
+    }
     throw std::runtime_error(
         "Could not receive frame from decoder: " +
         getFFMPEGErrorStringFromErrorCode(ffmpegStatus));

--- a/src/torchcodec/decoders/_core/VideoDecoder.h
+++ b/src/torchcodec/decoders/_core/VideoDecoder.h
@@ -169,6 +169,11 @@ class VideoDecoder {
     // The duration of the decoded frame in seconds.
     double durationSeconds;
   };
+  class EndOfFileException : public std::runtime_error {
+   public:
+    explicit EndOfFileException(const std::string& msg)
+        : std::runtime_error(msg) {}
+  };
   // Decodes the frame where the current cursor position is. It also advances
   // the cursor to the next frame.
   DecodedOutput getNextDecodedOutput();

--- a/test/decoders/CMakeLists.txt
+++ b/test/decoders/CMakeLists.txt
@@ -28,21 +28,19 @@ add_executable(
 
 target_include_directories(VideoDecoderTest SYSTEM PRIVATE ${TORCH_INCLUDE_DIRS})
 target_include_directories(VideoDecoderTest PRIVATE ../../)
-target_include_directories(VideoDecoderTest SYSTEM PRIVATE ${TORCH_INCLUDE_DIRS})
+target_include_directories(VideoDecoderOpsTest SYSTEM PRIVATE ${TORCH_INCLUDE_DIRS})
 target_include_directories(VideoDecoderOpsTest PRIVATE ../../)
 
 target_link_libraries(
   VideoDecoderTest
   ${libtorchcodec_target_name}
   GTest::gtest_main
-  "${TORCH_LIBRARIES}"
 )
 
 target_link_libraries(
   VideoDecoderOpsTest
   ${libtorchcodec_target_name}
   GTest::gtest_main
-  "${TORCH_LIBRARIES}"
 )
 
 include(GoogleTest)

--- a/test/decoders/test_video_decoder_ops.py
+++ b/test/decoders/test_video_decoder_ops.py
@@ -168,7 +168,7 @@ class TestOps:
         last_frame, _, _ = get_next_frame(decoder)
         reference_last_frame = NASA_VIDEO.get_tensor_by_name("time12.979633")
         assert_tensor_equal(last_frame, reference_last_frame)
-        with pytest.raises(RuntimeError, match="End of file"):
+        with pytest.raises(StopIteration, match="no more frames"):
             get_next_frame(decoder)
 
     def test_throws_exception_if_seek_too_far(self):
@@ -176,7 +176,7 @@ class TestOps:
         add_video_stream(decoder)
         # pts=12.979633 is the last frame in the video.
         seek_to_pts(decoder, 12.979633 + 1.0e-4)
-        with pytest.raises(RuntimeError, match="End of file"):
+        with pytest.raises(StopIteration, match="no more frames"):
             get_next_frame(decoder)
 
     def test_compile_seek_and_next(self):


### PR DESCRIPTION
Summary:
Previously we were throwing a generic runtime_error when reading past the EOF in get_next_frame.

Now we throw a pybind11 specific error which gets translated to StopIteration in python. This seems more appropriate than a generic runtime_error.

Reviewed By: scotts

Differential Revision: D59694977
