### PR TITLE
[torchcodec] fix floating point equality

### DIFF
--- a/src/torchcodec/decoders/_core/VideoDecoder.h
+++ b/src/torchcodec/decoders/_core/VideoDecoder.h
@@ -249,6 +249,8 @@ class VideoDecoder {
   DecodeStats getDecodeStats() const;
   void resetDecodeStats();
 
+  double getPtsSecondsForFrame(int streamIndex, int64_t frameIndex);
+
  private:
   struct FrameInfo {
     int64_t pts = 0;
@@ -305,6 +307,7 @@ class VideoDecoder {
   void initializeDecoder();
   void validateUserProvidedStreamIndex(uint64_t streamIndex);
   void validateScannedAllStreams(const std::string& msg);
+  void validateFrameIndex(const StreamInfo& stream, int64_t frameIndex);
   // Creates and initializes a filter graph for a stream. The filter graph can
   // do rescaling and color conversion.
   void initializeFilterGraphForStream(

--- a/src/torchcodec/decoders/_core/VideoDecoderOps.h
+++ b/src/torchcodec/decoders/_core/VideoDecoderOps.h
@@ -100,6 +100,21 @@ OpsBatchDecodedOutput get_frames_by_pts_in_range(
     double start_seconds,
     double stop_seconds);
 
+// For testing only. We need to implement this operation as a core library
+// function because what we're testing is round-tripping pts values as
+// double-precision floating point numbers from C++ to Python and back to C++.
+// We want to make sure that the value is preserved exactly, bit-for-bit, during
+// this process.
+//
+// Returns true if for the given decoder, in the stream stream_index, the pts
+// value when converted to seconds as a double is exactly pts_seconds_to_test.
+// Returns false otherwise.
+bool _test_frame_pts_equality(
+    at::Tensor& decoder,
+    int64_t stream_index,
+    int64_t frame_index,
+    double pts_seconds_to_test);
+
 // Get the metadata from the video as a string.
 std::string get_json_metadata(at::Tensor& decoder);
 

--- a/src/torchcodec/decoders/_core/__init__.py
+++ b/src/torchcodec/decoders/_core/__init__.py
@@ -12,6 +12,7 @@ from ._metadata import (
     VideoStreamMetadata,
 )
 from .video_decoder_ops import (
+    _test_frame_pts_equality,
     add_video_stream,
     create_from_bytes,
     create_from_file,

--- a/src/torchcodec/decoders/_core/video_decoder_ops.py
+++ b/src/torchcodec/decoders/_core/video_decoder_ops.py
@@ -69,6 +69,7 @@ get_frames_at_indices = torch.ops.torchcodec_ns.get_frames_at_indices.default
 get_frames_in_range = torch.ops.torchcodec_ns.get_frames_in_range.default
 get_frames_by_pts_in_range = torch.ops.torchcodec_ns.get_frames_by_pts_in_range.default
 get_json_metadata = torch.ops.torchcodec_ns.get_json_metadata.default
+_test_frame_pts_equality = torch.ops.torchcodec_ns._test_frame_pts_equality.default
 _get_container_json_metadata = (
     torch.ops.torchcodec_ns.get_container_json_metadata.default
 )
@@ -220,6 +221,17 @@ def get_container_json_metadata_abstract(decoder: torch.Tensor) -> str:
 @register_fake("torchcodec_ns::get_stream_json_metadata")
 def get_stream_json_metadata_abstract(decoder: torch.Tensor, stream_idx: int) -> str:
     return ""
+
+
+@register_fake("torchcodec_ns::_test_frame_pts_equality")
+def _test_frame_pts_equality_abstract(
+    decoder: torch.Tensor,
+    *,
+    stream_index: int,
+    frame_index: int,
+    pts_seconds_to_test: float,
+) -> bool:
+    return False
 
 
 @register_fake("torchcodec_ns::_get_json_ffmpeg_library_versions")

--- a/test/decoders/test_simple_video_decoder.py
+++ b/test/decoders/test_simple_video_decoder.py
@@ -406,19 +406,10 @@ class TestSimpleDecoder:
         # in the pts-based method. We ensure it is correct by making sure it returns the
         # frames at the indices we know the pts-values map to.
 
-        # TODO: Investigate our need for this "nudge" value and floating point in general.
-        # We currently have a problem where round-tripping pts values from the C++ side
-        # to Python back to the C++ side seems to result in values slightly less than
-        # expected. We use this "nudge" value to ensure the values we provide in testing
-        # are comfortably above or below the target value.
-        #
-        # (The one exception to this reasoning is 0.0 in pts seconds.)
-        NUDGE = 0.000001
-
         # This value is rougly half of the duration of a frame in seconds in the test
         # stream. We use it to obtain values that fall rougly halfway between the pts
         # values for two back-to-back frames.
-        HALF_DURATION = 0.015
+        HALF_DURATION = (1 / decoder.metadata.average_fps) / 2
 
         # The intention here is that the stop and start are exactly specified. In practice, the pts
         # value for frame 5 that we have access to on the Python side is slightly less than the pts
@@ -439,7 +430,7 @@ class TestSimpleDecoder:
         # Again, the intention here is to provide the exact values we care about. In practice, our
         # pts values are slightly smaller, so we nudge the start upwards.
         frames5_9 = decoder.get_frames_displayed_at(
-            decoder.get_frame_at(5).pts_seconds + NUDGE,
+            decoder.get_frame_at(5).pts_seconds,
             decoder.get_frame_at(10).pts_seconds,
         )
         assert_tensor_equal(frames5_9.data, NASA_VIDEO.get_frame_data_by_range(5, 10))
@@ -448,15 +439,15 @@ class TestSimpleDecoder:
         # also should land in the same window of time between two frame's pts values. As
         # a result, we should only get back one frame.
         frame6 = decoder.get_frames_displayed_at(
-            decoder.get_frame_at(6).pts_seconds + NUDGE,
+            decoder.get_frame_at(6).pts_seconds,
             decoder.get_frame_at(6).pts_seconds + HALF_DURATION,
         )
         assert_tensor_equal(frame6.data, NASA_VIDEO.get_frame_data_by_range(6, 7))
 
         # Very small range that falls in the same frame.
         frame35 = decoder.get_frames_displayed_at(
-            decoder.get_frame_at(35).pts_seconds + NUDGE,
-            decoder.get_frame_at(35).pts_seconds + (2 * NUDGE),
+            decoder.get_frame_at(35).pts_seconds,
+            decoder.get_frame_at(35).pts_seconds + 1e-10,
         )
         assert_tensor_equal(frame35.data, NASA_VIDEO.get_frame_data_by_range(35, 36))
 
@@ -471,8 +462,8 @@ class TestSimpleDecoder:
 
         # Start and stop seconds are the same value, which should not return a frame.
         empty_frame = decoder.get_frames_displayed_at(
-            NASA_VIDEO.frames[4].pts_seconds + NUDGE,
-            NASA_VIDEO.frames[4].pts_seconds + NUDGE,
+            NASA_VIDEO.frames[4].pts_seconds,
+            NASA_VIDEO.frames[4].pts_seconds,
         )
         assert_tensor_equal(empty_frame.data, NASA_VIDEO.empty_chw_tensor)
         assert_tensor_equal(empty_frame.pts_seconds, NASA_VIDEO.empty_pts_seconds)


### PR DESCRIPTION
Summary:
We had a subtle bug where we said:
```
  return std::make_tuple(
      frame.frame,
      torch::tensor(frame.ptsSeconds),
      torch::tensor(frame.durationSeconds));
```
When we should have said:
```
  return std::make_tuple(
      frame.frame,
      torch::tensor(frame.ptsSeconds, torch::dtype(torch::kFloat64)),
      torch::tensor(frame.durationSeconds, torch::dtype(torch::kFloat64)));
}
```
PyTorch, both in C++ and in Python, defaults to 32-bit floating point numbers - despite the fact that we were providing 64-bit doubles in C++. This meant that we could not round-trip pts in seconds from C++ to Python and back to C++ with bit-for-bit equality; we got a truncated value that was slightly less. In addition to fixing this bug, we:

* Add a new core library operation that is meant exclusively for testing. Because we want to test round-tripping from C++ to Python back to C++, we have to implement this as a core library operation. We make it private, as it is for internal use only. Its signature:
```
def _test_frame_pts_equality(
    decoder: torch.Tensor,
    *,
    stream_index: int,
    frame_index: int,
    pts_seconds_to_test: float,
) -> bool:
```
* Add tests which explicitly test for bit-for-bit floating point equality when round-tripping, using the above. Because this is such an easy mistake to make, we need a test to ensure it does not happen again.
* Fix the behavior of `get_frames_displayed_at()` in `SimpleVideoDecoder`. Because we could not reliably provide exact pts values in seconds before, we could not test for it. We had to turn `<` into `<=` for the behavior we want.
*  Fix the tests for `get_frames_displayed_at()` to not use `NUDGE`, which also removes a TODO.

Differential Revision: D60604309
