### PR TITLE
[torchcodec] Add stream_index to the output of core functions

### DIFF
--- a/src/torchcodec/decoders/_core/VideoDecoder.h
+++ b/src/torchcodec/decoders/_core/VideoDecoder.h
@@ -185,11 +185,13 @@ class VideoDecoder {
   DecodedOutput getFrameDisplayedAtTimestamp(double seconds);
   DecodedOutput getFrameAtIndex(int streamIndex, int64_t frameIndex);
   struct BatchDecodedOutput {
+    torch::Tensor streamIndices;
     torch::Tensor frames;
     torch::Tensor ptsSeconds;
     torch::Tensor durationSeconds;
 
     explicit BatchDecodedOutput(
+        int inStreamIndex,
         int64_t numFrames,
         const VideoStreamDecoderOptions& options,
         const StreamMetadata& metadata);

--- a/src/torchcodec/decoders/_core/VideoDecoderOps.h
+++ b/src/torchcodec/decoders/_core/VideoDecoderOps.h
@@ -42,7 +42,8 @@ void seek_to_pts(at::Tensor& decoder, double seconds);
 //   3. A single float value for the duration in seconds.
 // The reason we use Tensors for the second and third values is so we can run
 // under torch.compile().
-using FramePtsDuration = std::tuple<at::Tensor, at::Tensor, at::Tensor>;
+using OpsDecodedOutput =
+    std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor>;
 
 // All elements of this tuple are tensors of the same leading dimension. The
 // tuple represents the frames for N total frames, where N is the dimension of
@@ -53,22 +54,23 @@ using FramePtsDuration = std::tuple<at::Tensor, at::Tensor, at::Tensor>;
 //   float.
 //   3. Tensor of N durationis in seconds, where each duration is a
 //   single float.
-using BatchedFramesPtsDuration = std::tuple<at::Tensor, at::Tensor, at::Tensor>;
+using OpsBatchDecodedOutput =
+    std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor>;
 
 // Return the frame that is visible at a given timestamp in seconds. Each frame
 // in FFMPEG has a presentation timestamp and a duration. The frame visible at a
 // given timestamp T has T >= PTS and T < PTS + Duration.
-FramePtsDuration get_frame_at_pts(at::Tensor& decoder, double seconds);
+OpsDecodedOutput get_frame_at_pts(at::Tensor& decoder, double seconds);
 
 // Return the frame that is visible at a given index in the video.
-FramePtsDuration get_frame_at_index(
+OpsDecodedOutput get_frame_at_index(
     at::Tensor& decoder,
     int64_t stream_index,
     int64_t frame_index);
 
 // Get the next frame from the video as a tuple that has the frame data, pts and
 // duration as tensors.
-FramePtsDuration get_next_frame(at::Tensor& decoder);
+OpsDecodedOutput get_next_frame(at::Tensor& decoder);
 
 // Return the frames at a given index for a given stream as a single stacked
 // Tensor.
@@ -79,7 +81,7 @@ at::Tensor get_frames_at_indices(
 
 // Return the frames inside a range as a single stacked Tensor. The range is
 // defined as [start, stop).
-BatchedFramesPtsDuration get_frames_in_range(
+OpsBatchDecodedOutput get_frames_in_range(
     at::Tensor& decoder,
     int64_t stream_index,
     int64_t start,

--- a/src/torchcodec/decoders/_core/video_decoder_ops.py
+++ b/src/torchcodec/decoders/_core/video_decoder_ops.py
@@ -121,7 +121,7 @@ def seek_abstract(decoder: torch.Tensor, seconds: float) -> None:
 @impl_abstract("torchcodec_ns::get_next_frame")
 def get_next_frame_abstract(
     decoder: torch.Tensor,
-) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     # Images are 3 dimensions: height, width, channels.
     # The exact permutation depends on the constructor options passed in.
     image_size = [get_ctx().new_dynamic_size() for _ in range(3)]
@@ -129,30 +129,33 @@ def get_next_frame_abstract(
         torch.empty(image_size),
         torch.empty([], dtype=torch.float),
         torch.empty([], dtype=torch.float),
+        torch.empty([], dtype=torch.int64),
     )
 
 
 @impl_abstract("torchcodec_ns::get_frame_at_pts")
 def get_frame_at_pts_abstract(
     decoder: torch.Tensor, seconds: float
-) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     image_size = [get_ctx().new_dynamic_size() for _ in range(3)]
     return (
         torch.empty(image_size),
         torch.empty([], dtype=torch.float),
         torch.empty([], dtype=torch.float),
+        torch.empty([], dtype=torch.int64),
     )
 
 
 @impl_abstract("torchcodec_ns::get_frame_at_index")
 def get_frame_at_index_abstract(
     decoder: torch.Tensor, *, stream_index: int, frame_index: int
-) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     image_size = [get_ctx().new_dynamic_size() for _ in range(3)]
     return (
         torch.empty(image_size),
         torch.empty([], dtype=torch.float),
         torch.empty([], dtype=torch.float),
+        torch.empty([], dtype=torch.int64),
     )
 
 
@@ -175,9 +178,10 @@ def get_frames_in_range_abstract(
     start: int,
     stop: int,
     step: Optional[int] = None,
-) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+) -> Tuple[int, torch.Tensor, torch.Tensor, torch.Tensor]:
     image_size = [get_ctx().new_dynamic_size() for _ in range(4)]
     return (
+        0,
         torch.empty(image_size),
         torch.empty([], dtype=torch.float),
         torch.empty([], dtype=torch.float),

--- a/src/torchcodec/decoders/_simple_video_decoder.py
+++ b/src/torchcodec/decoders/_simple_video_decoder.py
@@ -15,6 +15,7 @@ class Frame(Iterable):
     data: Tensor
     pts_seconds: float
     duration_seconds: float
+    stream_index: int
 
     def __iter__(self) -> Iterator[Union[Tensor, float]]:
         for field in dataclasses.fields(self):
@@ -26,6 +27,7 @@ class FrameBatch(Iterable):
     data: Tensor
     pts_seconds: Tensor
     duration_seconds: Tensor
+    stream_indices: Tensor
 
     def __iter__(self) -> Iterator[Union[Tensor, float]]:
         for field in dataclasses.fields(self):

--- a/src/torchcodec/samplers/video_clip_sampler.py
+++ b/src/torchcodec/samplers/video_clip_sampler.py
@@ -334,7 +334,7 @@ class VideoClipSampler(nn.Module):
         ) * video_frame_dilation + 1
         clip = []
         for _ in range(frames_needed_per_clip):
-            frame, _, _ = get_next_frame(video_decoder)
+            frame, _, _, _ = get_next_frame(video_decoder)
             clip.append(frame)
 
         # slice the list of tensor with frame_dilation and stack to tensor

--- a/test/decoders/manual_smoke_test.py
+++ b/test/decoders/manual_smoke_test.py
@@ -8,7 +8,7 @@ decoder = torchcodec.decoders._core.create_from_file(
 )
 torchcodec.decoders._core.scan_all_streams_to_update_metadata(decoder)
 torchcodec.decoders._core.add_video_stream(decoder, stream_index=3)
-frame, _, _ = torchcodec.decoders._core.get_frame_at_index(
+frame, _, _, _ = torchcodec.decoders._core.get_frame_at_index(
     decoder, stream_index=3, frame_index=180
 )
 frame = frame.permute(2, 0, 1)

--- a/test/decoders/test_simple_video_decoder.py
+++ b/test/decoders/test_simple_video_decoder.py
@@ -256,11 +256,12 @@ class TestSimpleDecoder:
         decoder = SimpleVideoDecoder(NASA_VIDEO.path)
 
         frame = decoder.get_frame_at(50)
-        data, pts, duration = decoder.get_frame_at(50)
+        data, pts, duration, stream_index = decoder.get_frame_at(50)
 
         assert_tensor_equal(frame.data, data)
         assert frame.pts_seconds == pts
         assert frame.duration_seconds == duration
+        assert frame.stream_index == stream_index
 
     def test_get_frame_at_fails(self):
         decoder = SimpleVideoDecoder(NASA_VIDEO.path)

--- a/test/decoders/test_video_decoder_ops.py
+++ b/test/decoders/test_video_decoder_ops.py
@@ -49,14 +49,14 @@ class TestOps:
     def test_seek_and_next(self):
         decoder = create_from_file(str(NASA_VIDEO.path))
         add_video_stream(decoder)
-        frame0, _, _ = get_next_frame(decoder)
+        frame0, _, _, _ = get_next_frame(decoder)
         reference_frame0 = NASA_VIDEO.get_frame_data_by_index(0)
         assert_tensor_equal(frame0, reference_frame0)
         reference_frame1 = NASA_VIDEO.get_frame_data_by_index(1)
-        frame1, _, _ = get_next_frame(decoder)
+        frame1, _, _, _ = get_next_frame(decoder)
         assert_tensor_equal(frame1, reference_frame1)
         seek_to_pts(decoder, 6.0)
-        frame_time6, _, _ = get_next_frame(decoder)
+        frame_time6, _, _, _ = get_next_frame(decoder)
         reference_frame_time6 = NASA_VIDEO.get_frame_by_name("time6.000000")
         assert_tensor_equal(frame_time6, reference_frame_time6)
 
@@ -65,17 +65,17 @@ class TestOps:
         add_video_stream(decoder)
         # This frame has pts=6.006 and duration=0.033367, so it should be visible
         # at timestamps in the range [6.006, 6.039367) (not including the last timestamp).
-        frame6, _, _ = get_frame_at_pts(decoder, 6.006)
+        frame6, _, _, _ = get_frame_at_pts(decoder, 6.006)
         reference_frame6 = NASA_VIDEO.get_frame_by_name("time6.000000")
         assert_tensor_equal(frame6, reference_frame6)
-        frame6, _, _ = get_frame_at_pts(decoder, 6.02)
+        frame6, _, _, _ = get_frame_at_pts(decoder, 6.02)
         assert_tensor_equal(frame6, reference_frame6)
-        frame6, _, _ = get_frame_at_pts(decoder, 6.039366)
+        frame6, _, _, _ = get_frame_at_pts(decoder, 6.039366)
         assert_tensor_equal(frame6, reference_frame6)
         # Note that this timestamp is exactly on a frame boundary, so it should
         # return the next frame since the right boundary of the interval is
         # open.
-        next_frame, _, _ = get_frame_at_pts(decoder, 6.039367)
+        next_frame, _, _, _ = get_frame_at_pts(decoder, 6.039367)
         with pytest.raises(AssertionError):
             assert_tensor_equal(next_frame, reference_frame6)
 
@@ -83,11 +83,11 @@ class TestOps:
         decoder = create_from_file(str(NASA_VIDEO.path))
         scan_all_streams_to_update_metadata(decoder)
         add_video_stream(decoder)
-        frame0, _, _ = get_frame_at_index(decoder, stream_index=3, frame_index=0)
+        frame0, _, _, _ = get_frame_at_index(decoder, stream_index=3, frame_index=0)
         reference_frame0 = NASA_VIDEO.get_frame_data_by_index(0)
         assert_tensor_equal(frame0, reference_frame0)
         # The frame that is displayed at 6 seconds is frame 180 from a 0-based index.
-        frame6, _, _ = get_frame_at_index(decoder, stream_index=3, frame_index=180)
+        frame6, _, _, _ = get_frame_at_index(decoder, stream_index=3, frame_index=180)
         reference_frame6 = NASA_VIDEO.get_frame_by_name("time6.000000")
         assert_tensor_equal(frame6, reference_frame6)
 
@@ -95,13 +95,14 @@ class TestOps:
         decoder = create_from_file(str(NASA_VIDEO.path))
         scan_all_streams_to_update_metadata(decoder)
         add_video_stream(decoder)
-        frame6, pts, duration = get_frame_at_index(
+        frame6, pts, duration, stream_index = get_frame_at_index(
             decoder, stream_index=3, frame_index=180
         )
         reference_frame6 = NASA_VIDEO.get_frame_by_name("time6.000000")
         assert_tensor_equal(frame6, reference_frame6)
         assert pts.item() == pytest.approx(6.006, rel=1e-3)
         assert duration.item() == pytest.approx(0.03337, rel=1e-3)
+        assert stream_index == 3
 
     def test_get_frames_at_indices(self):
         decoder = create_from_file(str(NASA_VIDEO.path))
@@ -169,7 +170,7 @@ class TestOps:
         decoder = create_from_file(str(NASA_VIDEO.path))
         add_video_stream(decoder)
         seek_to_pts(decoder, 12.979633)
-        last_frame, _, _ = get_next_frame(decoder)
+        last_frame, _, _, _ = get_next_frame(decoder)
         reference_last_frame = NASA_VIDEO.get_frame_by_name("time12.979633")
         assert_tensor_equal(last_frame, reference_last_frame)
         with pytest.raises(StopIteration, match="no more frames"):
@@ -190,9 +191,9 @@ class TestOps:
         @torch.compile(fullgraph=True, backend="eager")
         def get_frame1_and_frame_time6(decoder):
             add_video_stream(decoder)
-            frame0, _, _ = get_next_frame(decoder)
+            frame0, _, _, _ = get_next_frame(decoder)
             seek_to_pts(decoder, 6.0)
-            frame_time6, _, _ = get_next_frame(decoder)
+            frame_time6, _, _, _ = get_next_frame(decoder)
             return frame0, frame_time6
 
         # NB: create needs to happen outside the torch.compile region,
@@ -210,9 +211,9 @@ class TestOps:
         def class_based_get_frame1_and_frame_time6(
             decoder: ReferenceDecoder,
         ) -> Tuple[torch.Tensor, torch.Tensor]:
-            frame0, _, _ = decoder.get_next_frame()
+            frame0, _, _, _ = decoder.get_next_frame()
             decoder.seek(6.0)
-            frame_time6, _, _ = decoder.get_next_frame()
+            frame_time6, _, _, _ = decoder.get_next_frame()
             return frame0, frame_time6
 
         decoder = ReferenceDecoder()
@@ -237,14 +238,14 @@ class TestOps:
             decoder = create_from_bytes(video_bytes)
 
         add_video_stream(decoder)
-        frame0, _, _ = get_next_frame(decoder)
+        frame0, _, _, _ = get_next_frame(decoder)
         reference_frame0 = NASA_VIDEO.get_frame_data_by_index(0)
         assert_tensor_equal(frame0, reference_frame0)
         reference_frame1 = NASA_VIDEO.get_frame_data_by_index(1)
-        frame1, _, _ = get_next_frame(decoder)
+        frame1, _, _, _ = get_next_frame(decoder)
         assert_tensor_equal(frame1, reference_frame1)
         seek_to_pts(decoder, 6.0)
-        frame_time6, _, _ = get_next_frame(decoder)
+        frame_time6, _, _, _ = get_next_frame(decoder)
         reference_frame_time6 = NASA_VIDEO.get_frame_by_name("time6.000000")
         assert_tensor_equal(frame_time6, reference_frame_time6)
 


### PR DESCRIPTION
Summary:
We need to return stream_index for handling torchaudio style de-multiplexing on the python side where the user could configure 2 streams and asks for the next frame from any available stream and uses that.

I also renamed the tuples to be closer to their names on the C++ side.

Differential Revision: D59930581
