### PR TITLE
Use `int` instead of `numbers.integral` in docstring

### DIFF
--- a/src/torchcodec/decoders/_video_decoder.py
+++ b/src/torchcodec/decoders/_video_decoder.py
@@ -191,7 +191,7 @@ class VideoDecoder:
         """Return frame or frames as tensors, at the given index or range.
 
         Args:
-            key(numbers.Integral or slice): The index or range of frame(s) to retrieve.
+            key(int or slice): The index or range of frame(s) to retrieve.
 
         Returns:
             torch.Tensor: The frame or frames at the given index or range.


### PR DESCRIPTION
In general we want to avoid having type-annotation-like types within the docstring. Type annotations are meant to be read by a machine, not by humans, and over time they will clutter the docs.

In this instance, `int` is a more common and familiar term than `numbers.Integral`, and will help keep the doc more user-friendly. I don't believe there is any loss of accuracy keeping `int` in the docstring.