### PR TITLE
Update example to add get_frames_displayed_at()

### DIFF
--- a/examples/basic_example.py
+++ b/examples/basic_example.py
@@ -151,13 +151,26 @@ plot(middle_frames.data, "Middle frames")
 #
 # So far, we have retrieved frames based on their index. We can also retrieve
 # frames based on *when* they are displayed with
-# :meth:`~torchcodec.decoders.SimpleVideoDecoder.get_frame_displayed_at`, which
-# also returns :class:`~torchcodec.decoders.Frame`.
+# :meth:`~torchcodec.decoders.SimpleVideoDecoder.get_frame_displayed_at` and
+# :meth:`~torchcodec.decoders.SimpleVideoDecoder.get_frames_displayed_at`, which
+# also returns :class:`~torchcodec.decoders.Frame` and :class:`~torchcodec.decoders.FrameBatch`
+# respectively.
 
 frame_at_2_seconds = decoder.get_frame_displayed_at(seconds=2)
 print(f"{type(frame_at_2_seconds) = }")
 print(frame_at_2_seconds)
+
+# %%
+first_two_seconds = decoder.get_frames_displayed_at(
+    start_seconds=0,
+    stop_seconds=2,
+)
+print(f"{type(first_two_seconds) = }")
+print(first_two_seconds)
+
+# %%
 plot(frame_at_2_seconds.data, "Frame displayed at 2 seconds")
+plot(first_two_seconds.data, "Frames displayed during [0, 2) seconds")
 
 # %%
 # Using a CUDA GPU to accelerate decoding


### PR DESCRIPTION
Summary:
Adds example usage of `get_frames_displayed_at()`. Incorporate it in such a way that the index-based and time-based examples parallel each other.