### PR TITLE
Use register_fake instead of impl_abstract

### DIFF
--- a/src/torchcodec/decoders/_core/video_decoder_ops.py
+++ b/src/torchcodec/decoders/_core/video_decoder_ops.py
@@ -9,17 +9,10 @@ import warnings
 from typing import List, Optional, Tuple
 
 import torch
-from torch.library import get_ctx, impl_abstract
+from torch.library import get_ctx, register_fake
 
 from torchcodec._internally_replaced_utils import (  # @manual=//pytorch/torchcodec/src:internally_replaced_utils
     _get_extension_path,
-)
-
-# TODO_BEFORE_RELEASE: Remove this warning filter and use @register_fake once pytorch 2.4 is released
-warnings.filterwarnings(
-    "ignore",
-    category=FutureWarning,
-    message="`torch.library.impl_abstract` was renamed to `torch.library.register_fake`. Please use that instead; we will remove `torch.library.impl_abstract` in a future version of PyTorch",
 )
 
 
@@ -102,17 +95,17 @@ def create_from_bytes(video_bytes: bytes) -> torch.Tensor:
 # ==============================
 # Abstract impl for the operators. Needed by torch.compile.
 # ==============================
-@impl_abstract("torchcodec_ns::create_from_file")
+@register_fake("torchcodec_ns::create_from_file")
 def create_from_file_abstract(filename: str) -> torch.Tensor:
     return torch.empty([], dtype=torch.long)
 
 
-@impl_abstract("torchcodec_ns::create_from_tensor")
+@register_fake("torchcodec_ns::create_from_tensor")
 def create_from_tensor_abstract(video_tensor: torch.Tensor) -> torch.Tensor:
     return torch.empty([], dtype=torch.long)
 
 
-@impl_abstract("torchcodec_ns::add_video_stream")
+@register_fake("torchcodec_ns::add_video_stream")
 def add_video_stream_abstract(
     decoder: torch.Tensor,
     *,
@@ -125,12 +118,12 @@ def add_video_stream_abstract(
     return
 
 
-@impl_abstract("torchcodec_ns::seek_to_pts")
+@register_fake("torchcodec_ns::seek_to_pts")
 def seek_abstract(decoder: torch.Tensor, seconds: float) -> None:
     return
 
 
-@impl_abstract("torchcodec_ns::get_next_frame")
+@register_fake("torchcodec_ns::get_next_frame")
 def get_next_frame_abstract(
     decoder: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
@@ -144,7 +137,7 @@ def get_next_frame_abstract(
     )
 
 
-@impl_abstract("torchcodec_ns::get_frame_at_pts")
+@register_fake("torchcodec_ns::get_frame_at_pts")
 def get_frame_at_pts_abstract(
     decoder: torch.Tensor, seconds: float
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
@@ -156,7 +149,7 @@ def get_frame_at_pts_abstract(
     )
 
 
-@impl_abstract("torchcodec_ns::get_frame_at_index")
+@register_fake("torchcodec_ns::get_frame_at_index")
 def get_frame_at_index_abstract(
     decoder: torch.Tensor, *, stream_index: int, frame_index: int
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
@@ -168,7 +161,7 @@ def get_frame_at_index_abstract(
     )
 
 
-@impl_abstract("torchcodec_ns::get_frames_at_indices")
+@register_fake("torchcodec_ns::get_frames_at_indices")
 def get_frames_at_indices_abstract(
     decoder: torch.Tensor,
     *,
@@ -179,7 +172,7 @@ def get_frames_at_indices_abstract(
     return torch.empty(image_size)
 
 
-@impl_abstract("torchcodec_ns::get_frames_in_range")
+@register_fake("torchcodec_ns::get_frames_in_range")
 def get_frames_in_range_abstract(
     decoder: torch.Tensor,
     *,
@@ -196,27 +189,27 @@ def get_frames_in_range_abstract(
     )
 
 
-@impl_abstract("torchcodec_ns::get_json_metadata")
+@register_fake("torchcodec_ns::get_json_metadata")
 def get_json_metadata_abstract(decoder: torch.Tensor) -> str:
     return ""
 
 
-@impl_abstract("torchcodec_ns::get_container_json_metadata")
+@register_fake("torchcodec_ns::get_container_json_metadata")
 def get_container_json_metadata_abstract(decoder: torch.Tensor) -> str:
     return ""
 
 
-@impl_abstract("torchcodec_ns::get_stream_json_metadata")
+@register_fake("torchcodec_ns::get_stream_json_metadata")
 def get_stream_json_metadata_abstract(decoder: torch.Tensor, stream_idx: int) -> str:
     return ""
 
 
-@impl_abstract("torchcodec_ns::_get_json_ffmpeg_library_versions")
+@register_fake("torchcodec_ns::_get_json_ffmpeg_library_versions")
 def _get_json_ffmpeg_library_versions_abstract() -> str:
     return ""
 
 
-@impl_abstract("torchcodec_ns::scan_all_streams_to_update_metadata")
+@register_fake("torchcodec_ns::scan_all_streams_to_update_metadata")
 def scan_all_streams_to_update_metadata_abstract(decoder: torch.Tensor) -> None:
     return
 


### PR DESCRIPTION
Pytorch 2.4 is now out, and this is what our first release of torchcodec will be built against (and expect as dependency). We can thus safely update our code to use `register_fake` instead of the deprecated `impl_abstract`