### PR TITLE
Add CI for linux cuda

### DIFF
--- a/.github/workflows/test_linux_cuda.yaml
+++ b/.github/workflows/test_linux_cuda.yaml
@@ -32,10 +32,10 @@ jobs:
         pwd
         conda create --yes --name test
         conda activate test
-        conda install --yes pip cmake pkg-config nasm
+        conda install --quiet --yes pip cmake pkg-config nasm
 
-        pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu124
-        conda install --yes nvidia::libnpp
+        pip install --quiet --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu124
+        conda install --quiet --yes nvidia::libnpp
 
         # Build and install FFMPEG from source with CUDA enabled.
         # The one on conda doesn't have CUDA enabled.
@@ -54,7 +54,7 @@ jobs:
         which pkg-config
         pkg-config --list-all
         ./configure --prefix=$CONDA_PREFIX --enable-nonfree --enable-cuda-nvcc --disable-static --enable-shared --optflags=-fno-omit-frame-pointer --disable-stripping --enable-cuvid
-        make -j install
+        make --quiet -j install
         popd
 
         CMAKE_BUILD_PARALLEL_LEVEL=8 CXXFLAGS="" LDFLAGS="-Wl,--allow-shlib-undefined -Wl,-rpath,$CONDA_PREFIX/lib -Wl,-rpath-link,$CONDA_PREFIX/lib -L$CONDA_PREFIX/lib" CMAKE_BUILD_TYPE=Release ENABLE_CUDA=1 ENABLE_NVTX=1 pip install -e . --no-build-isolation -vv --debug

--- a/.github/workflows/test_linux_cuda.yaml
+++ b/.github/workflows/test_linux_cuda.yaml
@@ -57,8 +57,7 @@ jobs:
         make --quiet -j install
         popd
 
-        CMAKE_BUILD_PARALLEL_LEVEL=8 CXXFLAGS="" LDFLAGS="-Wl,--allow-shlib-undefined -Wl,-rpath,$CONDA_PREFIX/lib -Wl,-rpath-link,$CONDA_PREFIX/lib -L$CONDA_PREFIX/lib" CMAKE_BUILD_TYPE=Release ENABLE_CUDA=1 ENABLE_NVTX=1 pip install -e . --no-build-isolation -vv --debug
-        pip install pytest
+        CMAKE_BUILD_PARALLEL_LEVEL=8 CXXFLAGS="" LDFLAGS="-Wl,--allow-shlib-undefined -Wl,-rpath,$CONDA_PREFIX/lib -Wl,-rpath-link,$CONDA_PREFIX/lib -L$CONDA_PREFIX/lib" CMAKE_BUILD_TYPE=Release ENABLE_CUDA=1 ENABLE_NVTX=1 pip install -e ".[dev]"" --no-build-isolation -vv --debug
 
         # We skip certain tests because they are not relevant to GPU decoding and they always fail with
         # a custom FFMPEG build.

--- a/.github/workflows/test_linux_cuda.yaml
+++ b/.github/workflows/test_linux_cuda.yaml
@@ -64,7 +64,7 @@ jobs:
         find $CONDA_PREFIX -name libavutil.so\*
         find $CONDA_PREFIX -name \*libavutil.so\*
 
-        ffmpeg -version
-        ffprobe -version
+        # ffmpeg -version
+        # ffprobe -version
         pytest test
         conda deactivate

--- a/.github/workflows/test_linux_cuda.yaml
+++ b/.github/workflows/test_linux_cuda.yaml
@@ -31,7 +31,7 @@ jobs:
         pwd
         conda create --yes --name test
         conda activate test
-        conda install --yes pip
+        conda install --yes pip cmake pkg-config
         pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu124
         conda install --yes ffmpeg
         CMAKE_BUILD_PARALLEL_LEVEL=8 CXXFLAGS="" CMAKE_BUILD_TYPE=Release ENABLE_CUDA=1 ENABLE_NVTX=1 pip install -e . --no-build-isolation -vv --debug

--- a/.github/workflows/test_linux_cuda.yaml
+++ b/.github/workflows/test_linux_cuda.yaml
@@ -48,7 +48,7 @@ jobs:
         # Now build FFMPEG from source with CUDA enabled.
         git clone https://git.ffmpeg.org/ffmpeg.git ffmpeg/
         pushd ffmpeg
