### PR TITLE
Add `dimension_order` parameter to `SimpleVideoDecoder`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ To run the C++ tests run:
 ```bash
 mkdir build
 cd build
-cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=1 -DCMAKE_PREFIX_PATH=$(python3 -c 'import torch;print(torch.utils.cmake_prefix_path)) ..
+cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=1 -DCMAKE_PREFIX_PATH=$(python3 -c 'import torch;print(torch.utils.cmake_prefix_path)') ..
 cmake --build . -- VERBOSE=1
 ctest --rerun-failed --output-on-failure
 ```

--- a/benchmarks/decoders/BenchmarkDecodersMain.cpp
+++ b/benchmarks/decoders/BenchmarkDecodersMain.cpp
@@ -140,7 +140,7 @@ void runNDecodeIterationsWithCustomOps(
         /*width=*/std::nullopt,
         /*height=*/std::nullopt,
         /*thread_count=*/std::nullopt,
-        /*shape=*/std::nullopt,
+        /*dimension_order=*/std::nullopt,
         /*stream_index=*/std::nullopt);
 
     for (double pts : ptsList) {

--- a/src/torchcodec/decoders/_core/VideoDecoder.h
+++ b/src/torchcodec/decoders/_core/VideoDecoder.h
@@ -129,9 +129,9 @@ class VideoDecoder {
     // utilize all cores. If not set, it will be the default FFMPEG behavior for
     // the given codec.
     std::optional<int> ffmpegThreadCount;
-    // Currently the shape can be either NHWC or NCHW.
+    // Currently the dimension order can be either NHWC or NCHW.
     // H=height, W=width, C=channel.
-    std::string shape = "NHWC";
+    std::string dimensionOrder = "NCHW";
     // The output height and width of the frame. If not specified, the output
     // is the same as the original video.
     std::optional<int> width;

--- a/src/torchcodec/decoders/_core/VideoDecoderOps.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoderOps.cpp
@@ -25,7 +25,7 @@ TORCH_LIBRARY(torchcodec_ns, m) {
   m.def("create_from_file(str filename) -> Tensor");
   m.def("create_from_tensor(Tensor video_tensor) -> Tensor");
   m.def(
-      "add_video_stream(Tensor(a!) decoder, *, int? width=None, int? height=None, int? num_threads=None, str? shape=None, int? stream_index=None) -> ()");
+      "add_video_stream(Tensor(a!) decoder, *, int? width=None, int? height=None, int? num_threads=None, str? dimension_order=None, int? stream_index=None) -> ()");
   m.def("seek_to_pts(Tensor(a!) decoder, float seconds) -> ()");
   m.def("get_next_frame(Tensor(a!) decoder) -> (Tensor, Tensor, Tensor)");
   m.def(
@@ -108,17 +108,17 @@ void add_video_stream(
     std::optional<int64_t> width,
     std::optional<int64_t> height,
     std::optional<int64_t> num_threads,
-    std::optional<c10::string_view> shape,
+    std::optional<c10::string_view> dimension_order,
     std::optional<int64_t> stream_index) {
   VideoDecoder::VideoStreamDecoderOptions options;
   options.width = width;
   options.height = height;
   options.ffmpegThreadCount = num_threads;
 
-  if (shape.has_value()) {
-    std::string stdShape{shape.value()};
-    TORCH_CHECK(stdShape == "NHWC" || stdShape == "NCHW");
-    options.shape = stdShape;
+  if (dimension_order.has_value()) {
+    std::string stdDimensionOrder{dimension_order.value()};
+    TORCH_CHECK(stdDimensionOrder == "NHWC" || stdDimensionOrder == "NCHW");
+    options.dimensionOrder = stdDimensionOrder;
   }
 
   auto videoDecoder = unwrapTensorToGetDecoder(decoder);

--- a/src/torchcodec/decoders/_core/VideoDecoderOps.h
+++ b/src/torchcodec/decoders/_core/VideoDecoderOps.h
@@ -30,7 +30,7 @@ void add_video_stream(
     std::optional<int64_t> width = std::nullopt,
     std::optional<int64_t> height = std::nullopt,
     std::optional<int64_t> num_threads = std::nullopt,
-    std::optional<c10::string_view> shape = std::nullopt,
+    std::optional<c10::string_view> dimension_order = std::nullopt,
     std::optional<int64_t> stream_index = std::nullopt);
 
 // Seek to a particular presentation timestamp in the video in seconds.

--- a/src/torchcodec/decoders/_core/video_decoder_ops.py
+++ b/src/torchcodec/decoders/_core/video_decoder_ops.py
@@ -108,7 +108,7 @@ def add_video_stream_abstract(
     width: Optional[int] = None,
     height: Optional[int] = None,
     num_threads: Optional[int] = None,
-    shape: Optional[str] = None,
+    dimension_order: Optional[str] = None,
     stream_index: Optional[int] = None,
 ) -> None:
     return

--- a/src/torchcodec/samplers/video_clip_sampler.py
+++ b/src/torchcodec/samplers/video_clip_sampler.py
@@ -202,7 +202,7 @@ class VideoClipSampler(nn.Module):
             metadata_json (`Dict[str, Any]`): The metadata of the video in json format
 
         Returns:
-            clips (` List[Tensor]`): List of clips, where each clip is a Tensor represents list of frames, Tensor shape default is NHWC.
+            clips (` List[Tensor]`): List of clips, where each clip is a Tensor represents list of frames, Tensor shape default is NCHW.
         """
 
         sample_start_index = max(0, index_based_sampler_args.sample_start_index)

--- a/test/decoders/VideoDecoderOpsTest.cpp
+++ b/test/decoders/VideoDecoderOpsTest.cpp
@@ -39,7 +39,7 @@ TEST(VideoDecoderOpsTest, TestCreateDecoderFromBuffer) {
   add_video_stream(decoder);
   auto result = get_next_frame(decoder);
   at::Tensor tensor1 = std::get<0>(result);
-  EXPECT_EQ(tensor1.sizes(), std::vector<long>({270, 480, 3}));
+  EXPECT_EQ(tensor1.sizes(), std::vector<long>({3, 270, 480}));
   EXPECT_EQ(std::get<1>(result).item<double>(), 0);
   EXPECT_NEAR(std::get<2>(result).item<double>(), 0.033367, 1e-6);
 }

--- a/test/decoders/VideoDecoderTest.cpp
+++ b/test/decoders/VideoDecoderTest.cpp
@@ -108,7 +108,7 @@ torch::Tensor readTensorFromDisk(const std::string& filename) {
       (std::istreambuf_iterator<char>()));
   VLOG(3) << "Read tensor from disk: " << filepath << ": " << data.size()
           << std::endl;
-  return torch::pickle_load(data).toTensor();
+  return torch::pickle_load(data).toTensor().permute({2, 0, 1});
 }
 
 torch::Tensor floatAndNormalizeFrame(const torch::Tensor& frame) {
@@ -130,7 +130,7 @@ double computeAverageCosineSimilarity(
 
 // TEST(DecoderOptionsTest, ConvertsFromStringToOptions) {
 //   std::string optionsString =
-//       "ffmpeg_thread_count=3,shape=NCHW,width=100,height=120";
+//       "ffmpeg_thread_count=3,dimension_order=NCHW,width=100,height=120";
 //   VideoDecoder::DecoderOptions options =
 //       VideoDecoder::DecoderOptions(optionsString);
 //   EXPECT_EQ(options.ffmpegThreadCount, 3);
@@ -145,18 +145,18 @@ TEST(VideoDecoderTest, RespectsWidthAndHeightFromOptions) {
   streamOptions.height = 120;
   decoder->addVideoStreamDecoder(-1, streamOptions);
   torch::Tensor tensor = decoder->getNextDecodedOutput().frame;
-  EXPECT_EQ(tensor.sizes(), std::vector<long>({120, 100, 3}));
+  EXPECT_EQ(tensor.sizes(), std::vector<long>({3, 120, 100}));
 }
 
-TEST(VideoDecoderTest, RespectsOutputTensorShapeFromOptions) {
+TEST(VideoDecoderTest, RespectsOutputTensorDimensionOrderFromOptions) {
   std::string path = getResourcePath("nasa_13013.mp4");
   std::unique_ptr<VideoDecoder> decoder =
       VideoDecoder::createFromFilePath(path);
   VideoDecoder::VideoStreamDecoderOptions streamOptions;
-  streamOptions.shape = "NCHW";
+  streamOptions.dimensionOrder = "NHWC";
   decoder->addVideoStreamDecoder(-1, streamOptions);
   torch::Tensor tensor = decoder->getNextDecodedOutput().frame;
-  EXPECT_EQ(tensor.sizes(), std::vector<long>({3, 270, 480}));
+  EXPECT_EQ(tensor.sizes(), std::vector<long>({270, 480, 3}));
 }
 
 TEST_P(VideoDecoderTest, ReturnsFirstTwoFramesOfVideo) {
@@ -166,12 +166,12 @@ TEST_P(VideoDecoderTest, ReturnsFirstTwoFramesOfVideo) {
   ourDecoder->addVideoStreamDecoder(-1);
   auto output = ourDecoder->getNextDecodedOutput();
   torch::Tensor tensor0FromOurDecoder = output.frame;
-  EXPECT_EQ(tensor0FromOurDecoder.sizes(), std::vector<long>({270, 480, 3}));
+  EXPECT_EQ(tensor0FromOurDecoder.sizes(), std::vector<long>({3, 270, 480}));
   EXPECT_EQ(output.ptsSeconds, 0.0);
   EXPECT_EQ(output.pts, 0);
   output = ourDecoder->getNextDecodedOutput();
   torch::Tensor tensor1FromOurDecoder = output.frame;
-  EXPECT_EQ(tensor1FromOurDecoder.sizes(), std::vector<long>({270, 480, 3}));
+  EXPECT_EQ(tensor1FromOurDecoder.sizes(), std::vector<long>({3, 270, 480}));
   EXPECT_EQ(output.ptsSeconds, 1'001. / 30'000);
   EXPECT_EQ(output.pts, 1001);
 
@@ -180,12 +180,12 @@ TEST_P(VideoDecoderTest, ReturnsFirstTwoFramesOfVideo) {
   torch::Tensor tensor1FromFFMPEG =
       readTensorFromDisk("nasa_13013.mp4.frame000001.pt");
 
-  EXPECT_EQ(tensor1FromFFMPEG.sizes(), std::vector<long>({270, 480, 3}));
+  EXPECT_EQ(tensor1FromFFMPEG.sizes(), std::vector<long>({3, 270, 480}));
   EXPECT_TRUE(torch::equal(tensor0FromOurDecoder, tensor0FromFFMPEG));
   EXPECT_TRUE(torch::equal(tensor1FromOurDecoder, tensor1FromFFMPEG));
   EXPECT_TRUE(
       torch::allclose(tensor0FromOurDecoder, tensor0FromFFMPEG, 0.1, 20));
-  EXPECT_EQ(tensor1FromFFMPEG.sizes(), std::vector<long>({270, 480, 3}));
+  EXPECT_EQ(tensor1FromFFMPEG.sizes(), std::vector<long>({3, 270, 480}));
   EXPECT_TRUE(
       torch::allclose(tensor1FromOurDecoder, tensor1FromFFMPEG, 0.1, 20));
 
@@ -197,7 +197,7 @@ TEST_P(VideoDecoderTest, ReturnsFirstTwoFramesOfVideo) {
   }
 }
 
-TEST_P(VideoDecoderTest, DecodesFramesInABatchInNHWC) {
+TEST_P(VideoDecoderTest, DecodesFramesInABatchInNCHW) {
   std::string path = getResourcePath("nasa_13013.mp4");
   std::unique_ptr<VideoDecoder> ourDecoder =
       createDecoderFromPath(path, GetParam());
@@ -208,7 +208,7 @@ TEST_P(VideoDecoderTest, DecodesFramesInABatchInNHWC) {
   // Frame with index 180 corresponds to timestamp 6.006.
   auto output = ourDecoder->getFramesAtIndexes(bestVideoStreamIndex, {0, 180});
   auto tensor = output.frames;
-  EXPECT_EQ(tensor.sizes(), std::vector<long>({2, 270, 480, 3}));
+  EXPECT_EQ(tensor.sizes(), std::vector<long>({2, 3, 270, 480}));
 
   torch::Tensor tensor0FromFFMPEG =
       readTensorFromDisk("nasa_13013.mp4.frame000000.pt");
@@ -219,7 +219,7 @@ TEST_P(VideoDecoderTest, DecodesFramesInABatchInNHWC) {
   EXPECT_TRUE(torch::equal(tensor[1], tensorTime6FromFFMPEG));
 }
 
-TEST_P(VideoDecoderTest, DecodesFramesInABatchInNCHW) {
+TEST_P(VideoDecoderTest, DecodesFramesInABatchInNHWC) {
   std::string path = getResourcePath("nasa_13013.mp4");
   std::unique_ptr<VideoDecoder> ourDecoder =
       createDecoderFromPath(path, GetParam());
@@ -228,18 +228,18 @@ TEST_P(VideoDecoderTest, DecodesFramesInABatchInNCHW) {
       *ourDecoder->getContainerMetadata().bestVideoStreamIndex;
   ourDecoder->addVideoStreamDecoder(
       bestVideoStreamIndex,
-      VideoDecoder::VideoStreamDecoderOptions("shape=NCHW"));
+      VideoDecoder::VideoStreamDecoderOptions("dimension_order=NHWC"));
   // Frame with index 180 corresponds to timestamp 6.006.
   auto output = ourDecoder->getFramesAtIndexes(bestVideoStreamIndex, {0, 180});
   auto tensor = output.frames;
-  EXPECT_EQ(tensor.sizes(), std::vector<long>({2, 3, 270, 480}));
+  EXPECT_EQ(tensor.sizes(), std::vector<long>({2, 270, 480, 3}));
 
   torch::Tensor tensor0FromFFMPEG =
       readTensorFromDisk("nasa_13013.mp4.frame000000.pt");
   torch::Tensor tensorTime6FromFFMPEG =
       readTensorFromDisk("nasa_13013.mp4.time6.000000.pt");
 
-  tensor = tensor.permute({0, 2, 3, 1});
+  tensor = tensor.permute({0, 3, 1, 2});
   EXPECT_TRUE(torch::equal(tensor[0], tensor0FromFFMPEG));
   EXPECT_TRUE(torch::equal(tensor[1], tensorTime6FromFFMPEG));
 }

--- a/test/decoders/manual_smoke_test.py
+++ b/test/decoders/manual_smoke_test.py
@@ -11,5 +11,4 @@ torchcodec.decoders._core.add_video_stream(decoder, stream_index=3)
 frame, _, _ = torchcodec.decoders._core.get_frame_at_index(
     decoder, stream_index=3, frame_index=180
 )
-frame = frame.permute(2, 0, 1)
 write_png(frame, "frame180.png")

--- a/test/decoders/test_video_decoder_ops.py
+++ b/test/decoders/test_video_decoder_ops.py
@@ -162,7 +162,7 @@ class TestOps:
 
         # an empty range is valid!
         empty_frame, *_ = get_frames_in_range(decoder, stream_index=3, start=5, stop=5)
-        assert_tensor_equal(empty_frame, NASA_VIDEO.empty_hwc_tensor)
+        assert_tensor_equal(empty_frame, NASA_VIDEO.empty_chw_tensor)
 
     def test_throws_exception_at_eof(self):
         decoder = create_from_file(str(NASA_VIDEO.path))

--- a/test/samplers/test_video_clip_sampler.py
+++ b/test/samplers/test_video_clip_sampler.py
@@ -47,9 +47,9 @@ def test_sampler(sampler_args):
         clip = torch.stack(clip)
     assert clip.shape == (
         sampler_args.frames_per_clip,
+        3,
         desired_height,
         desired_width,
-        3,
     )
 
 

--- a/test/utils.py
+++ b/test/utils.py
@@ -46,7 +46,7 @@ def _get_file_path(filename: str) -> pathlib.Path:
 
 def _load_tensor_from_file(filename: str) -> torch.Tensor:
     file_path = _get_file_path(filename)
-    return torch.load(file_path, weights_only=True)
+    return torch.load(file_path, weights_only=True).permute(2, 0, 1)
 
 
 @dataclass
@@ -119,9 +119,9 @@ class TestVideo(TestContainerFile):
     num_color_channels: int
 
     @property
-    def empty_hwc_tensor(self) -> torch.Tensor:
+    def empty_chw_tensor(self) -> torch.Tensor:
         return torch.empty(
-            [0, self.height, self.width, self.num_color_channels], dtype=torch.uint8
+            [0, self.num_color_channels, self.height, self.width], dtype=torch.uint8
         )
 
 


### PR DESCRIPTION
This PR adds the `dimension_order` parameter to `SimpleVideoDecoder`. The default is `NCHW`.

See https://colab.research.google.com/drive/1u_M9KCp95LRe-XHX48i3tAL1jUOESOTN#scrollTo=diqSRZ_tyoK3 for context on why NCHW is more appropriate than NHWC as the default.