### PR TITLE
[torchcodec] Handle negative buffer sizes

### DIFF
--- a/src/torchcodec/decoders/_core/FFMPEGCommon.cpp
+++ b/src/torchcodec/decoders/_core/FFMPEGCommon.cpp
@@ -6,6 +6,8 @@
 
 #include "src/torchcodec/decoders/_core/FFMPEGCommon.h"
 
+#include <c10/util/Exception.h>
+
 namespace facebook::torchcodec {
 
 std::string getFFMPEGErrorStringFromErrorCode(int errorCode) {
@@ -68,6 +70,14 @@ int AVIOBytesContext::read(void* opaque, uint8_t* buf, int buf_size) {
   struct AVIOBufferData* bufferData =
       static_cast<struct AVIOBufferData*>(opaque);
   buf_size = FFMIN(buf_size, bufferData->size - bufferData->current);
+  TORCH_CHECK(
+      buf_size >= 0,
+      "Tried to read negative bytes: buf_size=",
+      buf_size,
+      ", size=",
+      bufferData->size,
+      ", current=",
+      bufferData->current);
   if (!buf_size) {
     return AVERROR_EOF;
   }

--- a/src/torchcodec/decoders/_core/VideoDecoder.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoder.cpp
@@ -237,6 +237,7 @@ std::unique_ptr<VideoDecoder> VideoDecoder::createFromBuffer(
     const void* buffer,
     size_t length,
     const VideoDecoder::DecoderOptions& options) {
+  TORCH_CHECK(buffer != nullptr, "Video buffer cannot be nullptr!");
   AVInput input = createAVFormatContextFromBuffer(buffer, length);
   std::unique_ptr<VideoDecoder> decoder(new VideoDecoder());
   decoder->formatContext_ = std::move(input.formatContext);


### PR DESCRIPTION
Summary:
Not sure if we will ever hit this case, but this may be a reason why TorchCodec is crashing on some videos.

Maybe the user passes in a negative value for size and it trickles all the way to the read function. We should not be treating negative sizes as large sizes.

Reviewed By: scotts

Differential Revision: D60461269