-        ./configure --prefix=$CONDA_PREFIX --enable-nonfree --enable-cuda-nvcc --enable-libnpp --disable-static --enable-shared --optflags=-fno-omit-frame-pointer --disable-stripping
+        ./configure --prefix=$CONDA_PREFIX --enable-nonfree --enable-cuda-nvcc --disable-static --enable-shared --optflags=-fno-omit-frame-pointer --disable-stripping
         make -j install
         popd
 

--- a/.github/workflows/test_linux_cuda.yaml
+++ b/.github/workflows/test_linux_cuda.yaml
@@ -34,6 +34,7 @@ jobs:
         conda install --yes pip cmake pkg-config
         pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu124
         conda install --yes ffmpeg
+        conda install --yes nvidia::npp
         CMAKE_BUILD_PARALLEL_LEVEL=8 CXXFLAGS="" CMAKE_BUILD_TYPE=Release ENABLE_CUDA=1 ENABLE_NVTX=1 pip install -e . --no-build-isolation -vv --debug
         pip install pytest
         pytest test

--- a/.github/workflows/test_linux_cuda.yaml
+++ b/.github/workflows/test_linux_cuda.yaml
@@ -61,13 +61,8 @@ jobs:
 
         CMAKE_BUILD_PARALLEL_LEVEL=8 CXXFLAGS="" LDFLAGS="-Wl,--allow-shlib-undefined -Wl,-rpath,$CONDA_PREFIX/lib -Wl,-rpath-link,$CONDA_PREFIX/lib -L$CONDA_PREFIX/lib" CMAKE_BUILD_TYPE=Release ENABLE_CUDA=1 ENABLE_NVTX=1 pip install -e . --no-build-isolation -vv --debug
         pip install pytest
-        ldd $(which ffmpeg)
-        ldd $(which ffprobe)
-        find $CONDA_PREFIX -name libavutil.so.59
-        find $CONDA_PREFIX -name libavutil.so\*
-        find $CONDA_PREFIX -name \*libavutil.so\*
 
-        # ffmpeg -version
-        # ffprobe -version
-        pytest test
+        # We skip certain tests because they are not relevant to GPU decoding and they always fail with
+        # a custom FFMPEG build.
+        pytest -k "not (test_get_metadata or get_ffmpeg_version)"
         conda deactivate

--- a/.github/workflows/test_linux_cuda.yaml
+++ b/.github/workflows/test_linux_cuda.yaml
@@ -37,5 +37,7 @@ jobs:
         conda install --yes nvidia::libnpp
         CMAKE_BUILD_PARALLEL_LEVEL=8 CXXFLAGS="" CMAKE_BUILD_TYPE=Release ENABLE_CUDA=1 ENABLE_NVTX=1 pip install -e . --no-build-isolation -vv --debug
         pip install pytest
+        ffmpeg -version
+        ffprobe -version
         pytest test
         conda deactivate

--- a/.github/workflows/test_linux_cuda.yaml
+++ b/.github/workflows/test_linux_cuda.yaml
@@ -56,6 +56,9 @@ jobs:
         pip install pytest
         ldd $(which ffmpeg)
         ldd $(which ffprobe)
+        find $CONDA_PREFIX -name libavutil.so.59
+        find $CONDA_PREFIX -name libavutil.so\*
+        find $CONDA_PREFIX -name \*libavutil.so\*
 
         ffmpeg -version
         ffprobe -version

--- a/.github/workflows/test_linux_cuda.yaml
+++ b/.github/workflows/test_linux_cuda.yaml
@@ -54,6 +54,8 @@ jobs:
 
         CMAKE_BUILD_PARALLEL_LEVEL=8 CXXFLAGS="" CMAKE_BUILD_TYPE=Release ENABLE_CUDA=1 ENABLE_NVTX=1 pip install -e . --no-build-isolation -vv --debug
         pip install pytest
+        ldd $(which ffmpeg)
+        ldd $(which ffprobe)
         ffmpeg -version
         ffprobe -version
         pytest test

--- a/.github/workflows/test_linux_cuda.yaml
+++ b/.github/workflows/test_linux_cuda.yaml
@@ -32,9 +32,9 @@ jobs:
         conda create --yes --name test
         conda activate test
         conda install --yes pip cmake pkg-config nasm
+        conda install --yes conda-forge::compilers
         pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu124
         conda install --yes nvidia::libnpp
-        conda install --yes conda-forge::compilers
 
         # Build and install FFMPEG from source with CUDA enabled.
         # The one on conda doesn't have CUDA enabled.

