### PR TITLE
[torchcodec] Follow up to make testing work internally & make it more robust/fast

### DIFF
--- a/test/decoders/test_video_decoder_ops.py
+++ b/test/decoders/test_video_decoder_ops.py
@@ -392,8 +392,11 @@ class TestOps:
     def test_color_conversion_library_with_generated_videos(
         self, tmp_path, width, height, width_scaling_factor, height_scaling_factor
     ):
+        ffmpeg_cli = "ffmpeg"
         if os.environ.get("IN_FBCODE_TORCHCODEC") == "1":
-            return
+            import importlib.resources
+
+            ffmpeg_cli = importlib.resources.path(__package__, "ffmpeg")
         # We consider filtergraph to be the reference color conversion library.
         # However the video decoder sometimes uses swscale as that is faster.
         # The exact color conversion library used is an implementation detail
@@ -404,8 +407,11 @@ class TestOps:
         # swscale if it chooses for certain video widths) to make sure they are
         # always the same.
         video_path = f"{tmp_path}/frame_numbers_{width}x{height}.mp4"
+        # We don't specify a particular encoder because the ffmpeg binary could
+        # be configured with different encoders. For the purposes of this test,
+        # the actual encoder is irrelevant.
         command = [
-            "ffmpeg",
+            ffmpeg_cli,
             "-y",
             "-f",
             "lavfi",
@@ -415,9 +421,7 @@ class TestOps:
             "yuv420p",
             "-s",
             f"{width}x{height}",
-            "-c:v",
-            "libopenh264",
-            "-t",
+            "-frames:v",
             "1",
             video_path,
         ]


### PR DESCRIPTION
Summary:
Making testing of sws_scale more robust by:
1. Not specifying an encoder for generating videos. Sometimes users' ffmpeg may not have the libopen264 encoder available but may have some other encoder available as the default.
2. Use a single frame to save up on temporary space instead of a one-second video. We are not testing seeking here -- only color conversion so a single frame is sufficient.
3. Use a different cli binary when using fbcode.

Differential Revision: D63638863
