### PR TITLE
Add rpath fixups to Mac non-GPL FFmpeg build

### DIFF
--- a/packaging/build_ffmpeg.sh
+++ b/packaging/build_ffmpeg.sh
@@ -64,3 +64,96 @@ tar -xf ffmpeg.tar.gz --strip-components 1
 
 make -j install
 ls ${prefix}/*
+
+# macos: Fix rpath so that the libraries are searched dynamically in user environment.
+# In Linux, this is handled by `--enable-rpath` flag.
+if [[ "$(uname)" == Darwin ]]; then
+    ffmpeg_version="${FFMPEG_VERSION:-4.1.8}"
+    major_ver=${ffmpeg_version:0:1}
+    if [[ ${major_ver} == 4 ]]; then
+        avutil=libavutil.56
+        avcodec=libavcodec.58
+        avformat=libavformat.58
+        avdevice=libavdevice.58
+        avfilter=libavfilter.7
+    elif [[ ${major_ver} == 5 ]]; then
+        avutil=libavutil.57
+        avcodec=libavcodec.59
+        avformat=libavformat.59
+        avdevice=libavdevice.59
+        avfilter=libavfilter.8
+    elif [[ ${major_ver} == 6 ]]; then
+        avutil=libavutil.58
+        avcodec=libavcodec.60
+        avformat=libavformat.60
+        avdevice=libavdevice.60
+        avfilter=libavfilter.9
+    elif [[ ${major_ver} == 7 ]]; then
+        avutil=libavutil.59
+        avcodec=libavcodec.61
+        avformat=libavformat.61
+        avdevice=libavdevice.61
+        avfilter=libavfilter.10
+    else
+        printf "Error: unexpected FFmpeg major version: %s\n"  ${major_ver}
+        exit 1;
+    fi
+
+    otool="/usr/bin/otool"
+    # NOTE: miniconda has a version of otool and install_name_tool installed and we want
+    #       to use the default sytem version instead of the miniconda version since the miniconda
+    #       version can produce inconsistent results
+
+    # Attempt to use /usr/bin/otool as our default otool
+    if [[ ! -e ${otool} ]]; then
+        otool="$(which otool)"
+    fi
+    install_name_tool="/usr/bin/install_name_tool"
+    # Attempt to use /usr/bin/install_name_tool as our default install_name_tool
+    if [[ ! -e ${install_name_tool} ]]; then
+        install_name_tool="$(which install_name_tool)"
+    fi
+
+    # list up the paths to fix
+    for lib in ${avcodec} ${avdevice} ${avfilter} ${avformat} ${avutil}; do
+        ${otool} -l ${prefix}/lib/${lib}.dylib | grep -B2 ${prefix}
+    done
+
+    # Replace the hardcoded paths to @rpath
+    ${install_name_tool} \
+        -change ${prefix}/lib/${avutil}.dylib @rpath/${avutil}.dylib \
+        -delete_rpath ${prefix}/lib \
+        -id @rpath/${avcodec}.dylib \
+        ${prefix}/lib/${avcodec}.dylib
+    ${otool} -l ${prefix}/lib/${avcodec}.dylib | grep -B2 ${prefix}
+
+    ${install_name_tool} \
+        -change ${prefix}/lib/${avformat}.dylib @rpath/${avformat}.dylib \
+        -change ${prefix}/lib/${avcodec}.dylib @rpath/${avcodec}.dylib \
+        -change ${prefix}/lib/${avutil}.dylib @rpath/${avutil}.dylib \
+        -delete_rpath ${prefix}/lib \
+        -id @rpath/${avdevice}.dylib \
+        ${prefix}/lib/${avdevice}.dylib
+    ${otool} -l ${prefix}/lib/${avdevice}.dylib | grep -B2 ${prefix}
+
+    ${install_name_tool} \
+        -change ${prefix}/lib/${avutil}.dylib @rpath/${avutil}.dylib \
+        -delete_rpath ${prefix}/lib \
+        -id @rpath/${avfilter}.dylib \
+        ${prefix}/lib/${avfilter}.dylib
+    ${otool} -l ${prefix}/lib/${avfilter}.dylib | grep -B2 ${prefix}
+
+    ${install_name_tool} \
+        -change ${prefix}/lib/${avcodec}.dylib @rpath/${avcodec}.dylib \
+        -change ${prefix}/lib/${avutil}.dylib @rpath/${avutil}.dylib \
+        -delete_rpath ${prefix}/lib \
+        -id @rpath/${avformat}.dylib \
+        ${prefix}/lib/${avformat}.dylib
+    ${otool} -l ${prefix}/lib/${avformat}.dylib | grep -B2 ${prefix}
+
+    ${install_name_tool} \
+        -delete_rpath ${prefix}/lib \
+        -id @rpath/${avutil}.dylib \
+        ${prefix}/lib/${avutil}.dylib
+    ${otool} -l ${prefix}/lib/${avutil}.dylib | grep -B2 ${prefix}
+fi


### PR DESCRIPTION
We had previously thought that the rpath fixup stuff specific to Mac that torchaudio did was not necessary for us. The work I'm doing in #210 indicates that we actually _do_ need this. What leads me to this conclusion is when I do `otool -L` (Mac's equivalent to `ldd`):
```
otool -L src/torchcodec/libtorchcodec4.dylib
src/torchcodec/libtorchcodec4.dylib:
	@rpath/libtorchcodec4.dylib (compatibility version 0.0.0, current version 0.0.0)
	@rpath/libc10.dylib (compatibility version 0.0.0, current version 0.0.0)
	@rpath/libpython3.9.dylib (compatibility version 3.9.0, current version 3.9.0)
	/Users/ec2-user/runner/_work/torchcodec/torchcodec/pytorch/torchcodec/ffmpeg/lib/libavutil.56.dylib (compatibility version 56.0.0, current version 56.70.100)
	/Users/ec2-user/runner/_work/torchcodec/torchcodec/pytorch/torchcodec/ffmpeg/lib/libavcodec.58.dylib (compatibility version 58.0.0, current version 58.134.100)
	/Users/ec2-user/runner/_work/torchcodec/torchcodec/pytorch/torchcodec/ffmpeg/lib/libavformat.58.dylib (compatibility version 58.0.0, current version 58.76.100)
	/Users/ec2-user/runner/_work/torchcodec/torchcodec/pytorch/torchcodec/ffmpeg/lib/libavdevice.58.dylib (compatibility version 58.0.0, current version 58.13.100)
	/Users/ec2-user/runner/_work/torchcodec/torchcodec/pytorch/torchcodec/ffmpeg/lib/libavfilter.7.dylib (compatibility version 7.0.0, current version 7.110.100)
	@rpath/libtorch.dylib (compatibility version 0.0.0, current version 0.0.0)
	@rpath/libtorch_cpu.dylib (compatibility version 0.0.0, current version 0.0.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 1700.2[55](https://github.com/pytorch/torchcodec/actions/runs/10841142043/job/30084689904?pr=210#step:9:56).0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1345.100.2)
```
Note that things like libc++ and libtorch have `@rpath/` in front of them, indicating (I believe) that they can be dynamically loaded. The FFmpeg libraries are hard-coded to where they were during build time. This causes failures at import time, because the libraries can't be found.

In order to test, I had versions of this PR where I hacked the build_ffmpeg.yaml workflow to run on the pull request. It succeeds: https://github.com/pytorch/torchcodec/actions/runs/10842665681