--- a/.github/workflows/test_linux_cuda.yaml
+++ b/.github/workflows/test_linux_cuda.yaml
@@ -28,8 +28,6 @@ jobs:
 
       script: |
         nvidia-smi
-        ls -l
-        pwd
         conda create --yes --name test
         conda activate test
         conda install --quiet --yes pip cmake pkg-config nasm

--- a/.github/workflows/test_linux_cuda.yaml
+++ b/.github/workflows/test_linux_cuda.yaml
@@ -43,10 +43,9 @@ jobs:
         # The one on conda doesn't have CUDA enabled.
         # Sub-step: install nvidia headers. Reference this link for details:
         # https://docs.nvidia.com/video-technologies/video-codec-sdk/12.1/ffmpeg-with-nvidia-gpu/index.html
-        git clone https://github.com/FFmpeg/nv-codec-headers.git
+        git clone https://git.videolan.org/git/ffmpeg/nv-codec-headers.git
 
         pushd nv-codec-headers
-        git checkout n11.0.10.1
         make PREFIX=$CONDA_PREFIX -j install
         popd
 

--- a/.github/workflows/test_linux_cuda.yaml
+++ b/.github/workflows/test_linux_cuda.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         python_version: ["3.8", "3.9", "3.10"]
-        cuda_arch_version: ["11.8"]
+        cuda_arch_version: ["12.4"]
       fail-fast: false
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:

--- a/.github/workflows/test_linux_cuda.yaml
+++ b/.github/workflows/test_linux_cuda.yaml
@@ -14,7 +14,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        python_version: ["3.9", "3.10"]
+        python_version: ["3.9"]
         # TODO: Add more cuda versions.
         cuda_arch_version: ["12.4"]
       fail-fast: false

--- a/.github/workflows/test_linux_cuda.yaml
+++ b/.github/workflows/test_linux_cuda.yaml
@@ -43,7 +43,8 @@ jobs:
         # The one on conda doesn't have CUDA enabled.
         # Sub-step: install nvidia headers. Reference this link for details:
         # https://docs.nvidia.com/video-technologies/video-codec-sdk/12.1/ffmpeg-with-nvidia-gpu/index.html
-        git clone https://git.videolan.org/git/ffmpeg/nv-codec-headers.git
+        git clone https://github.com/FFmpeg/nv-codec-headers.git
+
         pushd nv-codec-headers
         git checkout n11.0.10.1
         make PREFIX=$CONDA_PREFIX -j install
@@ -53,6 +54,8 @@ jobs:
         git clone https://git.ffmpeg.org/ffmpeg.git ffmpeg/
         pushd ffmpeg
         git checkout origin/release/6.1
+        which pkg-config
+        pkg-config --list-all
         ./configure --prefix=$CONDA_PREFIX --enable-nonfree --enable-cuda-nvcc --disable-static --enable-shared --optflags=-fno-omit-frame-pointer --disable-stripping --enable-cuvid
         make -j install
         popd

--- a/.github/workflows/test_linux_cuda.yaml
+++ b/.github/workflows/test_linux_cuda.yaml
@@ -14,7 +14,8 @@ jobs:
   tests:
     strategy:
       matrix:
-        python_version: ["3.8", "3.9", "3.10"]
+        python_version: ["3.9", "3.10"]
+        # TODO: Add more cuda versions.
         cuda_arch_version: ["12.4"]
       fail-fast: false
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
@@ -32,9 +33,6 @@ jobs:
         conda create --yes --name test
         conda activate test
         conda install --yes pip cmake pkg-config nasm
-
-        # This fails because conda reactivate fails inside this env
-        # conda install --yes conda-forge::compilers
 
         pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu124
         conda install --yes nvidia::libnpp
@@ -65,4 +63,5 @@ jobs:
         # We skip certain tests because they are not relevant to GPU decoding and they always fail with
         # a custom FFMPEG build.
         pytest -k "not (test_get_metadata or get_ffmpeg_version)"
+        python benchmarks/decoders/gpu_benchmark.py
         conda deactivate

--- a/.github/workflows/test_linux_cuda.yaml
+++ b/.github/workflows/test_linux_cuda.yaml
@@ -34,7 +34,7 @@ jobs:
         conda install --yes pip cmake pkg-config
         pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu124
         conda install --yes ffmpeg
