### PR TITLE
Pass thread count to ffmpeg's filtergraph

### DIFF
--- a/src/torchcodec/decoders/_core/VideoDecoder.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoder.cpp
@@ -254,6 +254,9 @@ void VideoDecoder::initializeFilterGraphForStream(
   }
   filterState.filterGraph.reset(avfilter_graph_alloc());
   TORCH_CHECK(filterState.filterGraph.get() != nullptr);
+  if (options.ffmpegThreadCount.has_value()) {
+    filterState.filterGraph->nb_threads = options.ffmpegThreadCount.value();
+  }
   const AVFilter* buffersrc = avfilter_get_by_name("buffer");
   const AVFilter* buffersink = avfilter_get_by_name("buffersink");
   enum AVPixelFormat pix_fmts[] = {AV_PIX_FMT_RGB24, AV_PIX_FMT_NONE};


### PR DESCRIPTION
Summary: This ensures that ffmpeg does not create it's own thread pool when asked not to. Otherwise we pay the cost of passing work around between these 2 thread pools.

Differential Revision: D62141413
