### PR TITLE
[torchcodec] refactor stream index and scanned checks into validate functions

### DIFF
--- a/src/torchcodec/decoders/_core/VideoDecoder.h
+++ b/src/torchcodec/decoders/_core/VideoDecoder.h
@@ -276,6 +276,8 @@ class VideoDecoder {
   // for more details about the heuristics.
   int getBestStreamIndex(AVMediaType mediaType);
   void initializeDecoder();
+  void validateUserProvidedStreamIndex(uint64_t streamIndex);
+  void validateScannedAllStreams(const std::string& msg);
   // Creates and initializes a filter graph for a stream. The filter graph can
   // do rescaling and color conversion.
   void initializeFilterGraphForStream(
@@ -296,10 +298,6 @@ class VideoDecoder {
   DecodedOutput convertAVFrameToDecodedOutput(
       int streamIndex,
       UniqueAVFrame frame);
-  torch::Tensor getEmptyTensorForBatch(
-      int64_t numFrames,
-      const VideoStreamDecoderOptions& options,
-      const StreamMetadata& metadata);
 
   DecoderOptions options_;
   ContainerMetadata containerMetadata_;


### PR DESCRIPTION
Summary: We've been doing in-place checks for `streamIndex` validation and to validate that we've done a full scan. This leads leads to copy-paste code and may lead to subtle differences in the validations (such as not using `TORCH_CHECK` and inconsistent messages). This diff consolidates those checks into functions. These validations should only be necessary on the public-facing methods of `VideoDecoder` that have these assumptions.

Differential Revision: D59916313
