### PR TITLE
Rename SimpleVideoDecoder to VideoDecoder

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -18,10 +18,10 @@ body:
       # All necessary imports at the beginning
       import torch
       import torchcodec
-      from torchcodec.decoders import SimpleVideoDecoder
+      from torchcodec.decoders import VideoDecoder
 
       # A succinct reproducing example trimmed down to the essential parts:
-      decoder = SimpleVideoDecoder("path/to/video.mp4")  # Help! This fails!
+      decoder = VideoDecoder("path/to/video.mp4")  # Help! This fails!
       # ...
       ```
 

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ detailed example, [check out our
 documentation](https://pytorch.org/torchcodec/stable/generated_examples/)!
 
 ```python
-from torchcodec.decoders import SimpleVideoDecoder
+from torchcodec.decoders import VideoDecoder
 
-decoder = SimpleVideoDecoder("path/to/video.mp4")
+decoder = VideoDecoder("path/to/video.mp4")
 
 decoder.metadata
 # VideoStreamMetadata:

--- a/benchmarks/decoders/benchmark_decoders.py
+++ b/benchmarks/decoders/benchmark_decoders.py
@@ -13,7 +13,7 @@ import timeit
 
 import torch
 import torch.utils.benchmark as benchmark
-from torchcodec.decoders import SimpleVideoDecoder
+from torchcodec.decoders import VideoDecoder
 
 from torchcodec.decoders._core import (
     _add_video_stream,
@@ -404,9 +404,9 @@ def main() -> None:
     results = []
     for decoder_name, decoder in decoder_dict.items():
         for video_path in args.bm_video_paths.split(","):
-            # We only use the SimpleVideoDecoder to get the metadata and get
+            # We only use the VideoDecoder to get the metadata and get
             # the list of PTS values to seek to.
-            simple_decoder = SimpleVideoDecoder(video_path)
+            simple_decoder = VideoDecoder(video_path)
             duration = simple_decoder.metadata.duration_seconds
             pts_list = [
                 i * duration / num_uniform_samples for i in range(num_uniform_samples)
@@ -453,7 +453,7 @@ def main() -> None:
 
     first_video_path = args.bm_video_paths.split(",")[0]
     if args.bm_video_creation:
-        simple_decoder = SimpleVideoDecoder(first_video_path)
+        simple_decoder = VideoDecoder(first_video_path)
         metadata = simple_decoder.metadata
         metadata_string = f"{metadata.codec} {metadata.width}x{metadata.height}, {metadata.duration_seconds}s {metadata.average_fps}fps"
         creation_result = benchmark.Timer(

--- a/docs/source/api_ref_decoders.rst
+++ b/docs/source/api_ref_decoders.rst
@@ -12,7 +12,7 @@ torchcodec.decoders
     :nosignatures:
     :template: class.rst
 
-    SimpleVideoDecoder
+    VideoDecoder
 
 
 .. autosummary::

--- a/examples/basic_example.py
+++ b/examples/basic_example.py
@@ -6,11 +6,11 @@
 
 """
 ========================================
-Decoding a video with SimpleVideoDecoder
+Decoding a video with VideoDecoder
 ========================================
 
 In this example, we'll learn how to decode a video using the
-:class:`~torchcodec.decoders.SimpleVideoDecoder` class.
+:class:`~torchcodec.decoders.VideoDecoder` class.
 """
 
 # %%
@@ -60,10 +60,10 @@ def plot(frames: torch.Tensor, title : Optional[str] = None):
 # We can now create a decoder from the raw (encoded) video bytes. You can of
 # course use a local video file and pass the path as input, rather than download
 # a video.
-from torchcodec.decoders import SimpleVideoDecoder
+from torchcodec.decoders import VideoDecoder
 
 # You can also pass a path to a local file!
-decoder = SimpleVideoDecoder(raw_video_bytes)
+decoder = VideoDecoder(raw_video_bytes)
 
 # %%
 # The has not yet been decoded by the decoder, but we already have access to
@@ -90,7 +90,7 @@ print(f"{every_twenty_frame.dtype = }")
 # frames.  The batch dimension N is only present when we're decoding more than
 # one frame. The dimension order can be changed to ``N, H, W, C`` using the
 # ``dimension_order`` parameter of
-# :class:`~torchcodec.decoders.SimpleVideoDecoder`. Frames are always of
+# :class:`~torchcodec.decoders.VideoDecoder`. Frames are always of
 # ``torch.uint8`` dtype.
 #
 
@@ -119,8 +119,8 @@ for frame in decoder:
 # can be useful to retrieve additional information about the frames, such as
 # their :term:`pts` (Presentation Time Stamp), and their duration.
 # This can be achieved using the
-# :meth:`~torchcodec.decoders.SimpleVideoDecoder.get_frame_at` and
-# :meth:`~torchcodec.decoders.SimpleVideoDecoder.get_frames_at`  methods, which
+# :meth:`~torchcodec.decoders.VideoDecoder.get_frame_at` and
+# :meth:`~torchcodec.decoders.VideoDecoder.get_frames_at`  methods, which
 # will return a :class:`~torchcodec.decoders.Frame` and
 # :class:`~torchcodec.decoders.FrameBatch` objects respectively.
 
@@ -151,8 +151,8 @@ plot(middle_frames.data, "Middle frames")
 #
 # So far, we have retrieved frames based on their index. We can also retrieve
 # frames based on *when* they are displayed with
-# :meth:`~torchcodec.decoders.SimpleVideoDecoder.get_frame_displayed_at` and
-# :meth:`~torchcodec.decoders.SimpleVideoDecoder.get_frames_displayed_at`, which
+# :meth:`~torchcodec.decoders.VideoDecoder.get_frame_displayed_at` and
+# :meth:`~torchcodec.decoders.VideoDecoder.get_frames_displayed_at`, which
 # also returns :class:`~torchcodec.decoders.Frame` and :class:`~torchcodec.decoders.FrameBatch`
 # respectively.
 

--- a/src/torchcodec/decoders/__init__.py
+++ b/src/torchcodec/decoders/__init__.py
@@ -5,4 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 from ._core import VideoStreamMetadata
-from ._simple_video_decoder import Frame, FrameBatch, SimpleVideoDecoder  # noqa
+from ._video_decoder import Frame, FrameBatch, VideoDecoder  # noqa
+
+SimpleVideoDecoder = VideoDecoder

--- a/src/torchcodec/decoders/_core/_metadata.py
+++ b/src/torchcodec/decoders/_core/_metadata.py
@@ -47,9 +47,9 @@ class VideoStreamMetadata:
     Conceptually, this corresponds to last_frame.pts + last_frame.duration. It
     is computed as max(frame.pts + frame.duration) across all frames in the
     stream. Note that no frame is displayed at this time value, so calling
-    :meth:`~torchcodec.decoders.SimpleVideoDecoder.get_frame_displayed_at` with
+    :meth:`~torchcodec.decoders.VideoDecoder.get_frame_displayed_at` with
     this value would result in an error. Retrieving the last frame is best done
-    by simply indexing the :class:`~torchcodec.decoders.SimpleVideoDecoder`
+    by simply indexing the :class:`~torchcodec.decoders.VideoDecoder`
     object with ``[-1]``.
     """
     codec: Optional[str]

--- a/src/torchcodec/decoders/_video_decoder.py
+++ b/src/torchcodec/decoders/_video_decoder.py
@@ -75,7 +75,7 @@ https://github.com/pytorch/torchcodec/issues/new?assignees=&labels=&projects=&te
 """
 
 
-class SimpleVideoDecoder:
+class VideoDecoder:
     """A single-stream video decoder.
 
     If the video contains multiple video streams, the :term:`best stream` is

--- a/src/torchcodec/samplers/_implem.py
+++ b/src/torchcodec/samplers/_implem.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 
 import torch
 
-from torchcodec.decoders import FrameBatch, SimpleVideoDecoder
+from torchcodec.decoders import FrameBatch, VideoDecoder
 
 
 def _validate_params(
@@ -75,7 +75,7 @@ def _get_clip_span(*, num_indices_between_frames, num_frames_per_clip):
 
 
 def clips_at_random_indices(
-    decoder: SimpleVideoDecoder,
+    decoder: VideoDecoder,
     *,
     num_clips: int = 1,
     num_frames_per_clip: int = 1,

--- a/test/samplers/test_samplers.py
+++ b/test/samplers/test_samplers.py
@@ -4,7 +4,7 @@ import re
 
 import pytest
 import torch
-from torchcodec.decoders import FrameBatch, SimpleVideoDecoder
+from torchcodec.decoders import FrameBatch, VideoDecoder
 from torchcodec.samplers import clips_at_random_indices
 
 from ..utils import assert_tensor_equal, NASA_VIDEO
@@ -12,7 +12,7 @@ from ..utils import assert_tensor_equal, NASA_VIDEO
 
 @pytest.mark.parametrize("num_indices_between_frames", [1, 5])
 def test_random_sampler(num_indices_between_frames):
-    decoder = SimpleVideoDecoder(NASA_VIDEO.path)
+    decoder = VideoDecoder(NASA_VIDEO.path)
     num_clips = 2
     num_frames_per_clip = 3
 
@@ -63,7 +63,7 @@ def test_random_sampler_range(
     # same indices for clip starts, so we hard-code a seed that works.
     torch.manual_seed(0)
 
-    decoder = SimpleVideoDecoder(NASA_VIDEO.path)
+    decoder = VideoDecoder(NASA_VIDEO.path)
 
     clips = clips_at_random_indices(
         decoder,
@@ -90,7 +90,7 @@ def test_random_sampler_range_negative():
     # Test the passing negative values for sampling_range_start and
     # sampling_range_end is the same as passing `len(decoder) - val`
 
-    decoder = SimpleVideoDecoder(NASA_VIDEO.path)
+    decoder = VideoDecoder(NASA_VIDEO.path)
 
     clips_1 = clips_at_random_indices(
         decoder,
@@ -117,7 +117,7 @@ def test_random_sampler_range_negative():
 
 
 def test_random_sampler_randomness():
-    decoder = SimpleVideoDecoder(NASA_VIDEO.path)
+    decoder = VideoDecoder(NASA_VIDEO.path)
     num_clips = 5
 
     builtin_random_state_start = random.getstate()
@@ -151,7 +151,7 @@ def test_random_sampler_randomness():
 
 
 def test_random_sampler_errors():
-    decoder = SimpleVideoDecoder(NASA_VIDEO.path)
+    decoder = VideoDecoder(NASA_VIDEO.path)
     with pytest.raises(
         ValueError, match=re.escape("num_clips (0) must be strictly positive")
     ):


### PR DESCRIPTION
Renaming `SimpleVideoDecoder` to `VideoDecoder`. The rationale of "simple" was that we wanted an obvious entry point for users who were unfamiliar with video encoding structure. There will be many options on a full video decoder that are going to introduce concepts such users will not be familiar with. We now think we can provide reasonable defaults for all of those options, and those users can just as easily use the same class as power users.