### PR TITLE
Ignore unactionable warning from PyTorch in create_from_bytes

### DIFF
--- a/examples/basic_example.py
+++ b/examples/basic_example.py
@@ -8,19 +8,39 @@ the :class:`~torchcodec.decoders.SimpleVideoDecoder` class.
 """
 
 # %%
-import requests
+import inspect
+import os
 
-# %%
-# Video is CC0 Licensed, thanks to Coverr for uploading
-# Source: https://www.pexels.com/video/dog-eating-854132/
-video_url = "https://videos.pexels.com/video-files/854132/854132-sd_640_360_25fps.mp4"
-response = requests.get(video_url)
-
-if response.status_code != 200:
-    raise RuntimeError(f"Failed to download video")
-
-# %%
 from torchcodec.decoders import SimpleVideoDecoder
 
-decoder = SimpleVideoDecoder(source=response.content)
-decoder[0]
+# %%
+my_path = os.path.abspath(inspect.getfile(inspect.currentframe()))
+video_file_path = os.path.dirname(my_path) + "/../test/resources/nasa_13013.mp4"
+simple_decoder = SimpleVideoDecoder(video_file_path)
+
+# %%
+# You can get the total frame count for the best video stream by calling len().
+num_frames = len(simple_decoder)
+print(f"{video_file_path=} has {num_frames} frames")
+
+# %%
+# You can get the decoded frame by using the subscript operator.
+first_frame = simple_decoder[0]
+print(f"decoded frame has type {type(first_frame)}")
+
+# %%
+# The shape of the decoded frame is (H, W, C) where H and W are the height
+# and width of the video frame. C is 3 because we have 3 channels red, green,
+# and blue.
+print(f"{first_frame.shape=}")
+
+# %%
+# The dtype of the decoded frame is ``torch.uint8``.
+print(f"{first_frame.dtype=}")
+
+# %%
+# Negative indexes are supported.
+last_frame = simple_decoder[-1]
+print(f"{last_frame.shape=}")
+
+# TODO_BEFORE_RELEASE: add documentation for slices and metadata.


### PR DESCRIPTION
Using `create_from_bytes` generates the following warning:

```
UserWarning: The given buffer is not writable, and PyTorch does not support non-writable tensors. This means you can write to the underlying (supposedly non-writable) buffer using the tensor. You may want to copy the buffer to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at ../torch/csrc/utils/tensor_new.cpp:1544.)
  return create_from_tensor(torch.frombuffer(video_bytes, dtype=torch.uint8))
```

This is not actionable for users in this specific context, and also not a problem anyway. This PR silences this warning.