### PR TITLE
Add precommit hooks for clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,114 @@
+# The primary clang-format config file.
+# TODO(afuller): Set these settings when they aren't broken:
+# - AllowShortBlocksOnASingleLine: Empty
+---
+AccessModifierOffset: -1
+AlignAfterOpenBracket: AlwaysBreak
+AlignConsecutiveMacros: false
+AlignConsecutiveAssignments: false
+AlignConsecutiveBitFields: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands: DontAlign
+AlignTrailingComments: false
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortEnumsOnASingleLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: false
+BinPackParameters: false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: false
+ColumnLimit: 80
+CommentPragmas: '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat: false
+FixNamespaceComments: true
+ForEachMacros:
+  - FOR_EACH
+  - FOR_EACH_R
+  - FOR_EACH_RANGE
+IncludeBlocks: Preserve
+IncludeCategories:
+  - Regex:           '^<.*\.h(pp)?>'
+    Priority:        1
+  - Regex:           '^<.*'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        3
+IndentCaseLabels: true
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentExternBlock: AfterExternBlock
+IndentWidth: 2
+IndentWrappedFunctionNames: false
+InsertTrailingCommas: None
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd: ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: false
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+ReflowComments: true
+SortIncludes: true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+Standard: Latest
+TabWidth: 8
+UseCRLF: false
+UseTab: Never
+...

--- a/.clang-format
+++ b/.clang-format
@@ -1,6 +1,3 @@
-# The primary clang-format config file.
-# TODO(afuller): Set these settings when they aren't broken:
-# - AllowShortBlocksOnASingleLine: Empty
 ---
 AccessModifierOffset: -1
 AlignAfterOpenBracket: AlwaysBreak

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -36,6 +36,7 @@ jobs:
         run: |
           python -m pip install pre-commit
       - name: Run pre-commit checks
+        continue-on-error: true
         run: |
           pre-commit run --all-files
       - name: Check to see what files pre-commit modified

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -39,6 +39,7 @@ jobs:
         run: |
           pre-commit run --all-files
       - name: Check to see what files pre-commit modified
+        run: |
           git diff
 
   mypy:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -36,6 +36,7 @@ jobs:
         run: |
           python -m pip install pre-commit
       - name: Run pre-commit checks
+        # Continue on error to display the formatting diff in case lint fails.
         continue-on-error: true
         run: |
           pre-commit run --all-files

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -38,6 +38,7 @@ jobs:
       - name: Run pre-commit checks
         run: |
           pre-commit run --all-files
+      - name: Check to see what files pre-commit modified
           git diff
 
   mypy:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -38,6 +38,7 @@ jobs:
       - name: Run pre-commit checks
         run: |
           pre-commit run --all-files
+          git diff
 
   mypy:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
         args: [--config=.flake8]
 
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v13.0.0
+    rev: v18.1.3
     hooks:
       - id: clang-format
         name: clang-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,3 +27,11 @@ repos:
     hooks:
       - id: flake8
         args: [--config=.flake8]
+
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v13.0.0
+    hooks:
+      - id: clang-format
+        name: clang-format
+        files: \.(cpp|hpp|c|h)$
+        types: [file]

--- a/src/torchcodec/decoders/_core/VideoDecoder.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoder.cpp
@@ -674,8 +674,7 @@ VideoDecoder::DecodedOutput VideoDecoder::getDecodedOutputWithFilter(
       StreamInfo& streamInfo = streams_[streamIndex];
       ffmpegStatus =
           avcodec_receive_frame(streamInfo.codecContext.get(), frame.get());
-      VLOG(9) << "received frame"
-              << " status=" << ffmpegStatus
+      VLOG(9) << "received frame" << " status=" << ffmpegStatus
               << " streamIndex=" << streamInfo.stream->index;
       bool gotNonRetriableError =
           ffmpegStatus != AVSUCCESS && ffmpegStatus != AVERROR(EAGAIN);

--- a/src/torchcodec/decoders/_core/VideoDecoder.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoder.cpp
@@ -13,6 +13,7 @@
 
 extern "C" {
 #include <libavcodec/avcodec.h>
+
 #include <libavfilter/buffersink.h>
 #include <libavfilter/buffersrc.h>
 #include <libavformat/avformat.h>
@@ -674,7 +675,8 @@ VideoDecoder::DecodedOutput VideoDecoder::getDecodedOutputWithFilter(
       StreamInfo& streamInfo = streams_[streamIndex];
       ffmpegStatus =
           avcodec_receive_frame(streamInfo.codecContext.get(), frame.get());
-      VLOG(9) << "received frame" << " status=" << ffmpegStatus
+      VLOG(9) << "received frame"
+              << " status=" << ffmpegStatus
               << " streamIndex=" << streamInfo.stream->index;
       bool gotNonRetriableError =
           ffmpegStatus != AVSUCCESS && ffmpegStatus != AVERROR(EAGAIN);

--- a/src/torchcodec/decoders/_core/VideoDecoder.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoder.cpp
@@ -13,7 +13,6 @@
 
 extern "C" {
 #include <libavcodec/avcodec.h>
-
 #include <libavfilter/buffersink.h>
 #include <libavfilter/buffersrc.h>
 #include <libavformat/avformat.h>


### PR DESCRIPTION
I added the clang-format file from that we have been using while developing TorchCodec so far.

```
pre-commit run --all-files
check docstring is first.................................................Passed
trim trailing whitespace.................................................Passed
check toml...............................................................Passed
check yaml...............................................................Passed
mixed line ending........................................................Passed
fix end of files.........................................................Passed
check for added large files..............................................Passed
Format files with µfmt...................................................Passed
flake8...................................................................Passed
clang-format.............................................................Passed
```