### PR TITLE
[torchcodec] Rename tuple names to be consistent with VideoDecoder

### DIFF
--- a/src/torchcodec/decoders/_core/VideoDecoderOps.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoderOps.cpp
@@ -64,14 +64,14 @@ VideoDecoder* unwrapTensorToGetDecoder(at::Tensor& tensor) {
   return decoder;
 }
 
-FramePtsDuration makeFramePtsDuration(VideoDecoder::DecodedOutput& frame) {
+OpsDecodedOutput makeOpsDecodedOutput(VideoDecoder::DecodedOutput& frame) {
   return std::make_tuple(
       frame.frame,
       torch::tensor(frame.ptsSeconds),
       torch::tensor(frame.durationSeconds));
 }
 
-BatchedFramesPtsDuration makeBatchedFramesPtsDuration(
+OpsBatchDecodedOutput makeOpsBatchDecodedOutput(
     VideoDecoder::BatchDecodedOutput& batch) {
   return std::make_tuple(batch.frames, batch.ptsSeconds, batch.durationSeconds);
 }
@@ -130,7 +130,7 @@ void seek_to_pts(at::Tensor& decoder, double seconds) {
   videoDecoder->setCursorPtsInSeconds(seconds);
 }
 
-FramePtsDuration get_next_frame(at::Tensor& decoder) {
+OpsDecodedOutput get_next_frame(at::Tensor& decoder) {
   auto videoDecoder = unwrapTensorToGetDecoder(decoder);
   VideoDecoder::DecodedOutput result;
   try {
@@ -143,22 +143,22 @@ FramePtsDuration get_next_frame(at::Tensor& decoder) {
         "image_size is unexpected. Expected 3, got: " +
         std::to_string(result.frame.sizes().size()));
   }
-  return makeFramePtsDuration(result);
+  return makeOpsDecodedOutput(result);
 }
 
-FramePtsDuration get_frame_at_pts(at::Tensor& decoder, double seconds) {
+OpsDecodedOutput get_frame_at_pts(at::Tensor& decoder, double seconds) {
   auto videoDecoder = unwrapTensorToGetDecoder(decoder);
   auto result = videoDecoder->getFrameDisplayedAtTimestamp(seconds);
-  return makeFramePtsDuration(result);
+  return makeOpsDecodedOutput(result);
 }
 
-FramePtsDuration get_frame_at_index(
+OpsDecodedOutput get_frame_at_index(
     at::Tensor& decoder,
     int64_t stream_index,
     int64_t frame_index) {
   auto videoDecoder = unwrapTensorToGetDecoder(decoder);
   auto result = videoDecoder->getFrameAtIndex(stream_index, frame_index);
-  return makeFramePtsDuration(result);
+  return makeOpsDecodedOutput(result);
 }
 
 at::Tensor get_frames_at_indices(
@@ -172,7 +172,7 @@ at::Tensor get_frames_at_indices(
   return result.frames;
 }
 
-BatchedFramesPtsDuration get_frames_in_range(
+OpsBatchDecodedOutput get_frames_in_range(
     at::Tensor& decoder,
     int64_t stream_index,
     int64_t start,
@@ -181,7 +181,7 @@ BatchedFramesPtsDuration get_frames_in_range(
   auto videoDecoder = unwrapTensorToGetDecoder(decoder);
   auto result = videoDecoder->getFramesInRange(
       stream_index, start, stop, step.value_or(1));
-  return makeBatchedFramesPtsDuration(result);
+  return makeOpsBatchDecodedOutput(result);
 }
 
 std::string quoteValue(const std::string& value) {

--- a/src/torchcodec/decoders/_core/VideoDecoderOps.h
+++ b/src/torchcodec/decoders/_core/VideoDecoderOps.h
@@ -42,7 +42,7 @@ void seek_to_pts(at::Tensor& decoder, double seconds);
 //   3. A single float value for the duration in seconds.
 // The reason we use Tensors for the second and third values is so we can run
 // under torch.compile().
-using FramePtsDuration = std::tuple<at::Tensor, at::Tensor, at::Tensor>;
+using OpsDecodedOutput = std::tuple<at::Tensor, at::Tensor, at::Tensor>;
 
 // All elements of this tuple are tensors of the same leading dimension. The
 // tuple represents the frames for N total frames, where N is the dimension of
@@ -53,22 +53,22 @@ using FramePtsDuration = std::tuple<at::Tensor, at::Tensor, at::Tensor>;
 //   float.
 //   3. Tensor of N durationis in seconds, where each duration is a
 //   single float.
-using BatchedFramesPtsDuration = std::tuple<at::Tensor, at::Tensor, at::Tensor>;
+using OpsBatchDecodedOutput = std::tuple<at::Tensor, at::Tensor, at::Tensor>;
 
 // Return the frame that is visible at a given timestamp in seconds. Each frame
 // in FFMPEG has a presentation timestamp and a duration. The frame visible at a
 // given timestamp T has T >= PTS and T < PTS + Duration.
-FramePtsDuration get_frame_at_pts(at::Tensor& decoder, double seconds);
+OpsDecodedOutput get_frame_at_pts(at::Tensor& decoder, double seconds);
 
 // Return the frame that is visible at a given index in the video.
-FramePtsDuration get_frame_at_index(
+OpsDecodedOutput get_frame_at_index(
     at::Tensor& decoder,
     int64_t stream_index,
     int64_t frame_index);
 
 // Get the next frame from the video as a tuple that has the frame data, pts and
 // duration as tensors.
-FramePtsDuration get_next_frame(at::Tensor& decoder);
+OpsDecodedOutput get_next_frame(at::Tensor& decoder);
 
 // Return the frames at a given index for a given stream as a single stacked
 // Tensor.
@@ -79,7 +79,7 @@ at::Tensor get_frames_at_indices(
 
 // Return the frames inside a range as a single stacked Tensor. The range is
 // defined as [start, stop).
-BatchedFramesPtsDuration get_frames_in_range(
+OpsBatchDecodedOutput get_frames_in_range(
     at::Tensor& decoder,
     int64_t stream_index,
     int64_t start,


### PR DESCRIPTION
Summary: This makes the names consistent.

Differential Revision: D59972604
