### PR TITLE
[torchcodec] add get_frames_at method to SimpleVideoDecoder

### DIFF
--- a/src/torchcodec/decoders/__init__.py
+++ b/src/torchcodec/decoders/__init__.py
@@ -1,1 +1,1 @@
-from ._simple_video_decoder import Frame, SimpleVideoDecoder  # noqa
+from ._simple_video_decoder import Frame, FrameBatch, SimpleVideoDecoder  # noqa

--- a/src/torchcodec/decoders/_core/VideoDecoder.h
+++ b/src/torchcodec/decoders/_core/VideoDecoder.h
@@ -186,6 +186,13 @@ class VideoDecoder {
   DecodedOutput getFrameAtIndex(int streamIndex, int64_t frameIndex);
   struct BatchDecodedOutput {
     torch::Tensor frames;
+    torch::Tensor ptsSeconds;
+    torch::Tensor durationSeconds;
+
+    explicit BatchDecodedOutput(
+        int64_t numFrames,
+        const VideoStreamDecoderOptions& options,
+        const StreamMetadata& metadata);
   };
   // Returns frames at the given indexes for a given stream as a single stacked
   // Tensor.

--- a/src/torchcodec/decoders/_core/video_decoder_ops.py
+++ b/src/torchcodec/decoders/_core/video_decoder_ops.py
@@ -175,9 +175,13 @@ def get_frames_in_range_abstract(
     start: int,
     stop: int,
     step: Optional[int] = None,
-) -> torch.Tensor:
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     image_size = [get_ctx().new_dynamic_size() for _ in range(4)]
-    return torch.empty(image_size)
+    return (
+        torch.empty(image_size),
+        torch.empty([], dtype=torch.float),
+        torch.empty([], dtype=torch.float),
+    )
 
 
 @impl_abstract("torchcodec_ns::get_json_metadata")

--- a/test/decoders/test_simple_video_decoder.py
+++ b/test/decoders/test_simple_video_decoder.py
@@ -3,7 +3,7 @@ import torch
 
 from torchcodec.decoders import _core, SimpleVideoDecoder
 
-from ..utils import assert_tensor_equal, NASA_VIDEO
+from ..utils import assert_tensor_close, assert_tensor_equal, NASA_VIDEO
 
 
 class TestSimpleDecoder:
@@ -39,10 +39,10 @@ class TestSimpleDecoder:
     def test_getitem_int(self):
         decoder = SimpleVideoDecoder(NASA_VIDEO.path)
 
-        ref_frame0 = NASA_VIDEO.get_tensor_by_index(0)
-        ref_frame1 = NASA_VIDEO.get_tensor_by_index(1)
-        ref_frame180 = NASA_VIDEO.get_tensor_by_name("time6.000000")
-        ref_frame_last = NASA_VIDEO.get_tensor_by_name("time12.979633")
+        ref_frame0 = NASA_VIDEO.get_frame_data_by_index(0)
+        ref_frame1 = NASA_VIDEO.get_frame_data_by_index(1)
+        ref_frame180 = NASA_VIDEO.get_frame_by_name("time6.000000")
+        ref_frame_last = NASA_VIDEO.get_frame_by_name("time12.979633")
 
         assert_tensor_equal(ref_frame0, decoder[0])
         assert_tensor_equal(ref_frame1, decoder[1])
@@ -54,7 +54,7 @@ class TestSimpleDecoder:
 
         # ensure that the degenerate case of a range of size 1 works
 
-        ref0 = NASA_VIDEO.get_stacked_tensor_by_range(0, 1)
+        ref0 = NASA_VIDEO.get_frame_data_by_range(0, 1)
         slice0 = decoder[0:1]
         assert slice0.shape == torch.Size(
             [
@@ -66,7 +66,7 @@ class TestSimpleDecoder:
         )
         assert_tensor_equal(ref0, slice0)
 
-        ref4 = NASA_VIDEO.get_stacked_tensor_by_range(4, 5)
+        ref4 = NASA_VIDEO.get_frame_data_by_range(4, 5)
         slice4 = decoder[4:5]
         assert slice4.shape == torch.Size(
             [
@@ -78,7 +78,7 @@ class TestSimpleDecoder:
         )
         assert_tensor_equal(ref4, slice4)
 
-        ref8 = NASA_VIDEO.get_stacked_tensor_by_range(8, 9)
+        ref8 = NASA_VIDEO.get_frame_data_by_range(8, 9)
         slice8 = decoder[8:9]
         assert slice8.shape == torch.Size(
             [
@@ -90,7 +90,7 @@ class TestSimpleDecoder:
         )
         assert_tensor_equal(ref8, slice8)
 
-        ref180 = NASA_VIDEO.get_tensor_by_name("time6.000000")
+        ref180 = NASA_VIDEO.get_frame_by_name("time6.000000")
         slice180 = decoder[180:181]
         assert slice180.shape == torch.Size(
             [
@@ -103,7 +103,7 @@ class TestSimpleDecoder:
         assert_tensor_equal(ref180, slice180[0])
 
         # contiguous ranges
-        ref0_9 = NASA_VIDEO.get_stacked_tensor_by_range(0, 9)
+        ref0_9 = NASA_VIDEO.get_frame_data_by_range(0, 9)
         slice0_9 = decoder[0:9]
         assert slice0_9.shape == torch.Size(
             [
@@ -115,7 +115,7 @@ class TestSimpleDecoder:
         )
         assert_tensor_equal(ref0_9, slice0_9)
 
-        ref4_8 = NASA_VIDEO.get_stacked_tensor_by_range(4, 8)
+        ref4_8 = NASA_VIDEO.get_frame_data_by_range(4, 8)
         slice4_8 = decoder[4:8]
         assert slice4_8.shape == torch.Size(
             [
@@ -128,7 +128,7 @@ class TestSimpleDecoder:
         assert_tensor_equal(ref4_8, slice4_8)
 
         # ranges with a stride
-        ref15_35 = NASA_VIDEO.get_stacked_tensor_by_range(15, 36, 5)
+        ref15_35 = NASA_VIDEO.get_frame_data_by_range(15, 36, 5)
         slice15_35 = decoder[15:36:5]
         assert slice15_35.shape == torch.Size(
             [
@@ -140,7 +140,7 @@ class TestSimpleDecoder:
         )
         assert_tensor_equal(ref15_35, slice15_35)
 
-        ref0_9_2 = NASA_VIDEO.get_stacked_tensor_by_range(0, 9, 2)
+        ref0_9_2 = NASA_VIDEO.get_frame_data_by_range(0, 9, 2)
         slice0_9_2 = decoder[0:9:2]
         assert slice0_9_2.shape == torch.Size(
             [
@@ -153,7 +153,7 @@ class TestSimpleDecoder:
         assert_tensor_equal(ref0_9_2, slice0_9_2)
 
         # negative numbers in the slice
-        ref386_389 = NASA_VIDEO.get_stacked_tensor_by_range(386, 390)
+        ref386_389 = NASA_VIDEO.get_frame_data_by_range(386, 390)
         slice386_389 = decoder[-4:]
         assert slice386_389.shape == torch.Size(
             [
@@ -201,12 +201,12 @@ class TestSimpleDecoder:
     def test_iteration(self):
         decoder = SimpleVideoDecoder(NASA_VIDEO.path)
 
-        ref_frame0 = NASA_VIDEO.get_tensor_by_index(0)
-        ref_frame1 = NASA_VIDEO.get_tensor_by_index(1)
-        ref_frame9 = NASA_VIDEO.get_tensor_by_index(9)
-        ref_frame35 = NASA_VIDEO.get_tensor_by_index(35)
-        ref_frame180 = NASA_VIDEO.get_tensor_by_name("time6.000000")
-        ref_frame_last = NASA_VIDEO.get_tensor_by_name("time12.979633")
+        ref_frame0 = NASA_VIDEO.get_frame_data_by_index(0)
+        ref_frame1 = NASA_VIDEO.get_frame_data_by_index(1)
+        ref_frame9 = NASA_VIDEO.get_frame_data_by_index(9)
+        ref_frame35 = NASA_VIDEO.get_frame_data_by_index(35)
+        ref_frame180 = NASA_VIDEO.get_frame_by_name("time6.000000")
+        ref_frame_last = NASA_VIDEO.get_frame_by_name("time12.979633")
 
         # Access an arbitrary frame to make sure that the later iteration
         # still works as expected. The underlying C++ decoder object is
@@ -230,7 +230,7 @@ class TestSimpleDecoder:
 
     def test_iteration_slow(self):
         decoder = SimpleVideoDecoder(NASA_VIDEO.path)
-        ref_frame_last = NASA_VIDEO.get_tensor_by_index(389)
+        ref_frame_last = NASA_VIDEO.get_frame_data_by_index(389)
 
         # Force the decoder to seek around a lot while iterating; this will
         # slow down decoding, but we should still only iterate the exact number
@@ -245,7 +245,7 @@ class TestSimpleDecoder:
     def test_get_frame_at(self):
         decoder = SimpleVideoDecoder(NASA_VIDEO.path)
 
-        ref_frame9 = NASA_VIDEO.get_tensor_by_index(9)
+        ref_frame9 = NASA_VIDEO.get_frame_data_by_index(9)
         frame9 = decoder.get_frame_at(9)
 
         assert_tensor_equal(ref_frame9, frame9.data)
@@ -274,7 +274,7 @@ class TestSimpleDecoder:
     def test_get_frame_displayed_at(self):
         decoder = SimpleVideoDecoder(NASA_VIDEO.path)
 
-        ref_frame6 = NASA_VIDEO.get_tensor_by_name("time6.000000")
+        ref_frame6 = NASA_VIDEO.get_frame_by_name("time6.000000")
         assert_tensor_equal(ref_frame6, decoder.get_frame_displayed_at(6.006).data)
         assert_tensor_equal(ref_frame6, decoder.get_frame_displayed_at(6.02).data)
         assert_tensor_equal(ref_frame6, decoder.get_frame_displayed_at(6.039366).data)
@@ -287,6 +287,67 @@ class TestSimpleDecoder:
 
         with pytest.raises(IndexError, match="Invalid pts in seconds"):
             frame = decoder.get_frame_displayed_at(100.0)  # noqa
+
+    def test_get_frames_at(self):
+        decoder = SimpleVideoDecoder(NASA_VIDEO.path)
+
+        # test degenerate case where we only actually get 1 frame
+        ref_frames9 = NASA_VIDEO.get_frame_data_by_range(start=9, stop=10)
+        frames9 = decoder.get_frames_at(start=9, stop=10)
+
+        assert_tensor_equal(ref_frames9, frames9.data)
+        assert frames9.pts_seconds[0].item() == pytest.approx(0.3003, rel=1e-3)
+        assert frames9.duration_seconds[0].item() == pytest.approx(0.03337, rel=1e-3)
+
+        # test simple ranges
+        ref_frames0_9 = NASA_VIDEO.get_frame_data_by_range(start=0, stop=10)
+        frames0_9 = decoder.get_frames_at(start=0, stop=10)
+        assert frames0_9.data.shape == torch.Size(
+            [
+                10,
+                NASA_VIDEO.height,
+                NASA_VIDEO.width,
+                NASA_VIDEO.num_color_channels,
+            ]
+        )
+        assert_tensor_equal(ref_frames0_9, frames0_9.data)
+        assert_tensor_close(
+            NASA_VIDEO.get_pts_seconds_by_range(0, 10),
+            frames0_9.pts_seconds,
+        )
+        assert_tensor_close(
+            NASA_VIDEO.get_duration_seconds_by_range(0, 10),
+            frames0_9.duration_seconds,
+        )
+
+        # test steps
+        ref_frames0_8_2 = NASA_VIDEO.get_frame_data_by_range(start=0, stop=10, step=2)
+        frames0_8_2 = decoder.get_frames_at(start=0, stop=10, step=2)
+        assert frames0_8_2.data.shape == torch.Size(
+            [
+                5,
+                NASA_VIDEO.height,
+                NASA_VIDEO.width,
+                NASA_VIDEO.num_color_channels,
+            ]
+        )
+        assert_tensor_equal(ref_frames0_8_2, frames0_8_2.data)
+        assert_tensor_close(
+            NASA_VIDEO.get_pts_seconds_by_range(0, 10, 2),
+            frames0_8_2.pts_seconds,
+        )
+        assert_tensor_close(
+            NASA_VIDEO.get_duration_seconds_by_range(0, 10, 2),
+            frames0_8_2.duration_seconds,
+        )
+
+        # an empty range is valid!
+        empty_frames = decoder.get_frames_at(5, 5)
+        assert_tensor_equal(empty_frames.data, NASA_VIDEO.empty_hwc_tensor)
+        assert_tensor_equal(empty_frames.pts_seconds, NASA_VIDEO.empty_pts_seconds)
+        assert_tensor_equal(
+            empty_frames.duration_seconds, NASA_VIDEO.empty_duration_seconds
+        )
 
 
 if __name__ == "__main__":

--- a/test/utils.py
+++ b/test/utils.py
@@ -3,14 +3,28 @@ import os
 import pathlib
 
 from dataclasses import dataclass
+from typing import Dict
 
 import numpy as np
 
 import torch
 
 
+# For use with decoded data frames, or in other instances were we are confident that
+# reference and test tensors should be exactly equal. This is true for decoded data
+# frames from media because we expect our decoding to exactly match what a user can
+# do on the command line with ffmpeg.
 def assert_tensor_equal(*args, **kwargs):
     torch.testing.assert_close(*args, **kwargs, atol=0, rtol=0)
+
+
+# For use with floating point metadata, or in other instances where we are not confident
+# that reference and test tensors can be exactly equal. This is true for pts and duration
+# in seconds, as the reference values are from ffprobe's JSON output. In that case, it is
+# limiting the floating point precision when printing the value as a string. The value from
+# JSON and the value we retrieve during decoding are not exactly the same.
+def assert_tensor_close(*args, **kwargs):
+    torch.testing.assert_close(*args, **kwargs, atol=1e-6, rtol=1e-6)
 
 
 def in_fbcode() -> bool:
@@ -36,8 +50,15 @@ def _load_tensor_from_file(filename: str) -> torch.Tensor:
 
 
 @dataclass
+class TestFrameInfo:
+    pts_seconds: float
+    duration_seconds: float
+
+
+@dataclass
 class TestContainerFile:
     filename: str
+    frames: Dict[int, TestFrameInfo]
 
     @property
     def path(self) -> pathlib.Path:
@@ -47,17 +68,39 @@ class TestContainerFile:
         arr = np.fromfile(self.path, dtype=np.uint8)
         return torch.from_numpy(arr)
 
-    def get_tensor_by_index(self, idx: int) -> torch.Tensor:
+    def get_frame_data_by_index(self, idx: int) -> torch.Tensor:
         return _load_tensor_from_file(f"{self.filename}.frame{idx:06d}.pt")
 
-    def get_stacked_tensor_by_range(
+    def get_frame_data_by_range(
         self, start: int, stop: int, step: int = 1
     ) -> torch.Tensor:
-        tensors = [self.get_tensor_by_index(i) for i in range(start, stop, step)]
+        tensors = [self.get_frame_data_by_index(i) for i in range(start, stop, step)]
         return torch.stack(tensors)
 
-    def get_tensor_by_name(self, name: str) -> torch.Tensor:
+    def get_pts_seconds_by_range(
+        self, start: int, stop: int, step: int = 1
+    ) -> torch.Tensor:
+        all_pts = [self.frames[i].pts_seconds for i in range(start, stop, step)]
+        return torch.tensor(all_pts, dtype=torch.float)
+
+    def get_duration_seconds_by_range(
+        self, start: int, stop: int, step: int = 1
+    ) -> torch.Tensor:
+        all_durations = [
+            self.frames[i].duration_seconds for i in range(start, stop, step)
+        ]
+        return torch.tensor(all_durations, dtype=torch.float)
+
+    def get_frame_by_name(self, name: str) -> torch.Tensor:
         return _load_tensor_from_file(f"{self.filename}.{name}.pt")
+
+    @property
+    def empty_pts_seconds(self) -> torch.Tensor:
+        return torch.empty([0], dtype=torch.float)
+
+    @property
+    def empty_duration_seconds(self) -> torch.Tensor:
+        return torch.empty([0], dtype=torch.float)
 
 
 @dataclass
@@ -83,9 +126,28 @@ class TestVideo(TestContainerFile):
 
 
 NASA_VIDEO = TestVideo(
-    filename="nasa_13013.mp4", height=270, width=480, num_color_channels=3
+    filename="nasa_13013.mp4",
+    height=270,
+    width=480,
+    num_color_channels=3,
+    # TODO: improve the testing framework so that these values are loaded from a JSON
+    # file and not hardcoded. These values were copied over by hand from the JSON
+    # output from the following command:
+    #  $ ffprobe -v error -hide_banner -select_streams v:1 -show_frames -of json test/resources/nasa_13013.mp4 > out.json
+    frames={
+        0: TestFrameInfo(pts_seconds=0.0, duration_seconds=0.033367),
+        1: TestFrameInfo(pts_seconds=0.033367, duration_seconds=0.033367),
+        2: TestFrameInfo(pts_seconds=0.066733, duration_seconds=0.033367),
+        3: TestFrameInfo(pts_seconds=0.100100, duration_seconds=0.033367),
+        4: TestFrameInfo(pts_seconds=0.133467, duration_seconds=0.033367),
+        5: TestFrameInfo(pts_seconds=0.166833, duration_seconds=0.033367),
+        6: TestFrameInfo(pts_seconds=0.200200, duration_seconds=0.033367),
+        7: TestFrameInfo(pts_seconds=0.233567, duration_seconds=0.033367),
+        8: TestFrameInfo(pts_seconds=0.266933, duration_seconds=0.033367),
+        9: TestFrameInfo(pts_seconds=0.300300, duration_seconds=0.033367),
+    },
 )
 
 # When we start actually decoding audio-only files, we'll probably need to define
 # a TestAudio class with audio specific values. Until then, we only need a filename.
-NASA_AUDIO = TestContainerFile(filename="nasa_13013.mp4.audio.mp3")
+NASA_AUDIO = TestContainerFile(filename="nasa_13013.mp4.audio.mp3", frames={})


### PR DESCRIPTION
Summary:
This diff does several things:
1. Adds new method to `SimpleVideoDecoder`, with the signature:
  get_frames_at(
    self,
    start: int,
    stop: int,
    step: int = 1,
  ) -> Frames
2. Adds the `Frames` dataclass as a part of the public API. It has stacked versions of all return values, and is a sibling to the `Frame` dataclass.
3. Updates our testing framework so that we can systematically associate pts and duration metadata with a particular test file. In this diff we are hardcoding the metadata into the testing utils. In the future, we should read it from a checked-in JSON file we generate with ffprobe.

This diff is a partial implementation of the design in: https://fburl.com/gdoc/i6eqb634

Differential Revision: D59767617
