### PR TITLE
Add Mac to FFmpeg build CI

### DIFF
--- a/.github/workflows/build_ffmpeg.yaml
+++ b/.github/workflows/build_ffmpeg.yaml
@@ -6,7 +6,7 @@
 #
 # This job does not include the uploading part.
 # Upload needs to be done manually, and it should be done only once
-# par new major release of FFmepg.
+# per new major release of FFmepg.
 name: Build non-GPL FFmpeg from source
 
 on:
@@ -20,26 +20,47 @@ defaults:
 
 jobs:
   LGPL-Linux-x86_64:
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         ffmpeg-version: ["4.4.4", "5.1.4", "6.1.1", "7.0.1"]
-    steps:
-      - name: Check out repo
-        uses: actions/checkout@v3
-      - name: Build FFmpeg
-        run: |
-          export FFMPEG_VERSION="${{ matrix.ffmpeg-version }}"
-          export FFMPEG_ROOT="${PWD}/ffmpeg"
+    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+    with:
+      job-name: Build
+      upload-artifact: ffmpeg-lgpl
+      repository: pytorch/torchcodec
+      script: |
+        export FFMPEG_VERSION="${{ matrix.ffmpeg-version }}"
+        export FFMPEG_ROOT="${PWD}/ffmpeg"
 
-          packaging/build_ffmpeg.sh
+        packaging/build_ffmpeg.sh
 
-          tar -czf ffmpeg.tar.gz ffmpeg/include ffmpeg/lib
+        tar -cf ffmpeg.tar.gz ffmpeg/include ffmpeg/lib
 
-          mkdir -p artifact_dir
-          mv ffmpeg.tar.gz artifact_dir/ffmpeg_"${FFMPEG_VERSION}".tar.gz
-      - uses: actions/upload-artifact@v4
-        with:
-          name: "ffmpeg_${{ matrix.ffmpeg-version }}_linux_x86_64"
-          path: artifact_dir
+        artifact_dir="${RUNNER_ARTIFACT_DIR}/$(date +%Y-%m-%d)/linux_x86_64"
+        mkdir -p "${artifact_dir}"
+        mv ffmpeg.tar.gz "${artifact_dir}/${FFMPEG_VERSION}.tar.gz"
+
+  LGPL-macOS:
+    strategy:
+      fail-fast: false
+      matrix:
+        ffmpeg-version: ["4.4.4", "5.1.4", "6.1.1", "7.0.1"]
+        runner: ["macos-m1-stable", "macos-12"]
+    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
+    with:
+      job-name: Build
+      upload-artifact: ffmpeg-lgpl
+      repository: pytorch/torchcodec
+      runner: "${{ matrix.runner }}"
+      script: |
+        export FFMPEG_VERSION="${{ matrix.ffmpeg-version }}"
+        export FFMPEG_ROOT="${PWD}/ffmpeg"
+
+        packaging/build_ffmpeg.sh
+
+        tar -cf ffmpeg.tar.gz ffmpeg/include ffmpeg/lib
+
+        artifact_dir="${RUNNER_ARTIFACT_DIR}/$(date +%Y-%m-%d)/macos_$(uname -m)"
+        mkdir -p "${artifact_dir}"
+        mv ffmpeg.tar.gz "${artifact_dir}/${FFMPEG_VERSION}.tar.gz"


### PR DESCRIPTION
Adds a Mac build of the FFmpeg non-GPL libraries. The code is lifted almost verbatim from [TorchAudio's setup](https://github.com/pytorch/audio/blob/97ed7b36b7a741253d4e41e4da3c901d83294503/.github/workflows/ffmpeg.yml#L60), which reuses [pytorch/test-infra](https://github.com/pytorch/test-infra). Note there are subtle differences between our current Linux job spec and this new one for Mac - those differences are necessary to work with pytorch/test-infra's setup.

Since this action will only execute once a week on Sunday, I tested it by temporarily hacking it to run on a pull request. See the result of one of those runs to see successful execution: https://github.com/pytorch/torchcodec/actions/runs/10730119629