### PR TITLE
[torchcodec] Make versions a named tuple instead of a list

### DIFF
--- a/test/decoders/test_video_decoder_ops.py
+++ b/test/decoders/test_video_decoder_ops.py
@@ -297,6 +297,10 @@ class TestOps:
         # The earliest libavutil version is 50 as per:
         # https://www.ffmpeg.org/olddownload.html
         assert ffmpeg_dict["libavutil"][0] > 50
+        version_info = ffmpeg_dict["libavutil"]
+        assert version_info.major > 50
+        assert version_info.minor >= 0
+        assert version_info.micro >= 0
         ffmpeg_version = ffmpeg_dict["ffmpeg_version"]
         split_ffmpeg_version = [int(num) for num in ffmpeg_version.split(".")]
         assert len(split_ffmpeg_version) == 3


### PR DESCRIPTION
Summary:
For ffmpeg library versions we were returning a tuple of integers before this change.

We are still returning a tuple now, but we return a Named tuple where the user can extract the major, minor and micro version by name.

This addresses https://github.com/pytorch/torchcodec/issues/100

Differential Revision: D60398568
