### PR TITLE
Fix type of Frame.pts_seconds and Frame.duration_seconds

### DIFF
--- a/src/torchcodec/decoders/_simple_video_decoder.py
+++ b/src/torchcodec/decoders/_simple_video_decoder.py
@@ -192,10 +192,14 @@ class SimpleVideoDecoder:
             raise IndexError(
                 f"Index {index} is out of bounds; must be in the range [0, {self._num_frames})."
             )
-        frame = core.get_frame_at_index(
+        data, pts_seconds, duration_seconds = core.get_frame_at_index(
             self._decoder, frame_index=index, stream_index=self._stream_index
         )
-        return Frame(*frame)
+        return Frame(
+            data=data,
+            pts_seconds=pts_seconds.item(),
+            duration_seconds=duration_seconds.item(),
+        )
 
     def get_frames_at(self, start: int, stop: int, step: int = 1) -> FrameBatch:
         """Return multiple frames at the given index range.
@@ -245,8 +249,14 @@ class SimpleVideoDecoder:
                 f"It must be greater than or equal to {self._min_pts_seconds} "
                 f"and less than or equal to {self._max_pts_seconds}."
             )
-        frame = core.get_frame_at_pts(self._decoder, pts_seconds)
-        return Frame(*frame)
+        data, pts_seconds, duration_seconds = core.get_frame_at_pts(
+            self._decoder, pts_seconds
+        )
+        return Frame(
+            data=data,
+            pts_seconds=pts_seconds.item(),
+            duration_seconds=duration_seconds.item(),
+        )
 
 
 def _get_and_validate_stream_metadata(

--- a/test/decoders/test_simple_video_decoder.py
+++ b/test/decoders/test_simple_video_decoder.py
@@ -255,7 +255,9 @@ class TestSimpleDecoder:
         frame9 = decoder.get_frame_at(9)
 
         assert_tensor_equal(ref_frame9, frame9.data)
-        assert frame9.pts_seconds == 0.3003
+        assert isinstance(frame9.pts_seconds, float)
+        assert frame9.pts_seconds == pytest.approx(0.3003)
+        assert isinstance(frame9.duration_seconds, float)
         assert frame9.duration_seconds == pytest.approx(0.03337, rel=1e-3)
 
     def test_get_frame_at_tuple_unpacking(self):
@@ -284,6 +286,8 @@ class TestSimpleDecoder:
         assert_tensor_equal(ref_frame6, decoder.get_frame_displayed_at(6.006).data)
         assert_tensor_equal(ref_frame6, decoder.get_frame_displayed_at(6.02).data)
         assert_tensor_equal(ref_frame6, decoder.get_frame_displayed_at(6.039366).data)
+        assert isinstance(decoder.get_frame_displayed_at(6.02).pts_seconds, float)
+        assert isinstance(decoder.get_frame_displayed_at(6.02).duration_seconds, float)
 
     def test_get_frame_displayed_at_fails(self):
         decoder = SimpleVideoDecoder(NASA_VIDEO.path)


### PR DESCRIPTION
We have a minor bug where the `pts_seconds` and `duration_seconds` fields of `Frame` are tensors instead of floats. This fixes it.