### PR TITLE
Added colorspace and color_range to torchcodec

### DIFF
--- a/src/torchcodec/decoders/_core/VideoDecoder.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoder.cpp
@@ -359,14 +359,16 @@ void VideoDecoder::initializeFilterGraphForStream(
   snprintf(
       args,
       sizeof(args),
-      "video_size=%dx%d:pix_fmt=%d:time_base=%d/%d:pixel_aspect=%d/%d",
+      "video_size=%dx%d:pix_fmt=%d:time_base=%d/%d:pixel_aspect=%d/%d:colorspace=%d:range=%d",
       codecContext->width,
       codecContext->height,
       codecContext->pix_fmt,
       activeStream.stream->time_base.num,
       activeStream.stream->time_base.den,
       codecContext->sample_aspect_ratio.num,
-      codecContext->sample_aspect_ratio.den);
+      codecContext->sample_aspect_ratio.den,
+      codecContext->colorspace,
+      codecContext->color_range);
 
   int ffmpegStatus = avfilter_graph_create_filter(
       &filterState.sourceContext,


### PR DESCRIPTION
Without this change, with ffmpeg7 we get warning messages like the following:

Changing video frame properties on the fly is not supported by all filters

For more info see this:

https://trac.ffmpeg.org/ticket/10823