### PR TITLE
Add tons of docs

### DIFF
--- a/docs/source/_static/img/card-background.svg
+++ b/docs/source/_static/img/card-background.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 202.43 51">
+  <defs>
+    <style>
+      .cls-1 {
+        fill: #ee4c2a;
+        stroke: #ee4c2a;
+        stroke-miterlimit: 10;
+      }
+    </style>
+  </defs>
+  <rect class="cls-1" x=".5" y=".5" width="201.43" height="50"/>
+</svg>

--- a/docs/source/_templates/dataclass.rst
+++ b/docs/source/_templates/dataclass.rst
@@ -1,0 +1,10 @@
+.. role:: hidden
+    :class: hidden-section
+.. currentmodule:: {{ module }}
+
+
+{{ name | underline}}
+
+.. autoclass:: {{ name }}
+    :members:
+    :undoc-members: __init__

--- a/docs/source/api_ref_decoders.rst
+++ b/docs/source/api_ref_decoders.rst
@@ -1,0 +1,26 @@
+.. _decoders:
+
+===================
+torchcodec.decoders
+===================
+
+.. currentmodule:: torchcodec.decoders
+
+
+.. autosummary::
+    :toctree: generated/
+    :nosignatures:
+    :template: class.rst
+
+    SimpleVideoDecoder
+
+
+.. TODO The dataclass.rst template renders a bit ugly.
+.. autosummary::
+    :toctree: generated/
+    :nosignatures:
+    :template: dataclass.rst
+
+    Frame
+    FrameBatch
+    StreamMetadata

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -1,0 +1,12 @@
+Glossary
+========
+
+.. .. TODO: This doesn't render very well. It's supposed to look more like this
+.. https://scikit-learn.org/stable/glossary.html. The pytorch sphinx theme
+.. should handle this better.
+
+.. glossary::
+
+    pts
+       Presentation Time Stamp. The time at which a frame should be displayed.
+       In TorchCodec, pts are expressed in seconds.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,25 +1,62 @@
-Welcome to the TorchCodec documentation
-=======================================
+Welcome to the TorchCodec documentation!
+========================================
 
-Still WIP :)
+TorchCodec provides utilities for decoding videos into PyTorch tensors.
 
+.. TODO Add link to GH repo below
+.. note::
+
+   TorchCodec is still in early development stage and we are actively seeking
+   feedback. If you have any suggestions or issues, please let us know by
+   opening an issue on our GitHub repository.
+
+.. grid:: 3
+
+     .. grid-item-card:: :octicon:`file-code;1em`
+        Installation instructions
+        :img-top: _static/img/card-background.svg
+        :link: install_instructions.html
+        :link-type: url
+
+        How to install TorchCodec
+
+     .. grid-item-card:: :octicon:`file-code;1em`
+        Getting Started with TorchCodec
+        :img-top: _static/img/card-background.svg
+        :link: generated_examples/basic_example.html
+        :link-type: url
+
+        A simple video decoding example
+
+     .. grid-item-card:: :octicon:`file-code;1em`
+        API Reference
+        :img-top: _static/img/card-background.svg
+        :link: api_ref_decoders.html
+        :link-type: url
+
+        The API reference for TorchCodec
 
 .. toctree::
    :maxdepth: 1
-   :caption: Examples
+   :caption: TorchCodec documentation
+   :hidden:
 
+   Home <self>
+   glossary
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Examples and tutorials
+   :hidden:
+
+   install_instructions
    generated_examples/index
 
 
+.. toctree::
+   :glob:
+   :maxdepth: 1
+   :caption: API Reference
+   :hidden:
 
-API REF
--------
-
-.. TODO: Move that separately later. This is just for illustration purpose for
-.. now.
-
-.. autosummary::
-    :toctree: generated/
-    :template: class.rst
-
-    torchcodec.decoders.SimpleVideoDecoder
+   api_ref_decoders

