### PR TITLE
Fix documentation template

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -7,6 +7,7 @@ body:
     label: 📚 The doc issue
     description: >
       Is something confusing or wrong? Let us know! Please provide URLs to the content in https://pytorch.org/torchcodec/stable/index.html that you're referring to.
+  validations:
     required: true
 - type: markdown
   attributes:


### PR DESCRIPTION
Summary:

My previous commit messed up the YAML for the docs template. :/ If there is a way we can validate the YAML, I'd love to know about it.