### PR TITLE
[AMD] hipify torchcodec

### DIFF
--- a/src/torchcodec/decoders/_core/VideoDecoder.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoder.cpp
@@ -34,8 +34,6 @@ extern "C" {
 #endif
 }
 
-#include "src/torchcodec/decoders/_core/FFMPEGCommon.h"
-
 namespace facebook::torchcodec {
 namespace {
 


### PR DESCRIPTION
Summary: torchcodec fails build on AMD, this diff skips the ENABLE_CUDA flag on AMD.

Differential Revision: D60685256