--- a/docs/source/install_instructions.rst
+++ b/docs/source/install_instructions.rst
@@ -1,0 +1,29 @@
+Installation Instructions
+=========================
+
+.. note::
+    TorchCodec is only available on Linux for now. We plan to support other
+    platforms in the future.
+
+Installing torchcodec should be as simple as:
+
+.. code:: bash
+
+    pip install torchcodec
+
+
+You will also need FFmpeg installed on your system, and TorchCodec decoding
+capabilities are determined by your underlying FFmpeg installation. There are
+different options to install FFmpeg e.g.:
+
+.. code:: bash
+
+    conda install ffmpeg
+    # or
+    conda install ffmpeg -c conda-forge
+
+You Linux distribution probably comes with FFmpeg pre-installed as well.
+TorchCodec supports all major FFmpeg version in [4, 7].
+
+.. .. TODO add link
+.. For more advanced installation instructions and details, please refer to the guidelines in our GitHub repo.

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -1,4 +1,4 @@
 .. _gallery:
 
-Examples and tutorials
-======================
+Interactive examples
+====================

--- a/src/torchcodec/decoders/__init__.py
+++ b/src/torchcodec/decoders/__init__.py
@@ -1,1 +1,2 @@
+from ._core import StreamMetadata
 from ._simple_video_decoder import Frame, FrameBatch, SimpleVideoDecoder  # noqa

--- a/src/torchcodec/decoders/_core/_metadata.py
+++ b/src/torchcodec/decoders/_core/_metadata.py
@@ -13,22 +13,38 @@ from torchcodec.decoders._core.video_decoder_ops import (
 
 @dataclass
 class StreamMetadata:
+    """Metadata of a single video stream."""
+
     duration_seconds: Optional[float]
+    """Duration of the stream, in seconds (float or None)."""
     bit_rate: Optional[float]
+    """Bit rate of the stream, in seconds (float or None)."""
     # TODO: Before release, we should come up with names that better convey the
     # " 'fast and potentially inaccurate' vs 'slower but accurate' " tradeoff.
     num_frames_retrieved: Optional[int]
+    """Number of frames from stream metadata. This is potentially inaccurate. (int or None)."""
     num_frames_computed: Optional[int]
+    """Number of frames computed by TorchCodec. This is more accurate. (int or None)."""
     min_pts_seconds: Optional[float]
+    """TODO"""
     max_pts_seconds: Optional[float]
+    """TODO"""
     codec: Optional[str]
+    """Codec (str or None)."""
     width: Optional[int]
+    """Width of the frames (int or None)."""
     height: Optional[int]
+    """Height of the frames (int or None)."""
     average_fps: Optional[float]
+    """Averate fps of the stream (float or None)."""
     stream_index: int
+    """Index of the stream within its contains (int)."""
 
     @property
     def num_frames(self) -> Optional[int]:
+        """Number of frames in the stream. This corresponds to ``num_frames_computed`` if
+        it's not None, otherwise it corresponds to ``num_frames_retrieved``.
+        """
         if self.num_frames_computed is not None:
             return self.num_frames_computed
         else:


### PR DESCRIPTION
This PR adds a lot of docs. In particular:

- Revamp of the home / index page
- Document all of SimpleVideoDecoder, Frame, FrameBatch, and StreamMetadata
- Add basic installation guide
- Add glossary of terms.


Download built docs [here](https://github.com/pytorch-labs/torchcodec/actions/runs/10008329260?pr=88) for a preview.

The home page now looks like this

![hompage](https://github.com/user-attachments/assets/421c516f-e8cc-4378-85fc-d736db79516b)

The API ref looks liks this

![apiref](https://github.com/user-attachments/assets/4c7c8387-be6d-4188-ac77-d0a9f3dd3a3a)


And the SimpleVideoDecoder docstring looks like this

![videodecoder](https://github.com/user-attachments/assets/a9a23114-eac8-451c-9afb-8f3a541fd9b2)
