### PR TITLE
Update install instructions to explicitly mention PyTorch 2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,29 +95,28 @@ ffmpeg -f lavfi -i \
 ## Installing TorchCodec
 
 Note: if you're on MacOS, you'll need to [build from source](./CONTRIBUTING.md).
-Instructions below assume you're on Linux.
+The instructions below assume you're on Linux.
 
-First install the latest stable version of PyTorch following the [official
-instructions](https://pytorch.org/get-started/locally/).
+  1. Install the latest stable version of PyTorch following the
+     [official instructions](https://pytorch.org/get-started/locally/). TorchCodec
+     requires [PyTorch 2.4](https://pytorch.org/docs/2.4/).
 
-Then:
+  2. Install FFmpeg, if it's not already installed. Your Linux distribution probably
+     comes with FFmpeg pre-installed. TorchCodec supports all major FFmpeg versions
+     in [4, 7].
 
-```bash
-pip install torchcodec
-```
-You will also need FFmpeg installed on your system, and TorchCodec decoding
-capabilities are determined by your underlying FFmpeg installation. There are
-different options to install FFmpeg e.g.:
+     If FFmpeg is not already installed, or you need a later version, install it with:
 
-```bash
-conda install ffmpeg
-# or
-conda install ffmpeg -c conda-forge
-```
+     ```bash
+     conda install ffmpeg
+     # or
+     conda install ffmpeg -c conda-forge
+     ```
+  3. Install TorchCodec:
 
-Your Linux distribution probably comes with FFmpeg pre-installed as well.
-TorchCodec supports all major FFmpeg version in [4, 7].
-
+     ```bash
+     pip install torchcodec
+     ```
 
 ## Planned future work
 

--- a/docs/source/install_instructions.rst
+++ b/docs/source/install_instructions.rst
@@ -5,27 +5,27 @@ Installation Instructions
     TorchCodec is only available on Linux for now. We plan to support other
     platforms in the future.
 
-Installing torchcodec should be as simple as:
+There are three steps to installing TorchCodec:
 
-.. code:: bash
+1. Install the latest stable version of PyTorch following the
+   `official instructions <https://pytorch.org/get-started/locally/>`_. TorchCodec
+   requires `PyTorch 2.4 <https://pytorch.org/docs/2.4/>`_.
 
-    pip install torchcodec
+2. Install FFmpeg, if it's not already installed. Your Linux distribution probably
+   comes with FFmpeg pre-installed. TorchCodec supports all major FFmpeg versions
+   in [4, 7]. If FFmpeg is not already installed, or you need a later version, install
+   it with:
 
-You will need a working PyTorch installation, which you can install following
-the `official instructions <https://pytorch.org/get-started/locally/>`_.
+   .. code:: bash
 
-You will also need FFmpeg installed on your system, and TorchCodec decoding
-capabilities are determined by your underlying FFmpeg installation. There are
-different options to install FFmpeg e.g.:
+      conda install ffmpeg
+      # or
+      conda install ffmpeg -c conda-forge
+3. Install TorchCodec:
 
-.. code:: bash
+   .. code:: bash
 
-    conda install ffmpeg
-    # or
-    conda install ffmpeg -c conda-forge
-
-Your Linux distribution probably comes with FFmpeg pre-installed as well.
-TorchCodec supports all major FFmpeg version in [4, 7].
+      pip install torchcodec
 
 Note that installation instructions may slightly change over time. The most
 up-to-date instructions should be available from the `README


### PR DESCRIPTION
We did not explicitly mention that we need PyTorch 2.4. It was only implied by telling folks to get the latest stable version of PyTorch.

I'm also doing some minor editing on the text to list requirements first, then ending with how to install TorchCodec.