### PR TITLE
Use swscale for color conversion unless we are forced to do otherwise

### DIFF
--- a/.github/workflows/linux_wheel.yaml
+++ b/.github/workflows/linux_wheel.yaml
@@ -124,4 +124,4 @@ jobs:
           python test/decoders/manual_smoke_test.py
       - name: Run Python tests
         run: |
-          pytest test
+          pytest test -vvv

--- a/src/torchcodec/decoders/_core/FFMPEGCommon.cpp
+++ b/src/torchcodec/decoders/_core/FFMPEGCommon.cpp
@@ -7,7 +7,6 @@
 #include "src/torchcodec/decoders/_core/FFMPEGCommon.h"
 
 #include <c10/util/Exception.h>
-#include <iostream>
 
 namespace facebook::torchcodec {
 

--- a/src/torchcodec/decoders/_core/FFMPEGCommon.cpp
+++ b/src/torchcodec/decoders/_core/FFMPEGCommon.cpp
@@ -28,14 +28,6 @@ int64_t getDuration(const AVFrame* frame) {
 #endif
 }
 
-bool canSwsScaleHandleUnalignedData() {
-#if LIBSWSCALE_VERSION_MAJOR < 6
-  return false;
-#else
-  return true;
-#endif
-}
-
 AVIOBytesContext::AVIOBytesContext(
     const void* data,
     size_t data_size,

--- a/src/torchcodec/decoders/_core/FFMPEGCommon.cpp
+++ b/src/torchcodec/decoders/_core/FFMPEGCommon.cpp
@@ -7,6 +7,7 @@
 #include "src/torchcodec/decoders/_core/FFMPEGCommon.h"
 
 #include <c10/util/Exception.h>
+#include <iostream>
 
 namespace facebook::torchcodec {
 
@@ -25,6 +26,14 @@ int64_t getDuration(const AVFrame* frame) {
   return frame->pkt_duration;
 #else
   return frame->duration;
+#endif
+}
+
+bool canSwsScaleHandleUnalignedData() {
+#if LIBSWSCALE_VERSION_MAJOR < 6
+  return false;
+#else
+  return true;
 #endif
 }
 

--- a/src/torchcodec/decoders/_core/FFMPEGCommon.h
+++ b/src/torchcodec/decoders/_core/FFMPEGCommon.h
@@ -94,6 +94,9 @@ std::string getFFMPEGErrorStringFromErrorCode(int errorCode);
 int64_t getDuration(const UniqueAVFrame& frame);
 int64_t getDuration(const AVFrame* frame);
 
+// Returns true if sws_scale can handle unaligned data.
+bool canSwsScaleHandleUnalignedData();
+
 // A struct that holds state for reading bytes from an IO context.
 // We give this to FFMPEG and it will pass it back to us when it needs to read
 // or seek in the memory buffer.

--- a/src/torchcodec/decoders/_core/VideoDecoder.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoder.cpp
@@ -424,15 +424,32 @@ void VideoDecoder::addVideoStreamDecoder(
   updateMetadataWithCodecContext(streamInfo.streamIndex, codecContext);
   streamInfo.options = options;
   int width = options.width.value_or(codecContext->width);
-  auto colorConversionLibrary = options.colorConversionLibrary.value_or(
-      ColorConversionLibrary::FILTERGRAPH);
-  bool useFilterGraph =
-      (colorConversionLibrary != ColorConversionLibrary::SWSCALE);
-  if (useFilterGraph) {
+
+  // Use swscale for color conversion by default because it is faster.
+  VideoDecoder::ColorConversionLibrary autoColorConversionLibrary =
+      ColorConversionLibrary::SWSCALE;
+  // However, swscale requires widths to be multiples of 32:
+  // https://stackoverflow.com/questions/74351955/turn-off-sw-scale-conversion-to-planar-yuv-32-byte-alignment-requirements
+  // so we fall back to filtergraph if the width is not a multiple of 32.
+  if (width % 32 != 0 && !canSwsScaleHandleUnalignedData()) {
+    autoColorConversionLibrary = ColorConversionLibrary::FILTERGRAPH;
+  }
+  // If the user specifies the color conversion library (example in
+  // benchmarks), we use that instead.
+  auto colorConversionLibrary =
+      options.colorConversionLibrary.value_or(autoColorConversionLibrary);
+
+  if (colorConversionLibrary == ColorConversionLibrary::FILTERGRAPH) {
     initializeFilterGraphForStream(streamNumber, options);
     streamInfo.colorConversionLibrary = ColorConversionLibrary::FILTERGRAPH;
-  } else {
+  } else if (colorConversionLibrary == ColorConversionLibrary::SWSCALE) {
     streamInfo.colorConversionLibrary = ColorConversionLibrary::SWSCALE;
+  } else {
+    throw std::invalid_argument(
+        "Invalid colorConversionLibrary=" +
+        std::to_string(static_cast<int>(colorConversionLibrary)) +
+        ". colorConversionLibrary must be either "
+        "filtergraph or swscale.");
   }
 }
 

--- a/src/torchcodec/decoders/_core/VideoDecoder.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoder.cpp
@@ -95,6 +95,19 @@ std::vector<std::string> splitStringWithDelimiters(
   return result;
 }
 
+VideoDecoder::ColorConversionLibrary getDefaultColorConversionLibraryForWidth(
+    int width) {
+  VideoDecoder::ColorConversionLibrary library =
+      VideoDecoder::ColorConversionLibrary::SWSCALE;
+  // However, swscale requires widths to be multiples of 32:
+  // https://stackoverflow.com/questions/74351955/turn-off-sw-scale-conversion-to-planar-yuv-32-byte-alignment-requirements
+  // so we fall back to filtergraph if the width is not a multiple of 32.
+  if (width % 32 != 0) {
+    library = VideoDecoder::ColorConversionLibrary::FILTERGRAPH;
+  }
+  return library;
+}
+
 } // namespace
 
 VideoDecoder::VideoStreamDecoderOptions::VideoStreamDecoderOptions(
@@ -426,18 +439,12 @@ void VideoDecoder::addVideoStreamDecoder(
   int width = options.width.value_or(codecContext->width);
 
   // Use swscale for color conversion by default because it is faster.
-  VideoDecoder::ColorConversionLibrary autoColorConversionLibrary =
-      ColorConversionLibrary::SWSCALE;
-  // However, swscale requires widths to be multiples of 32:
-  // https://stackoverflow.com/questions/74351955/turn-off-sw-scale-conversion-to-planar-yuv-32-byte-alignment-requirements
-  // so we fall back to filtergraph if the width is not a multiple of 32.
-  if (width % 32 != 0 && !canSwsScaleHandleUnalignedData()) {
-    autoColorConversionLibrary = ColorConversionLibrary::FILTERGRAPH;
-  }
+  VideoDecoder::ColorConversionLibrary defaultColorConversionLibrary =
+      getDefaultColorConversionLibraryForWidth(width);
   // If the user specifies the color conversion library (example in
   // benchmarks), we use that instead.
   auto colorConversionLibrary =
-      options.colorConversionLibrary.value_or(autoColorConversionLibrary);
+      options.colorConversionLibrary.value_or(defaultColorConversionLibrary);
 
   if (colorConversionLibrary == ColorConversionLibrary::FILTERGRAPH) {
     initializeFilterGraphForStream(streamNumber, options);

--- a/src/torchcodec/decoders/_core/VideoDecoder.h
+++ b/src/torchcodec/decoders/_core/VideoDecoder.h
@@ -145,7 +145,7 @@ class VideoDecoder {
     // is the same as the original video.
     std::optional<int> width;
     std::optional<int> height;
-    std::optional<ColorConversionLibrary> colorConversionLibrary = FILTERGRAPH;
+    std::optional<ColorConversionLibrary> colorConversionLibrary;
   };
   struct AudioStreamDecoderOptions {};
   void addVideoStreamDecoder(

--- a/src/torchcodec/decoders/_core/VideoDecoderOps.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoderOps.cpp
@@ -122,13 +122,7 @@ void add_video_stream(
     std::optional<c10::string_view> dimension_order,
     std::optional<int64_t> stream_index) {
   _add_video_stream(
-      decoder,
-      width,
-      height,
-      num_threads,
-      dimension_order,
-      stream_index,
-      "filtergraph");
+      decoder, width, height, num_threads, dimension_order, stream_index);
 }
 
 void _add_video_stream(

--- a/test/decoders/test_video_decoder_ops.py
+++ b/test/decoders/test_video_decoder_ops.py
@@ -392,6 +392,15 @@ class TestOps:
     def test_color_conversion_library_with_generated_videos(
         self, tmp_path, width, height, width_scaling_factor, height_scaling_factor
     ):
+        # We consider filtergraph to be the reference color conversion library.
+        # However the video decoder sometimes uses swscale as that is faster.
+        # The exact color conversion library used is an implementation detail
+        # of the video decoder and depends on the video's width.
+        #
+        # In this test we compare the output of filtergraph (which is the
+        # reference) with the output of the video decoder (which may use
+        # swscale if it chooses for certain video widths) to make sure they are
+        # always the same.
         video_path = f"{tmp_path}/frame_numbers_{width}x{height}.mp4"
         command = [
             "ffmpeg",

--- a/test/decoders/test_video_decoder_ops.py
+++ b/test/decoders/test_video_decoder_ops.py
@@ -405,7 +405,7 @@ class TestOps:
             "-s",
             f"{width}x{height}",
             "-c:v",
-            "libx264",
+            "libopenh264",
             "-t",
             "1",
             video_path,

--- a/test/decoders/test_video_decoder_ops.py
+++ b/test/decoders/test_video_decoder_ops.py
@@ -410,7 +410,6 @@ class TestOps:
             "1",
             video_path,
         ]
-        print(" ".join(command))
         subprocess.check_call(command)
 
         decoder = create_from_file(str(video_path))

--- a/test/decoders/test_video_decoder_ops.py
+++ b/test/decoders/test_video_decoder_ops.py
@@ -392,6 +392,8 @@ class TestOps:
     def test_color_conversion_library_with_generated_videos(
         self, tmp_path, width, height, width_scaling_factor, height_scaling_factor
     ):
+        if os.environ.get("IN_FBCODE_TORCHCODEC") == "1":
+            return
         # We consider filtergraph to be the reference color conversion library.
         # However the video decoder sometimes uses swscale as that is faster.
         # The exact color conversion library used is an implementation detail


### PR DESCRIPTION
Before this diff, we would use filtergraph for color conversion.

After this diff, we prefer to use swscale for color conversion because it is faster.

We fall back to filtergraph if the width is not 32-byte aligned.

If the user forces us to use a specific color-conversion library we use that (i.e. for benchmarks).

Benchmark results:

```
python benchmarks/decoders/benchmark_decoders.py --decoders=tcoptions:color_conversion_library=swscale,tcoptions:color_conversion_library=filtergraph --bm_video_paths=/home/ahmads/jupyter/carmel1.mp4,/home/
ahmads/jupyter/853.mp4
[------------------------------- video=/home/ahmads/jupyter/carmel1.mp4 h264 640x360, 1.3s 30.0fps --------------------------------]
                                                                  |  10 seek()+next()  |  1 next()  |  10 next()  |  create()+next()
1 threads: -------------------------------------------------------------------------------------------------------------------------
      TorchcodecNonCompiled:color_conversion_library=filtergraph  |        28.0        |    13.8    |     24.2    |                 
      TorchcodecNonCompiled:color_conversion_library=swscale      |        21.6        |    11.8    |     18.7    |                 
      TorchcodecNonCompiled                                       |                    |            |             |        11.9     

Times are in milliseconds (ms).

[------------- video=/home/ahmads/jupyter/853.mp4 h264 3840x2160, 4.988317s 59.94005593469701fps --------------]
                                                                  |  10 seek()+next()  |  1 next()  |  10 next()
1 threads: -----------------------------------------------------------------------------------------------------
      TorchcodecNonCompiled:color_conversion_library=filtergraph  |       1958.3       |   295.5    |    577.0  
      TorchcodecNonCompiled:color_conversion_library=swscale      |       2232.9       |   301.3    |    621.7  

Times are in milliseconds (ms).
```