-        conda install --yes nvidia::npp
+        conda install --yes nvidia::libnpp
         CMAKE_BUILD_PARALLEL_LEVEL=8 CXXFLAGS="" CMAKE_BUILD_TYPE=Release ENABLE_CUDA=1 ENABLE_NVTX=1 pip install -e . --no-build-isolation -vv --debug
         pip install pytest
         pytest test

--- a/.github/workflows/test_linux_cuda.yaml
+++ b/.github/workflows/test_linux_cuda.yaml
@@ -52,7 +52,8 @@ jobs:
         # Now build FFMPEG from source with CUDA enabled.
         git clone https://git.ffmpeg.org/ffmpeg.git ffmpeg/
         pushd ffmpeg
-        ./configure --prefix=$CONDA_PREFIX --enable-nonfree --enable-cuda-nvcc --disable-static --enable-shared --optflags=-fno-omit-frame-pointer --disable-stripping
+        git checkout origin/release/6.1
+        ./configure --prefix=$CONDA_PREFIX --enable-nonfree --enable-cuda-nvcc --disable-static --enable-shared --optflags=-fno-omit-frame-pointer --disable-stripping --enable-cuvid
         make -j install
         popd
 

--- a/.github/workflows/test_linux_cuda.yaml
+++ b/.github/workflows/test_linux_cuda.yaml
@@ -56,7 +56,7 @@ jobs:
         make -j install
         popd
 
-        CMAKE_BUILD_PARALLEL_LEVEL=8 CXXFLAGS="" LDFLAGS="-Wl,-rpath,$CONDA_PREFIX/lib" CMAKE_BUILD_TYPE=Release ENABLE_CUDA=1 ENABLE_NVTX=1 pip install -e . --no-build-isolation -vv --debug
+        CMAKE_BUILD_PARALLEL_LEVEL=8 CXXFLAGS="" LDFLAGS="-Wl,--allow-shlib-undefined -Wl,-rpath,$CONDA_PREFIX/lib -Wl,-rpath-link,$CONDA_PREFIX/lib -L$CONDA_PREFIX/lib" CMAKE_BUILD_TYPE=Release ENABLE_CUDA=1 ENABLE_NVTX=1 pip install -e . --no-build-isolation -vv --debug
         pip install pytest
         ldd $(which ffmpeg)
         ldd $(which ffprobe)

--- a/.github/workflows/test_linux_cuda.yaml
+++ b/.github/workflows/test_linux_cuda.yaml
@@ -41,23 +41,23 @@ jobs:
         # The one on conda doesn't have CUDA enabled.
         # Sub-step: install nvidia headers. Reference this link for details:
         # https://docs.nvidia.com/video-technologies/video-codec-sdk/12.1/ffmpeg-with-nvidia-gpu/index.html
-        git clone https://git.videolan.org/git/ffmpeg/nv-codec-headers.git
+        git clone --quiet https://git.videolan.org/git/ffmpeg/nv-codec-headers.git
 
         pushd nv-codec-headers
-        make PREFIX=$CONDA_PREFIX -j install
+        make --silent PREFIX=$CONDA_PREFIX -j install
         popd
 
         # Now build FFMPEG from source with CUDA enabled.
-        git clone https://git.ffmpeg.org/ffmpeg.git ffmpeg/
+        git clone --quiet https://git.ffmpeg.org/ffmpeg.git ffmpeg/
         pushd ffmpeg
         git checkout origin/release/6.1
         which pkg-config
         pkg-config --list-all
         ./configure --prefix=$CONDA_PREFIX --enable-nonfree --enable-cuda-nvcc --disable-static --enable-shared --optflags=-fno-omit-frame-pointer --disable-stripping --enable-cuvid
-        make --quiet -j install
+        make --silent -j install
         popd
 
-        CMAKE_BUILD_PARALLEL_LEVEL=8 CXXFLAGS="" LDFLAGS="-Wl,--allow-shlib-undefined -Wl,-rpath,$CONDA_PREFIX/lib -Wl,-rpath-link,$CONDA_PREFIX/lib -L$CONDA_PREFIX/lib" CMAKE_BUILD_TYPE=Release ENABLE_CUDA=1 ENABLE_NVTX=1 pip install -e ".[dev]"" --no-build-isolation -vv --debug
+        CMAKE_BUILD_PARALLEL_LEVEL=8 CXXFLAGS="" LDFLAGS="-Wl,--allow-shlib-undefined -Wl,-rpath,$CONDA_PREFIX/lib -Wl,-rpath-link,$CONDA_PREFIX/lib -L$CONDA_PREFIX/lib" CMAKE_BUILD_TYPE=Release ENABLE_CUDA=1 ENABLE_NVTX=1 pip install -e ".[dev]" --no-build-isolation -vv --debug
 
         # We skip certain tests because they are not relevant to GPU decoding and they always fail with
         # a custom FFMPEG build.

