### PR TITLE
Remove x86 Mac from non-GPL FFmpeg builds

### DIFF
--- a/.github/workflows/build_ffmpeg.yaml
+++ b/.github/workflows/build_ffmpeg.yaml
@@ -46,7 +46,7 @@ jobs:
       fail-fast: false
       matrix:
         ffmpeg-version: ["4.4.4", "5.1.4", "6.1.1", "7.0.1"]
-        runner: ["macos-m1-stable", "macos-12"]
+        runner: ["macos-m1-stable"]
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
     with:
       job-name: Build


### PR DESCRIPTION
As @NicolasHug pointed out, PyTorch no longer supports x86 Macs as of version 2.4. Because TorchCodec requires 2.4, that also means TorchCodec can't work on x86 Macs either. That means we should remove it from our non-GPL FFmpeg builds, as we will never be able to do a x86 Mac build.