### PR TITLE
Add PyTorch 2.4 as a possible reason for libtorchodec failing to load

### DIFF
--- a/src/torchcodec/decoders/_core/video_decoder_ops.py
+++ b/src/torchcodec/decoders/_core/video_decoder_ops.py
@@ -42,9 +42,13 @@ def load_torchcodec_extension():
         + "\n[end of libtorchcodec loading traceback]."
     )
     raise RuntimeError(
-        "Could not load libtorchcodec. "
-        "Is FFmpeg (4, 5, 6, or 7) properly installed in your environment? "
-        "The following exceptions were raised as we tried to load libtorchcodec: "
+        """Could not load libtorchcodec. Likely causes:
+          1. FFmpeg is not properly installed in your environment. We support
+             verisons 4, 5, 6 and 7.
+          2. PyTorch 2.4 is not properly installed in your environment.
+          3. Another runtime dependency; see exceptions below.
+        The following exceptions were raised as we tried to load libtorchcodec:
+        """
         f"{traceback}"
     )
 


### PR DESCRIPTION
If we fail to load `libtorchcodecN`, where `N=[4, 5, 6, 7]`, we currently blame FFmpeg not being installed correctly. However, we another strict dependency, which is PyTorch 2.4. If, for example, the user has the correct FFmpeg installed but they're still on PyTorch 2.3, `libtorchcodec` will also fail to load. This PR changes the error message to indicate the two most likely problems.

We _could_ try to be clever and search for string related to FFmpeg or PyTorch in the exception and hint the user in that direction, but let's keep this simple for now.