--- a/.github/workflows/test_linux_cuda.yaml
+++ b/.github/workflows/test_linux_cuda.yaml
@@ -33,8 +33,26 @@ jobs:
         conda activate test
         conda install --yes pip cmake pkg-config
         pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu124
-        conda install --yes ffmpeg
         conda install --yes nvidia::libnpp
+
+        # Build and install FFMPEG from source with CUDA enabled.
+        # The one on conda doesn't have CUDA enabled.
+        # Sub-step: install nvidia headers. Reference this link for details:
+        # https://docs.nvidia.com/video-technologies/video-codec-sdk/12.1/ffmpeg-with-nvidia-gpu/index.html
+        git clone https://git.videolan.org/git/ffmpeg/nv-codec-headers.git
+        pushd nv-codec-headers
+        git checkout n11.0.10.1
+        make PREFIX=$CONDA_PREFIX -j install
+        popd
+
+        # Now build FFMPEG from source with CUDA enabled.
+        git clone https://git.ffmpeg.org/ffmpeg.git ffmpeg/
+        pushd ffmpeg
+        ./configure --prefix=$CONDA_PREFIX --enable-nonfree --enable-cuda-nvcc --enable-libnpp --disable-static --enable-shared --optflags=-fno-omit-frame-pointer --disable-stripping
+        make -j install
+        popd
+
+
         CMAKE_BUILD_PARALLEL_LEVEL=8 CXXFLAGS="" CMAKE_BUILD_TYPE=Release ENABLE_CUDA=1 ENABLE_NVTX=1 pip install -e . --no-build-isolation -vv --debug
         pip install pytest
         ffmpeg -version

--- a/.github/workflows/test_linux_cuda.yaml
+++ b/.github/workflows/test_linux_cuda.yaml
@@ -34,6 +34,7 @@ jobs:
         conda install --yes pip cmake pkg-config nasm
         pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu124
         conda install --yes nvidia::libnpp
+        conda install --yes conda-forge::compilers
 
         # Build and install FFMPEG from source with CUDA enabled.
         # The one on conda doesn't have CUDA enabled.

