### PR TITLE
Update links and URLs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -5,7 +5,7 @@ body:
 - type: markdown
   attributes:
     value: >
-      #### Before submitting a bug, please make sure the issue hasn't been already addressed by searching through [the existing and past issues](TODO_UPDATE_LINK).
+      #### Before submitting a bug, please make sure the issue hasn't been already addressed by searching through [the existing and past issues](https://github.com/pytorch/torchcodec/issues?q=sort%3Aupdated-desc+is%3Aissue).
 - type: textarea
   attributes:
     label: 🐛 Describe the bug

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,12 +1,12 @@
 name: 📚 Documentation
-description: Report an issue related to TODO_UPDATE_LINK
+description: Report an issue related to the [TorchCodec documentation](https://pytorch.org/torchcodec/stable/index.html)
 
 body:
 - type: textarea
   attributes:
     label: 📚 The doc issue
     description: >
-      A clear and concise description of what content in TODO_UPDATE_LINK is an issue. If this has to do with the general https://pytorch.org website, please file an issue at https://github.com/pytorch/pytorch.github.io/issues/new/choose instead. If this has to do with https://pytorch.org/tutorials, please file an issue at https://github.com/pytorch/tutorials/issues/new.
+      A clear and concise description of what content in https://pytorch.org/torchcodec/stable/index.html is an issue. If this has to do with the general https://pytorch.org website, please file an issue at https://github.com/pytorch/pytorch.github.io/issues/new/choose instead. If this has to do with https://pytorch.org/tutorials, please file an issue at https://github.com/pytorch/tutorials/issues/new.
   validations:
     required: true
 - type: textarea

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,9 +36,9 @@ conda install cmake pkg-config ffmpeg -c conda-forge
 
 To clone and install the repo, run:
 
-<!-- TODO_UPDATE_LINK -->
 ```bash
-git clone https://github.com/pytorch-labs/torchcodec.git
+git clone git@github.com:pytorch/torchcodec.git
+# Or, using https instead of ssh: git clone https://github.com/pytorch/torchcodec.git
 cd torchcodec
 
 pip install -e ".[dev]" --no-build-isolation -vv

--- a/README.md
+++ b/README.md
@@ -7,9 +7,8 @@ TorchCodec is a Python package with a goal to provide useful and fast APIs to
 decode video frames to PyTorch Tensors.
 
 ⚠️ TorchCodec is still in early development stage and we are actively seeking
-feedback. If you have any suggestions or issues, please let us know by opening
-an issue!
-<!-- TODO_UPDATE_LINK add link to issue tracker -->
+feedback. If you have any suggestions or issues, please let us know by [opening
+an issue](https://github.com/pytorch/torchcodec/issues/new/choose)!
 
 ## Using TorchCodec
 
@@ -27,8 +26,7 @@ last_frame = video[-1]
 frame_visible_at_2_seconds = video.get_frame_displayed_at(2)
 ```
 
-<!-- TODO_UPDATE_LINK add link to docs -->
-For more detailed examples, check out our docs!
+For more detailed examples, [check out our docs](https://pytorch.org/torchcodec/stable/index.html)!
 
 ## Installing TorchCodec
 
@@ -59,12 +57,12 @@ TorchCodec supports all major FFmpeg version in [4, 7].
 
 We are actively working on the following features:
 
-<!-- TODO_UPDATE_LINK link to relevant issues-->
-- MacOS support (currently, only Linux is supported)
-- GPU decoding
-- Audio decoding
+- [MacOS support](https://github.com/pytorch/torchcodec/issues/111) (currently, only Linux is supported)
+- [GPU decoding](https://github.com/pytorch/torchcodec/pull/58)
+- [Audio decoding](https://github.com/pytorch/torchcodec/issues/85)
 
-Let us know if you have any feature requests by opening an issue!
+Let us know if you have any feature requests by [opening an
+issue](https://github.com/pytorch/torchcodec/issues/new?assignees=&labels=&projects=&template=feature-request.yml)!
 
 ## Contributing
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,12 +3,12 @@ Welcome to the TorchCodec documentation!
 
 TorchCodec provides utilities for decoding videos into PyTorch tensors.
 
-.. TODO_UPDATE_LINKE Add link to GH repo below
 .. note::
 
    TorchCodec is still in early development stage and we are actively seeking
    feedback. If you have any suggestions or issues, please let us know by
-   opening an issue on our GitHub repository.
+   `opening an issue <https://github.com/pytorch/torchcodec/issues/new/choose>`_
+   on our `GitHub repository <https://github.com/pytorch/torchcodec/>`_.
 
 .. grid:: 3
 

--- a/docs/source/install_instructions.rst
+++ b/docs/source/install_instructions.rst
@@ -27,5 +27,6 @@ different options to install FFmpeg e.g.:
 Your Linux distribution probably comes with FFmpeg pre-installed as well.
 TorchCodec supports all major FFmpeg version in [4, 7].
 
-.. .. TODO_UPDATE_LINK add link
-.. For more advanced installation instructions and details, please refer to the guidelines in our GitHub repo.
+Note that installation instructions may slightly change over time. The most
+up-to-date instructions should be available from the `README
+<https://github.com/pytorch/torchcodec?tab=readme-ov-file#installing-torchcodec>`_.

--- a/src/torchcodec/decoders/_simple_video_decoder.py
+++ b/src/torchcodec/decoders/_simple_video_decoder.py
@@ -47,7 +47,8 @@ class FrameBatch(Iterable):
 
 
 _ERROR_REPORTING_INSTRUCTIONS = """
-This should never happen. Please report an issue following the steps in <TODO_UPDATE_LINK>.
+This should never happen. Please report an issue following the steps in
+https://github.com/pytorch/torchcodec/issues/new?assignees=&labels=&projects=&template=bug-report.yml.
 """
 
 


### PR DESCRIPTION
Now that we're in the `pytorch/` GitHub org, we can safely update all the links. Note that the links to the docs like https://pytorch.org/torchcodec/stable/index.html give a 404, which is normal since we haven't shipped the docs yet. The URL is however correct (this is where the docs will live).

```
~/dev/torchcodec (update_links*) » git grep -i UPDATE_LINK | wc -l
0
```