### PR TITLE
Added swscale to FFMPEG build job

### DIFF
--- a/.github/workflows/build_ffmpeg.yaml
+++ b/.github/workflows/build_ffmpeg.yaml
@@ -10,15 +10,9 @@
 name: Build non-GPL FFmpeg from source
 
 on:
-  pull_request:
-  push:
-    branches:
-      - nightly
-      - main
-      - release/*
-    tags:
-        - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
   workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 0'  # on sunday
 
 defaults:
   run:

--- a/.github/workflows/build_ffmpeg.yaml
+++ b/.github/workflows/build_ffmpeg.yaml
@@ -10,9 +10,15 @@
 name: Build non-GPL FFmpeg from source
 
 on:
+  pull_request:
+  push:
+    branches:
+      - nightly
+      - main
+      - release/*
+    tags:
+        - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
   workflow_dispatch:
-  schedule:
-    - cron: '0 0 * * 0'  # on sunday
 
 defaults:
   run:

--- a/packaging/build_ffmpeg.sh
+++ b/packaging/build_ffmpeg.sh
@@ -60,7 +60,8 @@ tar -xf ffmpeg.tar.gz --strip-components 1
     --enable-avdevice \
     --enable-avfilter \
     --enable-avformat \
-    --enable-avutil
+    --enable-avutil \
+    --enable-swscale
 
 make -j install
 ls ${prefix}/*

--- a/packaging/build_ffmpeg.sh
+++ b/packaging/build_ffmpeg.sh
@@ -76,24 +76,28 @@ if [[ "$(uname)" == Darwin ]]; then
         avformat=libavformat.58
         avdevice=libavdevice.58
         avfilter=libavfilter.7
+        swscale=libswscale.5
     elif [[ ${major_ver} == 5 ]]; then
         avutil=libavutil.57
         avcodec=libavcodec.59
         avformat=libavformat.59
         avdevice=libavdevice.59
         avfilter=libavfilter.8
+        swscale=libswscale.6
     elif [[ ${major_ver} == 6 ]]; then
         avutil=libavutil.58
         avcodec=libavcodec.60
         avformat=libavformat.60
         avdevice=libavdevice.60
         avfilter=libavfilter.9
+        swscale=libswscale.7
     elif [[ ${major_ver} == 7 ]]; then
         avutil=libavutil.59
         avcodec=libavcodec.61
         avformat=libavformat.61
         avdevice=libavdevice.61
         avfilter=libavfilter.10
+        swscale=libswscale.8
     else
         printf "Error: unexpected FFmpeg major version: %s\n"  ${major_ver}
         exit 1;
@@ -115,7 +119,7 @@ if [[ "$(uname)" == Darwin ]]; then
     fi
 
     # list up the paths to fix
-    for lib in ${avcodec} ${avdevice} ${avfilter} ${avformat} ${avutil}; do
+    for lib in ${avcodec} ${avdevice} ${avfilter} ${avformat} ${avutil} ${swscale}; do
         ${otool} -l ${prefix}/lib/${lib}.dylib | grep -B2 ${prefix}
     done
 
@@ -142,6 +146,13 @@ if [[ "$(uname)" == Darwin ]]; then
         -id @rpath/${avfilter}.dylib \
         ${prefix}/lib/${avfilter}.dylib
     ${otool} -l ${prefix}/lib/${avfilter}.dylib | grep -B2 ${prefix}
+
+    ${install_name_tool} \
+        -change ${prefix}/lib/${avutil}.dylib @rpath/${avutil}.dylib \
+        -delete_rpath ${prefix}/lib \
+        -id @rpath/${swscale}.dylib \
+        ${prefix}/lib/${swscale}.dylib
+    ${otool} -l ${prefix}/lib/${swscale}.dylib | grep -B2 ${prefix}
 
     ${install_name_tool} \
         -change ${prefix}/lib/${avcodec}.dylib @rpath/${avcodec}.dylib \


### PR DESCRIPTION
Before this diff we were not building and creating swscale binaries to be uploaded to S3.

We will be explicitly depending on swscale after https://github.com/pytorch/torchcodec/pull/205, so this diff is in preparation for that.

Note that swscale only depends on avutil so that's the only rpath we need to fix.

```
ldd /home/ahmads/.conda/envs/lerobot9/lib/libswscale.so | grep av
        libavutil.so.59 => /home/ahmads/.conda/envs/lerobot9/lib/./libavutil.so.59 (0x00007fef24000000)
```


```
tar xf ./2024-09-23/macos_arm64/7.0.1.tar.gz -C ffmpeg7                                                                                                                                                       

(base)
ahmads@ahmads-mbp ~/w/ffmpeg_build> ls                                                                                                                                                                                                            

(base)
2024-09-23/ ffmpeg7/

ahmads@ahmads-mbp ~/w/ffmpeg_build> find ffmpeg7/ | grep swscale                                                                                                                                                                                  (base)
ffmpeg7//ffmpeg/include/libswscale
ffmpeg7//ffmpeg/include/libswscale/version.h
ffmpeg7//ffmpeg/include/libswscale/swscale.h
ffmpeg7//ffmpeg/include/libswscale/version_major.h
ffmpeg7//ffmpeg/lib/libswscale.dylib
ffmpeg7//ffmpeg/lib/pkgconfig/libswscale.pc
ffmpeg7//ffmpeg/lib/libswscale.8.1.100.dylib
ffmpeg7//ffmpeg/lib/libswscale.8.dylib
ahmads@ahmads-mbp ~/w/ffmpeg_build> otool -L ffmpeg7//ffmpeg/lib/libswscale.8.dylib                                                                                                                                                               

(base)
ffmpeg7//ffmpeg/lib/libswscale.8.dylib:
	@rpath/libswscale.8.dylib (compatibility version 8.0.0, current version 8.1.100)
	@rpath/libavutil.59.dylib (compatibility version 59.0.0, current version 59.8.100)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1345.100.2)
	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 2419.0.0)
	/System/Library/Frameworks/CoreVideo.framework/Versions/A/CoreVideo (compatibility version 1.2.0, current version 1.5.0)
	/System/Library/Frameworks/CoreMedia.framework/Versions/A/CoreMedia (compatibility version 1.0.0, current version 1.0.0)
```