### PR TITLE
Fix video download in basic example

### DIFF
--- a/examples/basic_example.py
+++ b/examples/basic_example.py
@@ -26,7 +26,7 @@ import requests
 # Video source: https://www.pexels.com/video/dog-eating-854132/
 # License: CC0. Author: Coverr.
 url = "https://videos.pexels.com/video-files/854132/854132-sd_640_360_25fps.mp4"
-response = requests.get(url)
+response = requests.get(url, headers={"User-Agent": ""})
 if response.status_code != 200:
     raise RuntimeError(f"Failed to download video. {response.status_code = }.")
 


### PR DESCRIPTION
Closes https://github.com/pytorch/torchcodec/pull/216
Partially addresses https://github.com/pytorch/torchcodec/issues/203

Looks like pexels started requiring the GET request to have a "User-Agent" header field. The solution was inspired from https://stackoverflow.com/questions/38489386/how-to-fix-403-forbidden-errors-when-calling-apis-using-python-requests.

I prefer going for this solution rather than https://github.com/pytorch/torchcodec/pull/216, but happy to reconsider if downloading the video keeps bringing flakyness to our CI.