### PR TITLE
Lower size of temporary buffer used by ffmpeg

### DIFF
--- a/src/torchcodec/decoders/_core/VideoDecoder.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoder.cpp
@@ -71,7 +71,7 @@ AVInput createAVFormatContextFromBuffer(const void* buffer, size_t length) {
   TORCH_CHECK(
       toReturn.formatContext.get() != nullptr,
       "Unable to alloc avformat context");
-  constexpr int kAVIOInternalTemporaryBufferSize = 4 * 1024 * 1024;
+  constexpr int kAVIOInternalTemporaryBufferSize = 64 * 1024;
   toReturn.ioBytesContext.reset(
       new AVIOBytesContext(buffer, length, kAVIOInternalTemporaryBufferSize));
   if (!toReturn.ioBytesContext) {


### PR DESCRIPTION
This improves the performance when we decode from memory. We don't actually need that much temporary memory for decoding.

Baseline:

```
[ Sampling 1 clips of 4 frames from a video /home/ahmads/jupyter/carmel1.mp4 ]
                        |  latency to sample 1 clips of 4 frames
1 threads: -----------------------------------------------------
      torchvision       |                   49.0                
      torchcodec_index  |                  244.8                

Times are in milliseconds (ms).

[ Sampling 1 clips of 4 frames from a video /home/ahmads/jupyter/853.mp4 ]
                        |  latency to sample 1 clips of 4 frames
1 threads: -----------------------------------------------------
      torchvision       |                  576.6                
      torchcodec_index  |                  826.0                

Times are in milliseconds (ms).
```

After this change:


```
[ Sampling 1 clips of 4 frames from a video /home/ahmads/jupyter/carmel1.mp4 ]
                        |  latency to sample 1 clips of 4 frames
1 threads: -----------------------------------------------------
      torchvision       |                   50.0                
      torchcodec_index  |                  237.8                

Times are in milliseconds (ms).

[ Sampling 1 clips of 4 frames from a video /home/ahmads/jupyter/853.mp4 ]
                        |  latency to sample 1 clips of 4 frames
1 threads: -----------------------------------------------------
      torchvision       |                  570.8                
      torchcodec_index  |                  787.6                

Times are in milliseconds (ms).

```