### PR TITLE
[torchcodec] Rename method parameter to seconds

### DIFF
--- a/src/torchcodec/decoders/_simple_video_decoder.py
+++ b/src/torchcodec/decoders/_simple_video_decoder.py
@@ -237,23 +237,25 @@ class SimpleVideoDecoder:
         )
         return FrameBatch(*frames)
 
-    def get_frame_displayed_at(self, pts_seconds: float) -> Frame:
-        """Return a single frame displayed at the given :term:`pts`, in seconds.
+    def get_frame_displayed_at(self, seconds: float) -> Frame:
+        """Return a single frame displayed at the given timestamp in seconds.
 
         Args:
-            pts (float): The :term:`pts` of the frame to retrieve, in seconds.
+            seconds (float): The time stamp in seconds when the frame is
+                displayed, i.e. seconds is in
+                [:term:`pts`, :term:`pts` + duration).
 
         Returns:
-            Frame: The frame at the given :term:`pts`.
+            Frame: The frame that is displayed at ``seconds``.
         """
-        if not self._min_pts_seconds <= pts_seconds < self._max_pts_seconds:
+        if not self._min_pts_seconds <= seconds < self._max_pts_seconds:
             raise IndexError(
-                f"Invalid pts in seconds: {pts_seconds}. "
+                f"Invalid pts in seconds: {seconds}. "
                 f"It must be greater than or equal to {self._min_pts_seconds} "
                 f"and less than or equal to {self._max_pts_seconds}."
             )
         data, pts_seconds, duration_seconds = core.get_frame_at_pts(
-            self._decoder, pts_seconds
+            self._decoder, seconds
         )
         return Frame(
             data=data,


### PR DESCRIPTION
Summary: The parameter is simply seconds because it doesn't correspond just to frame.pts. It selects a frame with `pts>=seconds and pts+duration<seconds`.

Differential Revision: D60242456
