### PR TITLE
Address doc TODO

### DIFF
--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -1,11 +1,10 @@
 {% extends "!layout.html" %}
 
 {% block sidebartitle %}
-    <!-- TODO_BEFORE_RELEASE: uncomment when we publish the docs on `pytorch.org` -->
-    <!-- <div class="version">
+    <div class="version">
         <a href='https://pytorch.org/torchcodec/versions.html'>{{ version }} &#x25BC</a>
       </div>
-    {% include "searchbox.html" %} -->
+    {% include "searchbox.html" %}
 {% endblock %}
 
 


### PR DESCRIPTION
TODO says "uncomment when we publish the docs on `pytorch.org`" but we should in fact address it now (before we actually publish the docs).