### PR TITLE
Better renderring for glossary

### DIFF
--- a/docs/source/_static/css/custom_torchcodec.css
+++ b/docs/source/_static/css/custom_torchcodec.css
@@ -185,3 +185,8 @@ article.pytorch-article .sphx-glr-thumbnails .sphx-glr-thumbcontainer {
 article.pytorch-article div.section div.wy-table-responsive tbody td {
     width: 50%;
 }
+
+article.pytorch-article section#glossary dl.simple.glossary dt {
+    font-weight: bold;
+    font-size: x-large;
+}


### PR DESCRIPTION
Closes https://github.com/pytorch-labs/torchcodec/issues/94


We go from this:

![image](https://github.com/user-attachments/assets/905d3295-50e4-4d18-a1f0-234b91a54fe7)


To this:

![new_glossary](https://github.com/user-attachments/assets/eaddd323-0c6c-475e-8cb2-73b40f5e6e30)
