### PR TITLE
[torchcodec] Add new core API: getDisplayedFrameIndexByTimestamp

### DIFF
--- a/src/torchcodec/decoders/_core/VideoDecoder.h
+++ b/src/torchcodec/decoders/_core/VideoDecoder.h
@@ -232,6 +232,13 @@ class VideoDecoder {
       int streamIndex,
       double startSeconds,
       double stopSeconds);
+
+  // Return index of frame displayed at a given timestamp for a given stream.
+  int64_t getDisplayedFrameIndexByTimestamp(int streamIndex, double seconds);
+
+  // Return pts Second for a given frame index of a given stream.
+  double getPtsSecondsForFrame(int streamIndex, int64_t frameIndex);
+
   // --------------------------------------------------------------------------
   // DECODER PERFORMANCE STATISTICS API
   // --------------------------------------------------------------------------
@@ -248,8 +255,6 @@ class VideoDecoder {
   };
   DecodeStats getDecodeStats() const;
   void resetDecodeStats();
-
-  double getPtsSecondsForFrame(int streamIndex, int64_t frameIndex);
 
  private:
   struct FrameInfo {

--- a/src/torchcodec/decoders/_core/VideoDecoderOps.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoderOps.cpp
@@ -42,6 +42,8 @@ TORCH_LIBRARY(torchcodec_ns, m) {
       "get_frames_in_range(Tensor(a!) decoder, *, int stream_index, int start, int stop, int? step=None) -> (Tensor, Tensor, Tensor)");
   m.def(
       "get_frames_by_pts_in_range(Tensor(a!) decoder, *, int stream_index, float start_seconds, float stop_seconds) -> (Tensor, Tensor, Tensor)");
+  m.def(
+      "get_displayed_frame_index_by_timestamp(Tensor(a!) decoder, *, int stream_index, float seconds) -> int");
   m.def("get_json_metadata(Tensor(a!) decoder) -> str");
   m.def("get_container_json_metadata(Tensor(a!) decoder) -> str");
   m.def(
@@ -206,6 +208,14 @@ OpsBatchDecodedOutput get_frames_by_pts_in_range(
   auto result = videoDecoder->getFramesDisplayedByTimestampInRange(
       stream_index, start_seconds, stop_seconds);
   return makeOpsBatchDecodedOutput(result);
+}
+
+int64_t get_displayed_frame_index_by_timestamp(
+    at::Tensor& decoder,
+    int64_t stream_index,
+    double seconds) {
+  auto videoDecoder = unwrapTensorToGetDecoder(decoder);
+  return videoDecoder->getDisplayedFrameIndexByTimestamp(stream_index, seconds);
 }
 
 std::string quoteValue(const std::string& value) {
@@ -440,6 +450,9 @@ TORCH_LIBRARY_IMPL(torchcodec_ns, CPU, m) {
   m.impl("get_frames_at_indices", &get_frames_at_indices);
   m.impl("get_frames_in_range", &get_frames_in_range);
   m.impl("get_frames_by_pts_in_range", &get_frames_by_pts_in_range);
+  m.impl(
+      "get_displayed_frame_index_by_timestamp",
+      &get_displayed_frame_index_by_timestamp);
   m.impl("_test_frame_pts_equality", &_test_frame_pts_equality);
   m.impl(
       "scan_all_streams_to_update_metadata",

--- a/src/torchcodec/decoders/_core/VideoDecoderOps.h
+++ b/src/torchcodec/decoders/_core/VideoDecoderOps.h
@@ -100,6 +100,11 @@ OpsBatchDecodedOutput get_frames_by_pts_in_range(
     double start_seconds,
     double stop_seconds);
 
+int64_t get_displayed_frame_index_by_timestamp(
+    at::Tensor& decoder,
+    int64_t stream_index,
+    double seconds);
+
 // For testing only. We need to implement this operation as a core library
 // function because what we're testing is round-tripping pts values as
 // double-precision floating point numbers from C++ to Python and back to C++.

--- a/src/torchcodec/decoders/_core/__init__.py
+++ b/src/torchcodec/decoders/_core/__init__.py
@@ -17,6 +17,7 @@ from .video_decoder_ops import (
     create_from_bytes,
     create_from_file,
     create_from_tensor,
+    get_displayed_frame_index_by_timestamp,
     get_ffmpeg_library_versions,
     get_frame_at_index,
     get_frame_at_pts,

--- a/src/torchcodec/decoders/_core/video_decoder_ops.py
+++ b/src/torchcodec/decoders/_core/video_decoder_ops.py
@@ -68,6 +68,9 @@ get_frame_at_index = torch.ops.torchcodec_ns.get_frame_at_index.default
 get_frames_at_indices = torch.ops.torchcodec_ns.get_frames_at_indices.default
 get_frames_in_range = torch.ops.torchcodec_ns.get_frames_in_range.default
 get_frames_by_pts_in_range = torch.ops.torchcodec_ns.get_frames_by_pts_in_range.default
+get_displayed_frame_index_by_timestamp = (
+    torch.ops.torchcodec_ns.get_displayed_frame_index_by_timestamp.default
+)
 get_json_metadata = torch.ops.torchcodec_ns.get_json_metadata.default
 _test_frame_pts_equality = torch.ops.torchcodec_ns._test_frame_pts_equality.default
 _get_container_json_metadata = (
@@ -206,6 +209,16 @@ def get_frames_by_pts_in_range_abstract(
         torch.empty([], dtype=torch.float),
         torch.empty([], dtype=torch.float),
     )
+
+
+@register_fake("torchcodec_ns::get_displayed_frame_index_by_timestamp")
+def get_displayed_frame_index_by_timestamp_abstract(
+    decoder: torch.Tensor,
+    *,
+    stream_index: int,
+    timestamp: float,
+) -> int:
+    return 0
 
 
 @register_fake("torchcodec_ns::get_json_metadata")

--- a/test/decoders/VideoDecoderTest.cpp
+++ b/test/decoders/VideoDecoderTest.cpp
@@ -344,6 +344,19 @@ TEST_P(VideoDecoderTest, GetsFrameDisplayedAtTimestamp) {
   EXPECT_EQ(output.ptsSeconds, kPtsOfLastFrameInVideoStream);
 }
 
+TEST_P(VideoDecoderTest, GetDisplayedFrameIndexByTimestamp) {
+  std::string path = getResourcePath("nasa_13013.mp4");
+  std::unique_ptr<VideoDecoder> ourDecoder =
+      createDecoderFromPath(path, GetParam());
+  ourDecoder->addVideoStreamDecoder(-1);
+  ourDecoder->scanFileAndUpdateMetadataAndIndex();
+  int bestVideoStreamIndex =
+      *ourDecoder->getContainerMetadata().bestVideoStreamIndex;
+  auto output = ourDecoder->getDisplayedFrameIndexByTimestamp(
+      bestVideoStreamIndex, 6.006);
+  EXPECT_EQ(output, 180);
+}
+
 TEST_P(VideoDecoderTest, SeeksToFrameWithSpecificPts) {
   std::string path = getResourcePath("nasa_13013.mp4");
   std::unique_ptr<VideoDecoder> ourDecoder =

--- a/test/decoders/test_video_decoder_ops.py
+++ b/test/decoders/test_video_decoder_ops.py
@@ -21,6 +21,7 @@ from torchcodec.decoders._core import (
     create_from_bytes,
     create_from_file,
     create_from_tensor,
+    get_displayed_frame_index_by_timestamp,
     get_ffmpeg_library_versions,
     get_frame_at_index,
     get_frame_at_pts,
@@ -170,6 +171,16 @@ class TestOps:
         # an empty range is valid!
         empty_frame, *_ = get_frames_in_range(decoder, stream_index=3, start=5, stop=5)
         assert_tensor_equal(empty_frame, NASA_VIDEO.empty_chw_tensor)
+
+    def test_get_displayed_frame_index_by_timestamp(self):
+        decoder = create_from_file(str(NASA_VIDEO.path))
+        scan_all_streams_to_update_metadata(decoder)
+        add_video_stream(decoder)
+        # The frame that is displayed at 6 seconds is frame 180 from a 0-based index.
+        frame_index = get_displayed_frame_index_by_timestamp(
+            decoder, stream_index=3, seconds=6.006
+        )
+        assert frame_index == 180
 
     def test_throws_exception_at_eof(self):
         decoder = create_from_file(str(NASA_VIDEO.path))


### PR DESCRIPTION
Summary:
This API retrieves displayed frame index by given timestamp, this helps to make conversion from time domain into index domain. This is useful in timeBasedSampler, where we only aware of start timestamp (no end ts) and need to query fixed amount of frames. This diff:

1.  The API reuses implementation in getFramesDisplayedByTimestampInRange where lower_bound and nextPts comparison to query the displayed index for given timestamp.
2. Correpsonding decoder ops is added so this can be used in python layer
3. Tests about core API and ops API

Differential Revision: D60806059