--- a/.github/workflows/test_linux_cuda.yaml
+++ b/.github/workflows/test_linux_cuda.yaml
@@ -1,0 +1,40 @@
+
+name: Unit-tests on Linux GPU
+
+on:
+  pull_request:
+  push:
+    branches:
+      - nightly
+      - main
+      - release/*
+  workflow_dispatch:
+
+jobs:
+  tests:
+    strategy:
+      matrix:
+        python_version: ["3.8", "3.9", "3.10"]
+        cuda_arch_version: ["11.8"]
+      fail-fast: false
+    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+    with:
+      runner: linux.g5.4xlarge.nvidia.gpu
+      repository: pytorch/torchcodec
+      gpu-arch-type: cuda
+      gpu-arch-version: ${{ matrix.cuda_arch_version }}
+      timeout: 120
+
+      script: |
+        nvidia-smi
+        ls -l
+        pwd
+        conda create --yes --name test
+        conda activate test
+        conda install --yes pip
+        pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu124
+        conda install --yes ffmpeg
+        CMAKE_BUILD_PARALLEL_LEVEL=8 CXXFLAGS="" CMAKE_BUILD_TYPE=Release ENABLE_CUDA=1 ENABLE_NVTX=1 pip install -e . --no-build-isolation -vv --debug
+        pip install pytest
+        pytest test
+        conda deactivate

--- a/.github/workflows/test_linux_cuda.yaml
+++ b/.github/workflows/test_linux_cuda.yaml
@@ -32,7 +32,10 @@ jobs:
         conda create --yes --name test
         conda activate test
         conda install --yes pip cmake pkg-config nasm
-        conda install --yes conda-forge::compilers
+
+        # This fails because conda reactivate fails inside this env
+        # conda install --yes conda-forge::compilers
+
         pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu124
         conda install --yes nvidia::libnpp
 
@@ -53,7 +56,7 @@ jobs:
         make -j install
         popd
 
-        CMAKE_BUILD_PARALLEL_LEVEL=8 CXXFLAGS="" CMAKE_BUILD_TYPE=Release ENABLE_CUDA=1 ENABLE_NVTX=1 pip install -e . --no-build-isolation -vv --debug
+        CMAKE_BUILD_PARALLEL_LEVEL=8 CXXFLAGS="" LDFLAGS="-Wl,-rpath,$CONDA_PREFIX/lib" CMAKE_BUILD_TYPE=Release ENABLE_CUDA=1 ENABLE_NVTX=1 pip install -e . --no-build-isolation -vv --debug
         pip install pytest
         ldd $(which ffmpeg)
         ldd $(which ffprobe)

--- a/.github/workflows/test_linux_cuda.yaml
+++ b/.github/workflows/test_linux_cuda.yaml
@@ -56,6 +56,7 @@ jobs:
         pip install pytest
         ldd $(which ffmpeg)
         ldd $(which ffprobe)
+
         ffmpeg -version
         ffprobe -version
         pytest test

--- a/.github/workflows/test_linux_cuda.yaml
+++ b/.github/workflows/test_linux_cuda.yaml
@@ -31,7 +31,7 @@ jobs:
         pwd
         conda create --yes --name test
         conda activate test
-        conda install --yes pip cmake pkg-config
+        conda install --yes pip cmake pkg-config nasm
         pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu124
         conda install --yes nvidia::libnpp
 
@@ -51,7 +51,6 @@ jobs:
         ./configure --prefix=$CONDA_PREFIX --enable-nonfree --enable-cuda-nvcc --enable-libnpp --disable-static --enable-shared --optflags=-fno-omit-frame-pointer --disable-stripping
         make -j install
         popd
-
 
         CMAKE_BUILD_PARALLEL_LEVEL=8 CXXFLAGS="" CMAKE_BUILD_TYPE=Release ENABLE_CUDA=1 ENABLE_NVTX=1 pip install -e . --no-build-isolation -vv --debug
         pip install pytest

--- a/src/torchcodec/decoders/_core/CMakeLists.txt
+++ b/src/torchcodec/decoders/_core/CMakeLists.txt
@@ -58,7 +58,9 @@ function(make_torchcodec_library library_name ffmpeg_target)
 
     set(NEEDED_LIBRARIES ${ffmpeg_target} ${TORCH_LIBRARIES} ${Python3_LIBRARIES})
     if(ENABLE_CUDA)
-        list(APPEND NEEDED_LIBRARIES ${CUDA_CUDA_LIBRARY})
+        find_library(NPPIF_LIBRARY nppif PATHS ${CUDA_PATH}/lib64)
+
+        list(APPEND NEEDED_LIBRARIES ${CUDA_CUDA_LIBRARY} ${NPPIF_LIBRARY})
     endif()
     if(ENABLE_NVTX)
         list(APPEND NEEDED_LIBRARIES nvtx3-cpp)

--- a/src/torchcodec/decoders/_core/CMakeLists.txt
+++ b/src/torchcodec/decoders/_core/CMakeLists.txt
@@ -58,9 +58,7 @@ function(make_torchcodec_library library_name ffmpeg_target)
 
     set(NEEDED_LIBRARIES ${ffmpeg_target} ${TORCH_LIBRARIES} ${Python3_LIBRARIES})
     if(ENABLE_CUDA)
-        find_library(NPPIF_LIBRARY nppif PATHS ${CUDA_PATH}/lib64)
-
-        list(APPEND NEEDED_LIBRARIES ${CUDA_CUDA_LIBRARY} ${NPPIF_LIBRARY})
+        list(APPEND NEEDED_LIBRARIES ${CUDA_CUDA_LIBRARY} ${CUDA_nppi_LIBRARY} ${CUDA_nppicc_LIBRARY} )
     endif()
     if(ENABLE_NVTX)
         list(APPEND NEEDED_LIBRARIES nvtx3-cpp)


### PR DESCRIPTION
This diff adds GPU CI to TorchCodec.

It installs the NVFFMPEG headers, builds FFMPEG from source, builds TorchCodec and then runs test on the GPU tests.

This will be useful to catch GPU recording regressions.

I also added an explicit dependency on NPP image processing library because it was failing to build inside the container environment.