### PR TITLE
Docs CI build installs PyTorch using official command

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -28,7 +28,9 @@ jobs:
         run: python -m pip install --upgrade pip
       - name: Install dependencies and FFmpeg
         run: |
-          python -m pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cpu
+          # TODO: torchvision and torchaudio shouldn't be needed. They were only added
+          #  to silence an error as seen in https://github.com/pytorch/torchcodec/issues/203
+          python -m pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu
           conda install "ffmpeg=7.0.1" pkg-config -c conda-forge
           ffmpeg -version
       - name: Build and install torchcodec


### PR DESCRIPTION
The Docs build was installing PyTorch but not TorchVision and TorchAudio. The official instructions say to install both of them, see: https://pytorch.org/get-started/locally/. This seems to fix our docs build. This PR, with #217, should resolve Issue #203.