### PR TITLE
remove _samplers from __init__.py

### DIFF
--- a/src/torchcodec/__init__.py
+++ b/src/torchcodec/__init__.py
@@ -4,4 +4,4 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from . import _samplers, decoders  # noqa
+from . import decoders  # noqa


### PR DESCRIPTION
This is not strictly needed because `_samplers` is private anyway, but there's no reason to expose it in `__init__.py` in any case, and we don't want to encourage users to use it at this stage.