### PR TITLE
Add flags to set benchmark video file paths

### DIFF
--- a/benchmarks/decoders/benchmark_decoders.py
+++ b/benchmarks/decoders/benchmark_decoders.py
@@ -27,6 +27,10 @@ torch._dynamo.config.cache_size_limit = 100
 torch._dynamo.config.capture_dynamic_output_shape_ops = True
 
 
+def in_fbcode() -> bool:
+    return "FB_PAR_RUNTIME_FILES" in os.environ
+
+
 class AbstractDecoder:
     def __init__(self):
         pass
@@ -198,14 +202,13 @@ class TorchAudioDecoder(AbstractDecoder):
 
 
 def get_test_resource_path(filename: str) -> str:
-    if not __package__:
-        return os.path.join(
-            os.path.dirname(__file__), "..", "..", "test", "resources", filename
-        )
-
-    resource = importlib.resources.files(__package__).joinpath(filename)
-    with importlib.resources.as_file(resource) as path:
-        return os.fspath(path)
+    if in_fbcode():
+        resource = importlib.resources.files(__package__).joinpath(filename)
+        with importlib.resources.as_file(resource) as path:
+            return os.fspath(path)
+    return os.path.join(
+        os.path.dirname(__file__), "..", "..", "test", "resources", filename
+    )
 
 
 def create_torchcodec_decoder_from_file(video_file):

--- a/benchmarks/decoders/benchmark_decoders.py
+++ b/benchmarks/decoders/benchmark_decoders.py
@@ -197,8 +197,12 @@ class TorchAudioDecoder(AbstractDecoder):
         return frames
 
 
-def get_video_path(filename: str) -> str:
-    return os.path.join("/home/ahmads/personal/torchcodec/test/resources", filename)
+def get_test_resource_path(filename: str) -> str:
+    if not __package__:
+        return os.path.join(
+            os.path.dirname(__file__), "..", "..", "test", "resources", filename
+        )
+
     resource = importlib.resources.files(__package__).joinpath(filename)
     with importlib.resources.as_file(resource) as path:
         return os.fspath(path)
@@ -243,13 +247,13 @@ def main() -> None:
         "--bm_large_video_path",
         help="Path to the large video file to benchmark",
         type=str,
-        default=get_video_path("853.mp4"),
+        default=get_test_resource_path("853.mp4"),
     )
     parser.add_argument(
         "--bm_small_video_path",
         help="Path to the small video file to benchmark",
         type=str,
-        default=get_video_path("nasa_13013.mp4"),
+        default=get_test_resource_path("nasa_13013.mp4"),
     )
 
     args = parser.parse_args()

--- a/benchmarks/decoders/benchmark_decoders.py
+++ b/benchmarks/decoders/benchmark_decoders.py
@@ -198,6 +198,7 @@ class TorchAudioDecoder(AbstractDecoder):
 
 
 def get_video_path(filename: str) -> str:
+    return os.path.join("/home/ahmads/personal/torchcodec/test/resources", filename)
     resource = importlib.resources.files(__package__).joinpath(filename)
     with importlib.resources.as_file(resource) as path:
         return os.fspath(path)
@@ -238,15 +239,27 @@ def main() -> None:
         type=float,
         default=2.0,
     )
+    parser.add_argument(
+        "--bm_large_video_path",
+        help="Path to the large video file to benchmark",
+        type=str,
+        default=get_video_path("853.mp4"),
+    )
+    parser.add_argument(
+        "--bm_small_video_path",
+        help="Path to the small video file to benchmark",
+        type=str,
+        default=get_video_path("nasa_13013.mp4"),
+    )
 
     args = parser.parse_args()
 
     # These are the PTS values we want to extract from the small video.
     small_pts_to_extract = [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
-    small_video_path = get_video_path("nasa_13013.mp4")
+    small_video_path = args.bm_small_video_path
 
     large_pts_to_extract = [0.0, 1.0, 2.0, 3.0, 4.0]
-    large_video_path = get_video_path("853.mp4")
+    large_video_path = args.bm_large_video_path
 
     decoder_dict = {}
     decoder_dict["DecordNonBatchDecoderAccurateSeek"] = (


### PR DESCRIPTION
We don't actually have a large video file in the repo by design (to keep the repo lightweight).

So we add a flag to specify it.

```
python benchmarks/decoders/benchmark_decoders.py --bm_large_video_path=/home/ahmads/jupyter/853.mp4
[------------------------------- decode latency for function call pattern for 700KB video ------------------------------]
                                             |  10 seek()+next()  |  1 next()  |  10 next()  |  100 next()  |  200 next()
1 threads: --------------------------------------------------------------------------------------------------------------
      DecordNonBatchDecoderAccurateSeek      |        71.2        |    22.5    |     29.8    |     94.7     |    135.5   
      TorchCodecDecoderNonCompiled           |       111.9        |    36.0    |     41.0    |     85.5     |    130.9   
      TCNonCompiled:ffmpeg_thread_count=1    |       173.5        |    20.1    |     26.1    |     90.3     |    169.7   
      TorchCodecDecoderCompiled              |       101.3        |    33.3    |     40.3    |     85.1     |    132.0   
      TVNewAPIDecoderWithBackendVideoReader  |       437.5        |    15.2    |     21.2    |     64.3     |    121.2   
      TorchAudioDecoder                      |       395.9        |     8.0    |     16.9    |     84.2     |    172.6   

Times are in milliseconds (ms).

[--------------- decode latency for function call pattern for 50MB video ----------------]
                                             |  5 seek()+next()  |  1 next()  |  10 next()
1 threads: -------------------------------------------------------------------------------
      DecordNonBatchDecoderAccurateSeek      |       1475.0      |   331.7    |     635.3 
      TorchCodecDecoderNonCompiled           |       1360.8      |   296.1    |     466.1 
      TCNonCompiled:ffmpeg_thread_count=1    |       7412.2      |   224.7    |     769.1 
      TorchCodecDecoderCompiled              |       1253.5      |   270.3    |     425.4 
      TVNewAPIDecoderWithBackendVideoReader  |      14022.6      |   298.3    |    1149.8 
      TorchAudioDecoder                      |      13059.1      |   315.1    |    1047.5 

Times are in milliseconds (ms).

[ creation latency for function call pattern for 50MB video ]
                         |  creation+next time
1 threads: -----------------------------------
      TorchCodecDecoder  |        293.6       

Times are in milliseconds (ms).
```