### PR TITLE
Minor comment update for ffmpegThreadCount

### DIFF
--- a/src/torchcodec/decoders/_core/VideoDecoder.h
+++ b/src/torchcodec/decoders/_core/VideoDecoder.h
@@ -130,8 +130,7 @@ class VideoDecoder {
     explicit VideoStreamDecoderOptions(const std::string& optionsString);
     // Number of threads we pass to FFMPEG for decoding.
     // 0 means FFMPEG will choose the number of threads automatically to fully
-    // utilize all cores. If not set, it will be the default FFMPEG behavior for
-    // the given codec.
+    // utilize all cores. If not set, this defaults to 0.
     std::optional<int> ffmpegThreadCount;
     // Currently the dimension order can be either NHWC or NCHW.
     // H=height, W=width, C=channel.


### PR DESCRIPTION
This is a nit. I originally read the existing comment as referring to 2 different behaviors, but IIUC the 2 sentences refer to the same behavior (i.e. when the value is 0). Hopefully this edit can avoid the misunderstanding I had.