### PR TITLE
[torchcodec] Add CUDA support to SimpleVideoDecoder

### DIFF
--- a/examples/basic_example.py
+++ b/examples/basic_example.py
@@ -158,3 +158,14 @@ frame_at_2_seconds = decoder.get_frame_displayed_at(seconds=2)
 print(f"{type(frame_at_2_seconds) = }")
 print(frame_at_2_seconds)
 plot(frame_at_2_seconds.data, "Frame displayed at 2 seconds")
+
+# %%
+# Using a CUDA GPU to accelerate decoding
+# ---------------------------------------
+#
+# If you have a CUDA GPU that has NVDEC, you can decode on the GPU.
+if torch.cuda.is_available():
+    cuda_decoder = SimpleVideoDecoder(raw_video_bytes, device="cuda:0")
+    cuda_frame = cuda_decoder.get_frame_displayed_at(seconds=2)
+    print(cuda_frame.data.device)  # should be cuda:0
+    plot(cuda_frame.data.to("cpu"), "Frame displayed at 2 seconds on CUDA")

--- a/src/torchcodec/decoders/_simple_video_decoder.py
+++ b/src/torchcodec/decoders/_simple_video_decoder.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable, Iterator, Literal, Tuple, Union
 
-from torch import Tensor
+from torch import device as torch_device, Tensor
 
 from torchcodec.decoders import _core as core
 
@@ -89,6 +89,14 @@ class SimpleVideoDecoder:
             This can be either "NCHW" (default) or "NHWC", where N is the batch
             size, C is the number of channels, H is the height, and W is the
             width of the frames.
+        device (torch.device, optional): The device to use for decoding.
+            Currently we only support CPU and CUDA devices. If CUDA is used,
+            we use NVDEC and CUDA to do decoding and color-conversion
+            respectively. The resulting frame is left on the GPU for further
+            processing.
+            You can either pass in a string like "cpu" or "cuda:0" or a
+            torch.device like torch.device("cuda:0").
+            Default: ``torch.device("cpu")``.
 
             .. note::
 
@@ -106,6 +114,7 @@ class SimpleVideoDecoder:
         self,
         source: Union[str, Path, bytes, Tensor],
         dimension_order: Literal["NCHW", "NHWC"] = "NCHW",
+        device: Union[str, torch_device] = torch_device("cpu"),
     ):
         if isinstance(source, str):
             self._decoder = core.create_from_file(source)
@@ -129,7 +138,20 @@ class SimpleVideoDecoder:
             )
 
         core.scan_all_streams_to_update_metadata(self._decoder)
-        core.add_video_stream(self._decoder, dimension_order=dimension_order)
+        num_threads = None
+        if isinstance(device, str):
+            device = torch_device(device)
+        if device.type == "cuda":
+            # Using multiple CPU threads seems to slow down decoding on CUDA.
+            # CUDA internally uses dedicated hardware to do decoding so we
+            # don't need CPU software threads here.
+            num_threads = 1
+        core.add_video_stream(
+            self._decoder,
+            dimension_order=dimension_order,
+            device_string=str(device),
+            num_threads=num_threads,
+        )
 
         self.metadata, self._stream_index = _get_and_validate_stream_metadata(
             self._decoder

--- a/test/decoders/test_simple_video_decoder.py
+++ b/test/decoders/test_simple_video_decoder.py
@@ -45,6 +45,34 @@ class TestSimpleDecoder:
         with pytest.raises(TypeError, match="Unknown source type"):
             decoder = SimpleVideoDecoder(123)  # noqa
 
+    def test_can_accept_devices(self):
+        # You can pass a CPU device as a string...<contd>
+        decoder = SimpleVideoDecoder(NASA_VIDEO.path, device="cpu")
+        assert_tensor_equal(decoder[0], NASA_VIDEO.get_frame_data_by_index(0))
+
+        # ...or as a torch.device.
+        decoder = SimpleVideoDecoder(NASA_VIDEO.path, device=torch.device("cpu"))
+        assert_tensor_equal(decoder[0], NASA_VIDEO.get_frame_data_by_index(0))
+
+        if torch.cuda.is_available():
+            # You can pass a CUDA device as a string...<contd>
+            decoder = SimpleVideoDecoder(NASA_VIDEO.path, device="cuda")
+            frame = decoder[0]
+            assert frame.device.type == "cuda"
+            assert frame.shape == torch.Size(
+                [NASA_VIDEO.num_color_channels, NASA_VIDEO.height, NASA_VIDEO.width]
+            )
+
+            # ...or as a torch.device.
+            decoder = SimpleVideoDecoder(NASA_VIDEO.path, device=torch.device("cuda"))
+            frame = decoder[0]
+            assert frame.device.type == "cuda"
+            assert frame.shape == torch.Size(
+                [NASA_VIDEO.num_color_channels, NASA_VIDEO.height, NASA_VIDEO.width]
+            )
+            # TODO: compare tensor values too. We don't compare values because
+            # the exact values are hardware-dependent.
+
     def test_getitem_int(self):
         decoder = SimpleVideoDecoder(NASA_VIDEO.path)
 


### PR DESCRIPTION
Summary:
Add a device type to the SimpleVideoDecoder constructor that defaults to the CPU device.

Use 1 CPU FFMPEG thread when using CUDA decoding because it seems to hurt performance to use multiple threads.

We could expose thread_count in SimpleVideoDecoder in a subsequent diff if need be.

Differential Revision: D60676983
