### PR TITLE
Add CUDA decoding support 

### DIFF
--- a/benchmarks/decoders/gpu_benchmark.py
+++ b/benchmarks/decoders/gpu_benchmark.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import pathlib
 import time
 from concurrent.futures import ThreadPoolExecutor
 
@@ -101,7 +102,7 @@ def main():
     parser.add_argument(
         "--video",
         type=str,
-        default=os.path.dirname(__file__) + "/../../test/resources/nasa_13013.mp4",
+        default=pathlib.Path(__file__).parent / "../../test/resources/nasa_13013.mp4",
     )
     parser.add_argument(
         "--use_torch_benchmark",

--- a/benchmarks/decoders/gpu_benchmark.py
+++ b/benchmarks/decoders/gpu_benchmark.py
@@ -102,7 +102,9 @@ def main():
     parser.add_argument(
         "--video",
         type=str,
-        default=pathlib.Path(__file__).parent / "../../test/resources/nasa_13013.mp4",
+        default=str(
+            pathlib.Path(__file__).parent / "../../test/resources/nasa_13013.mp4"
+        ),
     )
     parser.add_argument(
         "--use_torch_benchmark",

--- a/benchmarks/decoders/gpu_benchmark.py
+++ b/benchmarks/decoders/gpu_benchmark.py
@@ -77,7 +77,7 @@ def decode_videos_using_threads(
     executor = ThreadPoolExecutor(max_workers=num_threads)
     for i in range(num_videos):
         actual_decode_device = decode_device_string
-        if "cuda" in decode_device_string:
+        if "cuda" in decode_device_string and use_multiple_gpus:
             actual_decode_device = f"cuda:{i % torch.cuda.device_count()}"
         executor.submit(
             decode_full_video, video_path, actual_decode_device, resize_device_string

--- a/benchmarks/decoders/gpu_benchmark.py
+++ b/benchmarks/decoders/gpu_benchmark.py
@@ -1,0 +1,144 @@
+import argparse
+import os
+import time
+
+import torch.utils.benchmark as benchmark
+
+import torchcodec
+import torchvision.transforms.v2.functional as F
+
+RESIZED_WIDTH = 256
+RESIZED_HEIGHT = 256
+
+
+def transfer_and_resize_frame(frame, resize_device_string):
+    # This should be a no-op if the frame is already on the target device.
+    frame = frame.to(resize_device_string)
+    frame = F.resize(frame, (RESIZED_HEIGHT, RESIZED_WIDTH))
+    return frame
+
+
+def decode_full_video(video_path, decode_device_string, resize_device_string):
+    # We use the core API instead of SimpleVideoDecoder because the core API
+    # allows us to natively resize as part of the decode step.
+    print(f"{decode_device_string=} {resize_device_string=}")
+    decoder = torchcodec.decoders._core.create_from_file(video_path)
+    num_threads = None
+    if "cuda" in decode_device_string:
+        num_threads = 1
+    width = None
+    height = None
+    if "native" in resize_device_string:
+        width = RESIZED_WIDTH
+        height = RESIZED_HEIGHT
+    torchcodec.decoders._core._add_video_stream(
+        decoder,
+        stream_index=-1,
+        device=decode_device_string,
+        num_threads=num_threads,
+        width=width,
+        height=height,
+    )
+
+    start_time = time.time()
+    frame_count = 0
+    while True:
+        try:
+            frame, *_ = torchcodec.decoders._core.get_next_frame(decoder)
+            if resize_device_string != "none" and "native" not in resize_device_string:
+                frame = transfer_and_resize_frame(frame, resize_device_string)
+
+            frame_count += 1
+        except Exception as e:
+            print("EXCEPTION", e)
+            break
+
+    end_time = time.time()
+    elapsed = end_time - start_time
+    fps = frame_count / (end_time - start_time)
+    print(
+        f"****** DECODED full video {decode_device_string=} {frame_count=} {elapsed=} {fps=}"
+    )
+    return frame_count, end_time - start_time
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--devices",
+        default="cuda:0,cpu",
+        type=str,
+        help="Comma-separated devices to test decoding on.",
+    )
+    parser.add_argument(
+        "--resize_devices",
+        default="cuda:0,cpu,native,none",
+        type=str,
+        help="Comma-separated devices to test preroc (resize) on. Use 'none' to specify no resize.",
+    )
+    parser.add_argument(
+        "--video",
+        type=str,
+        default=os.path.dirname(__file__) + "/../../test/resources/nasa_13013.mp4",
+    )
+    parser.add_argument(
+        "--use_torch_benchmark",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help=(
+            "Use pytorch benchmark to measure decode time with warmup and "
+            "autorange. Without this we just run one iteration without warmup "
+            "to measure the cold start time."
+        ),
+    )
+    args = parser.parse_args()
+    video_path = args.video
+
+    if not args.use_torch_benchmark:
+        for device in args.devices.split(","):
+            print("Testing on", device)
+            decode_full_video(video_path, device)
+        return
+
+    resize_devices = args.resize_devices.split(",")
+    resize_devices = [d for d in resize_devices if d != ""]
+    if len(resize_devices) == 0:
+        resize_devices.append("none")
+
+    label = "Decode+Resize Time"
+
+    results = []
+    for decode_device_string in args.devices.split(","):
+        for resize_device_string in resize_devices:
+            decode_label = decode_device_string
+            if "cuda" in decode_label:
+                # Shorten "cuda:0" to "cuda"
+                decode_label = "cuda"
+            resize_label = resize_device_string
+            if "cuda" in resize_device_string:
+                # Shorten "cuda:0" to "cuda"
+                resize_label = "cuda"
+            print("decode_device", decode_device_string)
+            print("resize_device", resize_device_string)
+            t = benchmark.Timer(
+                stmt="decode_full_video(video_path, decode_device_string, resize_device_string)",
+                globals={
+                    "decode_device_string": decode_device_string,
+                    "video_path": video_path,
+                    "decode_full_video": decode_full_video,
+                    "resize_device_string": resize_device_string,
+                },
+                label=label,
+                description=f"video={os.path.basename(video_path)}",
+                sub_label=f"D={decode_label} R={resize_label}",
+            ).blocked_autorange()
+            results.append(t)
+    compare = benchmark.Compare(results)
+    compare.print()
+    print("Key: D=Decode, R=Resize")
+    print("Native resize is done as part of the decode step")
+    print("none resize means there is no resize step -- native or otherwise")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/torchcodec/decoders/_core/CMakeLists.txt
+++ b/src/torchcodec/decoders/_core/CMakeLists.txt
@@ -38,9 +38,6 @@ function(make_torchcodec_library library_name ffmpeg_target)
     if(ENABLE_CUDA)
         list(APPEND NEEDED_LIBRARIES ${CUDA_CUDA_LIBRARY} ${CUDA_nppi_LIBRARY} ${CUDA_nppicc_LIBRARY} )
     endif()
-    if(ENABLE_NVTX)
-        list(APPEND NEEDED_LIBRARIES nvtx3-cpp)
-    endif()
     target_link_libraries(
         ${library_name}
         PUBLIC

--- a/src/torchcodec/decoders/_core/CMakeLists.txt
+++ b/src/torchcodec/decoders/_core/CMakeLists.txt
@@ -38,7 +38,7 @@ function(make_torchcodec_library library_name ffmpeg_target)
         ${Python3_LIBRARIES})
     if(ENABLE_CUDA)
         list(APPEND NEEDED_LIBRARIES ${CUDA_CUDA_LIBRARY} \
-             ${CUDA_nppi_LIBRARY} ${CUDA_nppicc_LIBRARY} )
+            ${CUDA_nppi_LIBRARY} ${CUDA_nppicc_LIBRARY} )
     endif()
     target_link_libraries(
         ${library_name}

--- a/src/torchcodec/decoders/_core/CMakeLists.txt
+++ b/src/torchcodec/decoders/_core/CMakeLists.txt
@@ -34,10 +34,10 @@ function(make_torchcodec_library library_name ffmpeg_target)
         ${Python3_INCLUDE_DIRS}
     )
 
-    set(NEEDED_LIBRARIES ${ffmpeg_target} ${TORCH_LIBRARIES} \
+    set(NEEDED_LIBRARIES ${ffmpeg_target} ${TORCH_LIBRARIES}
         ${Python3_LIBRARIES})
     if(ENABLE_CUDA)
-        list(APPEND NEEDED_LIBRARIES ${CUDA_CUDA_LIBRARY} \
+        list(APPEND NEEDED_LIBRARIES ${CUDA_CUDA_LIBRARY}
             ${CUDA_nppi_LIBRARY} ${CUDA_nppicc_LIBRARY} )
     endif()
     target_link_libraries(

--- a/src/torchcodec/decoders/_core/CMakeLists.txt
+++ b/src/torchcodec/decoders/_core/CMakeLists.txt
@@ -34,9 +34,11 @@ function(make_torchcodec_library library_name ffmpeg_target)
         ${Python3_INCLUDE_DIRS}
     )
 
-    set(NEEDED_LIBRARIES ${ffmpeg_target} ${TORCH_LIBRARIES} ${Python3_LIBRARIES})
+    set(NEEDED_LIBRARIES ${ffmpeg_target} ${TORCH_LIBRARIES} \
+        ${Python3_LIBRARIES})
     if(ENABLE_CUDA)
-        list(APPEND NEEDED_LIBRARIES ${CUDA_CUDA_LIBRARY} ${CUDA_nppi_LIBRARY} ${CUDA_nppicc_LIBRARY} )
+        list(APPEND NEEDED_LIBRARIES ${CUDA_CUDA_LIBRARY} \
+             ${CUDA_nppi_LIBRARY} ${CUDA_nppicc_LIBRARY} )
     endif()
     target_link_libraries(
         ${library_name}

--- a/src/torchcodec/decoders/_core/CMakeLists.txt
+++ b/src/torchcodec/decoders/_core/CMakeLists.txt
@@ -34,12 +34,17 @@ function(make_torchcodec_library library_name ffmpeg_target)
         ${Python3_INCLUDE_DIRS}
     )
 
+    set(NEEDED_LIBRARIES ${ffmpeg_target} ${TORCH_LIBRARIES} ${Python3_LIBRARIES})
+    if(ENABLE_CUDA)
+        list(APPEND NEEDED_LIBRARIES ${CUDA_CUDA_LIBRARY} ${CUDA_nppi_LIBRARY} ${CUDA_nppicc_LIBRARY} )
+    endif()
+    if(ENABLE_NVTX)
+        list(APPEND NEEDED_LIBRARIES nvtx3-cpp)
+    endif()
     target_link_libraries(
         ${library_name}
         PUBLIC
-        ${ffmpeg_target}
-        ${TORCH_LIBRARIES}
-        ${Python3_LIBRARIES}
+        ${NEEDED_LIBRARIES}
     )
 
     # We already set the library_name to be libtorchcodecN, so we don't want

--- a/src/torchcodec/decoders/_core/CPUOnlyDevice.cpp
+++ b/src/torchcodec/decoders/_core/CPUOnlyDevice.cpp
@@ -1,8 +1,11 @@
 #include <torch/types.h>
+#include "src/torchcodec/decoders/_core/DeviceInterface.h"
 
 namespace facebook::torchcodec {
 
-void maybeInitializeDeviceContext(const torch::Device& device) {
+void maybeInitializeDeviceContext(
+    const torch::Device& device,
+    AVCodecContext* codecContext) {
   if (device.type() == torch::kCPU) {
     return;
   }

--- a/src/torchcodec/decoders/_core/CPUOnlyDevice.cpp
+++ b/src/torchcodec/decoders/_core/CPUOnlyDevice.cpp
@@ -24,7 +24,9 @@ VideoDecoder::DecodedOutput convertAVFrameToDecodedOutputOnDevice(
   return output;
 }
 
-void initializeDeviceContext(const torch::Device& device) {
+void initializeDeviceContext(
+    const torch::Device& device,
+    AVCodecContext* codecContext) {
   throwUnsupportedDeviceError(device);
 }
 

--- a/src/torchcodec/decoders/_core/CPUOnlyDevice.cpp
+++ b/src/torchcodec/decoders/_core/CPUOnlyDevice.cpp
@@ -14,7 +14,7 @@ namespace facebook::torchcodec {
   TORCH_CHECK(false, "Unsupported device: " + device.str());
 }
 
-void convertAVFrameToDecodedOutputOnDevice(
+void convertAVFrameToDecodedOutputOnCuda(
     const torch::Device& device,
     const VideoDecoder::VideoStreamDecoderOptions& options,
     AVCodecContext* codecContext,
@@ -23,7 +23,7 @@ void convertAVFrameToDecodedOutputOnDevice(
   throwUnsupportedDeviceError(device);
 }
 
-void initializeDeviceContext(
+void initializeContextOnCuda(
     const torch::Device& device,
     AVCodecContext* codecContext) {
   throwUnsupportedDeviceError(device);

--- a/src/torchcodec/decoders/_core/CPUOnlyDevice.cpp
+++ b/src/torchcodec/decoders/_core/CPUOnlyDevice.cpp
@@ -12,4 +12,12 @@ void maybeInitializeDeviceContext(
   throw std::runtime_error("Unsupported device: " + device.str());
 }
 
+VideoDecoder::DecodedOutput convertAVFrameToDecodedOutputOnDevice(
+    const torch::Device& device,
+    const VideoDecoder::VideoStreamDecoderOptions& options,
+    AVCodecContext* codecContext,
+    VideoDecoder::RawDecodedOutput& rawOutput) {
+  TORCH_CHECK(false, "We should not run device code on CPU")
+}
+
 } // namespace facebook::torchcodec

--- a/src/torchcodec/decoders/_core/CPUOnlyDevice.cpp
+++ b/src/torchcodec/decoders/_core/CPUOnlyDevice.cpp
@@ -7,21 +7,20 @@ namespace facebook::torchcodec {
 // So all functions will throw an error because they should only be called if
 // the device is not CPU.
 
-void throwUnsupportedDeviceError(const torch::Device& device) {
+[[noreturn]] void throwUnsupportedDeviceError(const torch::Device& device) {
   TORCH_CHECK(
       device.type() != torch::kCPU,
       "Device functions should only be called if the device is not CPU.")
-  throw std::runtime_error("Unsupported device: " + device.str());
+  TORCH_CHECK(false, "Unsupported device: " + device.str());
 }
 
-VideoDecoder::DecodedOutput convertAVFrameToDecodedOutputOnDevice(
+void convertAVFrameToDecodedOutputOnDevice(
     const torch::Device& device,
     const VideoDecoder::VideoStreamDecoderOptions& options,
     AVCodecContext* codecContext,
-    VideoDecoder::RawDecodedOutput& rawOutput) {
+    VideoDecoder::RawDecodedOutput& rawOutput,
+    VideoDecoder::DecodedOutput& output) {
   throwUnsupportedDeviceError(device);
-  VideoDecoder::DecodedOutput output;
-  return output;
 }
 
 void initializeDeviceContext(

--- a/src/torchcodec/decoders/_core/CudaDevice.cpp
+++ b/src/torchcodec/decoders/_core/CudaDevice.cpp
@@ -65,7 +65,7 @@ void initializeContextOnCuda(
   // This is a dummy tensor to initialize the cuda context.
   torch::Tensor dummyTensorForCudaInitialization = torch::empty(
       {1}, torch::TensorOptions().dtype(torch::kUInt8).device(device));
-  codecContext->hw_device_ctx = av_buffer_ref(getCudaContext(device));
+  codecContext->hw_device_ctx = getCudaContext(device);
   return;
 }
 

--- a/src/torchcodec/decoders/_core/CudaDevice.cpp
+++ b/src/torchcodec/decoders/_core/CudaDevice.cpp
@@ -18,19 +18,7 @@ AVBufferRef* getCudaContext() {
   TORCH_CHECK(type != AV_HWDEVICE_TYPE_NONE, "Failed to find cuda device");
   int err = 0;
   AVBufferRef* hw_device_ctx;
-  err = av_hwdevice_ctx_create(
-      &hw_device_ctx,
-      type,
-      nullptr,
-      nullptr,
-  // Introduced in 58.26.100:
-  // https://github.com/FFmpeg/FFmpeg/blob/4acb9b7d1046944345ae506165fb55883d04d8a6/doc/APIchanges#L265
-#if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(58, 26, 100)
-      AV_CUDA_USE_CURRENT_CONTEXT
-#else
-      0
-#endif
-  );
+  err = av_hwdevice_ctx_create(&hw_device_ctx, type, nullptr, nullptr, 0);
   if (err < 0) {
     TORCH_CHECK(
         false,

--- a/src/torchcodec/decoders/_core/CudaDevice.cpp
+++ b/src/torchcodec/decoders/_core/CudaDevice.cpp
@@ -19,6 +19,9 @@ AVBufferRef* getCudaContext(const torch::Device& device) {
   TORCH_CHECK(type != AV_HWDEVICE_TYPE_NONE, "Failed to find cuda device");
   torch::DeviceIndex deviceIndex = device.index();
   // FFMPEG cannot handle negative device indices.
+  // For single GPU- machines libtorch returns -1 for the device index. So for
+  // that case we set the device index to 0.
+  // TODO: Double check if this works for multi-GPU machines correctly.
   deviceIndex = std::max<at::DeviceIndex>(deviceIndex, 0);
   std::string deviceOrdinal = std::to_string(deviceIndex);
   AVBufferRef* hw_device_ctx;

--- a/src/torchcodec/decoders/_core/CudaDevice.cpp
+++ b/src/torchcodec/decoders/_core/CudaDevice.cpp
@@ -1,14 +1,17 @@
+#include <npp.h>
 #include <torch/types.h>
 #include "src/torchcodec/decoders/_core/DeviceInterface.h"
 #include "src/torchcodec/decoders/_core/FFMPEGCommon.h"
+#include "src/torchcodec/decoders/_core/VideoDecoder.h"
 
 extern "C" {
 #include <libavcodec/avcodec.h>
 #include <libavutil/hwcontext_cuda.h>
+#include <libavutil/pixdesc.h>
 }
 
 namespace facebook::torchcodec {
-
+namespace {
 AVBufferRef* getCudaContext() {
   enum AVHWDeviceType type = av_hwdevice_find_type_by_name("cuda");
   TORCH_CHECK(type != AV_HWDEVICE_TYPE_NONE, "Failed to find cuda device");
@@ -36,15 +39,74 @@ AVBufferRef* getCudaContext() {
   return hw_device_ctx;
 }
 
+torch::Tensor allocateDeviceTensor(
+    at::IntArrayRef shape,
+    torch::Device device,
+    const torch::Dtype dtype = torch::kUInt8) {
+  return torch::empty(
+      shape,
+      torch::TensorOptions()
+          .dtype(dtype)
+          .layout(torch::kStrided)
+          .device(device));
+}
+} // namespace
+
 void maybeInitializeDeviceContext(
     const torch::Device& device,
     AVCodecContext* codecContext) {
   if (device.type() == torch::kCPU) {
     return;
   } else if (device.type() == torch::kCUDA) {
+    torch::Tensor dummyTensorForCudaInitialization = torch::empty(
+        {1}, torch::TensorOptions().dtype(torch::kUInt8).device(device));
     codecContext->hw_device_ctx = av_buffer_ref(getCudaContext());
+    return;
   }
   throw std::runtime_error("Unsupported device: " + device.str());
+}
+
+VideoDecoder::DecodedOutput convertAVFrameToDecodedOutputOnDevice(
+    const torch::Device& device,
+    const VideoDecoder::VideoStreamDecoderOptions& options,
+    AVCodecContext* codecContext,
+    VideoDecoder::RawDecodedOutput& rawOutput) {
+  AVFrame* src = rawOutput.frame.get();
+
+  TORCH_CHECK(
+      src->format == AV_PIX_FMT_CUDA,
+      "Expected format to be AV_PIX_FMT_CUDA, got " +
+          std::string(av_get_pix_fmt_name((AVPixelFormat)src->format)));
+  int width = options.width.value_or(codecContext->width);
+  int height = options.height.value_or(codecContext->height);
+  NppStatus status;
+  NppiSize oSizeROI;
+  oSizeROI.width = width;
+  oSizeROI.height = height;
+  Npp8u* input[2];
+  input[0] = (Npp8u*)src->data[0];
+  input[1] = (Npp8u*)src->data[1];
+  VideoDecoder::DecodedOutput output;
+  torch::Tensor& dst = output.frame;
+  dst = allocateDeviceTensor({height, width, 3}, options.device);
+  auto start = std::chrono::high_resolution_clock::now();
+  status = nppiNV12ToRGB_8u_P2C3R(
+      input,
+      src->linesize[0],
+      static_cast<Npp8u*>(dst.data_ptr()),
+      dst.stride(0),
+      oSizeROI);
+  TORCH_CHECK(status == NPP_SUCCESS, "Failed to convert NV12 frame.");
+  auto end = std::chrono::high_resolution_clock::now();
+  std::chrono::duration<double, std::micro> duration = end - start;
+  VLOG(9) << "NPP Conversion of frame height=" << height << " width=" << width
+          << " took: " << duration.count() << "us" << std::endl;
+  if (options.dimensionOrder == "NCHW") {
+    // The docs guaranty this to return a view:
+    // https://pytorch.org/docs/stable/generated/torch.permute.html
+    dst = dst.permute({2, 0, 1});
+  }
+  return output;
 }
 
 } // namespace facebook::torchcodec

--- a/src/torchcodec/decoders/_core/CudaDevice.cpp
+++ b/src/torchcodec/decoders/_core/CudaDevice.cpp
@@ -16,12 +16,11 @@ namespace {
 AVBufferRef* getCudaContext(const torch::Device& device) {
   enum AVHWDeviceType type = av_hwdevice_find_type_by_name("cuda");
   TORCH_CHECK(type != AV_HWDEVICE_TYPE_NONE, "Failed to find cuda device");
-  int err = 0;
-  AVBufferRef* hw_device_ctx;
   torch::DeviceIndex deviceIndex = device.index();
   deviceIndex = std::max<at::DeviceIndex>(deviceIndex, 0);
   std::string deviceOrdinal = std::to_string(deviceIndex);
-  err = av_hwdevice_ctx_create(
+  AVBufferRef* hw_device_ctx;
+  int err = av_hwdevice_ctx_create(
       &hw_device_ctx, type, deviceOrdinal.c_str(), nullptr, 0);
   if (err < 0) {
     TORCH_CHECK(

--- a/src/torchcodec/decoders/_core/CudaDevice.cpp
+++ b/src/torchcodec/decoders/_core/CudaDevice.cpp
@@ -1,15 +1,48 @@
 #include <torch/types.h>
+#include "src/torchcodec/decoders/_core/DeviceInterface.h"
+#include "src/torchcodec/decoders/_core/FFMPEGCommon.h"
+
+extern "C" {
+#include <libavcodec/avcodec.h>
+#include <libavutil/hwcontext_cuda.h>
+}
 
 namespace facebook::torchcodec {
 
-void maybeInitializeDeviceContext(const torch::Device& device) {
+AVBufferRef* getCudaContext() {
+  enum AVHWDeviceType type = av_hwdevice_find_type_by_name("cuda");
+  TORCH_CHECK(type != AV_HWDEVICE_TYPE_NONE, "Failed to find cuda device");
+  int err = 0;
+  AVBufferRef* hw_device_ctx;
+  err = av_hwdevice_ctx_create(
+      &hw_device_ctx,
+      type,
+      nullptr,
+      nullptr,
+  // Introduced in 58.26.100:
+  // https://github.com/FFmpeg/FFmpeg/blob/4acb9b7d1046944345ae506165fb55883d04d8a6/doc/APIchanges#L265
+#if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(58, 26, 100)
+      AV_CUDA_USE_CURRENT_CONTEXT
+#else
+      0
+#endif
+  );
+  if (err < 0) {
+    TORCH_CHECK(
+        false,
+        "Failed to create specified HW device",
+        getFFMPEGErrorStringFromErrorCode(err));
+  }
+  return hw_device_ctx;
+}
+
+void maybeInitializeDeviceContext(
+    const torch::Device& device,
+    AVCodecContext* codecContext) {
   if (device.type() == torch::kCPU) {
     return;
   } else if (device.type() == torch::kCUDA) {
-    // TODO: https://github.com/pytorch/torchcodec/issues/238: Implement CUDA
-    // device.
-    throw std::runtime_error(
-        "CUDA device is unimplemented. Follow this issue for tracking progress: https://github.com/pytorch/torchcodec/issues/238");
+    codecContext->hw_device_ctx = av_buffer_ref(getCudaContext());
   }
   throw std::runtime_error("Unsupported device: " + device.str());
 }

--- a/src/torchcodec/decoders/_core/CudaDevice.cpp
+++ b/src/torchcodec/decoders/_core/CudaDevice.cpp
@@ -62,6 +62,8 @@ void initializeContextOnCuda(
     const torch::Device& device,
     AVCodecContext* codecContext) {
   throwErrorIfNonCudaDevice(device);
+  // It is important for pytorch itself to create the cuda context. If ffmpeg
+  // creates the context it may not be compatible with pytorch.
   // This is a dummy tensor to initialize the cuda context.
   torch::Tensor dummyTensorForCudaInitialization = torch::empty(
       {1}, torch::TensorOptions().dtype(torch::kUInt8).device(device));

--- a/src/torchcodec/decoders/_core/CudaDevice.cpp
+++ b/src/torchcodec/decoders/_core/CudaDevice.cpp
@@ -1,3 +1,4 @@
+#include <c10/cuda/CUDAStream.h>
 #include <npp.h>
 #include <torch/types.h>
 #include "src/torchcodec/decoders/_core/DeviceInterface.h"
@@ -96,7 +97,7 @@ VideoDecoder::DecodedOutput convertAVFrameToDecodedOutputOnDevice(
   dst = allocateDeviceTensor({height, width, 3}, options.device);
   auto start = std::chrono::high_resolution_clock::now();
   cudaStream_t nppStream = nppGetStream();
-  cudaStream_t torchStream = getCurrentCUDAStream().stream();
+  cudaStream_t torchStream = at::cuda::getCurrentCUDAStream().stream();
   status = nppiNV12ToRGB_8u_P2C3R(
       input,
       src->linesize[0],

--- a/src/torchcodec/decoders/_core/CudaDevice.cpp
+++ b/src/torchcodec/decoders/_core/CudaDevice.cpp
@@ -55,7 +55,7 @@ void throwErrorIfNonCudaDevice(const torch::Device& device) {
 }
 } // namespace
 
-void initializeDeviceContext(
+void initializeContextOnCuda(
     const torch::Device& device,
     AVCodecContext* codecContext) {
   throwErrorIfNonCudaDevice(device);
@@ -66,7 +66,7 @@ void initializeDeviceContext(
   return;
 }
 
-void convertAVFrameToDecodedOutputOnDevice(
+void convertAVFrameToDecodedOutputOnCuda(
     const torch::Device& device,
     const VideoDecoder::VideoStreamDecoderOptions& options,
     AVCodecContext* codecContext,

--- a/src/torchcodec/decoders/_core/CudaDevice.cpp
+++ b/src/torchcodec/decoders/_core/CudaDevice.cpp
@@ -19,9 +19,7 @@ AVBufferRef* getCudaContext(const torch::Device& device) {
   int err = 0;
   AVBufferRef* hw_device_ctx;
   torch::DeviceIndex deviceIndex = device.index();
-  if (deviceIndex < 0) {
-    deviceIndex = 0;
-  }
+  deviceIndex = std::max<at::DeviceIndex>(deviceIndex, 0);
   std::string deviceOrdinal = std::to_string(deviceIndex);
   err = av_hwdevice_ctx_create(
       &hw_device_ctx, type, deviceOrdinal.c_str(), nullptr, 0);

--- a/src/torchcodec/decoders/_core/DeviceInterface.h
+++ b/src/torchcodec/decoders/_core/DeviceInterface.h
@@ -10,6 +10,7 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include "src/torchcodec/decoders/_core/VideoDecoder.h"
 
 extern "C" {
 #include <libavcodec/avcodec.h>
@@ -22,5 +23,11 @@ namespace facebook::torchcodec {
 void maybeInitializeDeviceContext(
     const torch::Device& device,
     AVCodecContext* codecContext);
+
+VideoDecoder::DecodedOutput convertAVFrameToDecodedOutputOnDevice(
+    const torch::Device& device,
+    const VideoDecoder::VideoStreamDecoderOptions& options,
+    AVCodecContext* codecContext,
+    VideoDecoder::RawDecodedOutput& rawOutput);
 
 } // namespace facebook::torchcodec

--- a/src/torchcodec/decoders/_core/DeviceInterface.h
+++ b/src/torchcodec/decoders/_core/DeviceInterface.h
@@ -28,11 +28,11 @@ namespace facebook::torchcodec {
 
 // Initialize the hardware device that is specified in `device`. Some builds
 // support CUDA and others only support CPU.
-void initializeDeviceContext(
+void initializeContextOnCuda(
     const torch::Device& device,
     AVCodecContext* codecContext);
 
-void convertAVFrameToDecodedOutputOnDevice(
+void convertAVFrameToDecodedOutputOnCuda(
     const torch::Device& device,
     const VideoDecoder::VideoStreamDecoderOptions& options,
     AVCodecContext* codecContext,

--- a/src/torchcodec/decoders/_core/DeviceInterface.h
+++ b/src/torchcodec/decoders/_core/DeviceInterface.h
@@ -11,10 +11,16 @@
 #include <stdexcept>
 #include <string>
 
+extern "C" {
+#include <libavcodec/avcodec.h>
+}
+
 namespace facebook::torchcodec {
 
 // Initialize the hardware device that is specified in `device`. Some builds
 // support CUDA and others only support CPU.
-void maybeInitializeDeviceContext(const torch::Device& device);
+void maybeInitializeDeviceContext(
+    const torch::Device& device,
+    AVCodecContext* codecContext);
 
 } // namespace facebook::torchcodec

--- a/src/torchcodec/decoders/_core/DeviceInterface.h
+++ b/src/torchcodec/decoders/_core/DeviceInterface.h
@@ -32,10 +32,11 @@ void initializeDeviceContext(
     const torch::Device& device,
     AVCodecContext* codecContext);
 
-VideoDecoder::DecodedOutput convertAVFrameToDecodedOutputOnDevice(
+void convertAVFrameToDecodedOutputOnDevice(
     const torch::Device& device,
     const VideoDecoder::VideoStreamDecoderOptions& options,
     AVCodecContext* codecContext,
-    VideoDecoder::RawDecodedOutput& rawOutput);
+    VideoDecoder::RawDecodedOutput& rawOutput,
+    VideoDecoder::DecodedOutput& output);
 
 } // namespace facebook::torchcodec

--- a/src/torchcodec/decoders/_core/VideoDecoder.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoder.cpp
@@ -854,6 +854,13 @@ VideoDecoder::DecodedOutput VideoDecoder::convertAVFrameToDecodedOutput(
   output.duration = getDuration(frame);
   output.durationSeconds = ptsToSeconds(
       getDuration(frame), formatContext_->streams[streamIndex]->time_base);
+  if (streamInfo.options.device.type() != torch::kCPU) {
+    return convertAVFrameToDecodedOutputOnDevice(
+        streamInfo.options.device,
+        streamInfo.options,
+        streamInfo.codecContext.get(),
+        rawOutput);
+  }
   if (output.streamType == AVMEDIA_TYPE_VIDEO) {
     if (streamInfo.colorConversionLibrary == ColorConversionLibrary::SWSCALE) {
       int width = streamInfo.options.width.value_or(frame->width);

--- a/src/torchcodec/decoders/_core/VideoDecoder.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoder.cpp
@@ -428,7 +428,7 @@ void VideoDecoder::addVideoStreamDecoder(
   streamInfo.codecContext.reset(codecContext);
   int retVal = avcodec_parameters_to_context(
       streamInfo.codecContext.get(), streamInfo.stream->codecpar);
-  maybeInitializeDeviceContext(options.device);
+  maybeInitializeDeviceContext(options.device, codecContext);
   TORCH_CHECK_EQ(retVal, AVSUCCESS);
   retVal = avcodec_open2(streamInfo.codecContext.get(), codec, nullptr);
   if (retVal < AVSUCCESS) {

--- a/src/torchcodec/decoders/_core/VideoDecoder.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoder.cpp
@@ -429,7 +429,7 @@ void VideoDecoder::addVideoStreamDecoder(
   int retVal = avcodec_parameters_to_context(
       streamInfo.codecContext.get(), streamInfo.stream->codecpar);
   if (options.device.type() != torch::kCPU) {
-    initializeDeviceContext(options.device);
+    initializeDeviceContext(options.device, codecContext);
   }
   TORCH_CHECK_EQ(retVal, AVSUCCESS);
   retVal = avcodec_open2(streamInfo.codecContext.get(), codec, nullptr);

--- a/src/torchcodec/decoders/_core/VideoDecoder.h
+++ b/src/torchcodec/decoders/_core/VideoDecoder.h
@@ -364,6 +364,9 @@ class VideoDecoder {
       const AVFrame* frame);
   void convertFrameToBufferUsingSwsScale(RawDecodedOutput& rawOutput);
   DecodedOutput convertAVFrameToDecodedOutput(RawDecodedOutput& rawOutput);
+  void convertAVFrameToDecodedOutputOnCPU(
+      RawDecodedOutput& rawOutput,
+      DecodedOutput& output);
 
   DecoderOptions options_;
   ContainerMetadata containerMetadata_;

--- a/src/torchcodec/decoders/_core/VideoDecoderOps.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoderOps.cpp
@@ -168,8 +168,9 @@ void _add_video_stream(
   if (device.has_value()) {
     if (device.value() == "cpu") {
       options.device = torch::Device(torch::kCPU);
-    } else if (device.value() == "cuda") {
-      options.device = torch::Device(torch::kCUDA);
+    } else if (device.value().starts_with("cuda")) {
+      std::string deviceStr(device.value());
+      options.device = torch::Device(deviceStr);
     } else {
       throw std::runtime_error(
           "Invalid device=" + std::string(device.value()) +

--- a/test/decoders/test_video_decoder_ops.py
+++ b/test/decoders/test_video_decoder_ops.py
@@ -469,6 +469,8 @@ class TestOps:
         assert frame0.device.type == "cuda"
         frame0_cpu = frame0.to("cpu")
         reference_frame0 = NASA_VIDEO.get_frame_data_by_index(0)
+        # We pass in atol of 60 because the CUDA decoder is not bit-accurate
+        # compared to the CPU decoder.
         torch.testing.assert_close(frame0_cpu, reference_frame0, atol=60, rtol=0)
 
 

--- a/test/decoders/test_video_decoder_ops.py
+++ b/test/decoders/test_video_decoder_ops.py
@@ -465,13 +465,18 @@ class TestOps:
         decoder = create_from_file(str(NASA_VIDEO.path))
         scan_all_streams_to_update_metadata(decoder)
         add_video_stream(decoder, device="cuda")
-        frame0, *_ = get_next_frame(decoder)
+        frame0, pts, duration = get_next_frame(decoder)
         assert frame0.device.type == "cuda"
         frame0_cpu = frame0.to("cpu")
         reference_frame0 = NASA_VIDEO.get_frame_data_by_index(0)
-        # We pass in atol of 60 because the CUDA decoder is not bit-accurate
-        # compared to the CPU decoder.
-        torch.testing.assert_close(frame0_cpu, reference_frame0, atol=60, rtol=0)
+        # GPU decode is not bit-accurate. In the following assertion we ensure
+        # not more than 0.3% of values have a difference greater than 20.
+        diff = (reference_frame0.float() - frame0_cpu.float()).abs()
+        assert (diff > 20).float().mean() <= 0.003
+        assert pts == torch.tensor([0])
+        torch.testing.assert_close(
+            duration, torch.tensor(0.0334).double(), atol=0, rtol=1e-3
+        )
 
 
 if __name__ == "__main__":

--- a/test/decoders/test_video_decoder_ops.py
+++ b/test/decoders/test_video_decoder_ops.py
@@ -464,8 +464,12 @@ class TestOps:
     def test_cuda_decoder(self):
         decoder = create_from_file(str(NASA_VIDEO.path))
         scan_all_streams_to_update_metadata(decoder)
-        with pytest.raises(RuntimeError, match="CUDA device is unimplemented"):
-            add_video_stream(decoder, device="cuda")
+        add_video_stream(decoder, device="cuda")
+        frame0, *_ = get_next_frame(decoder)
+        assert frame0.device.type == "cuda"
+        frame0_cpu = frame0.to("cpu")
+        reference_frame0 = NASA_VIDEO.get_frame_data_by_index(0)
+        torch.testing.assert_close(frame0_cpu, reference_frame0, atol=60, rtol=0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Actually implement cuda decoding in C++:

1. Initialize a cuda device if requested. We create a small tensor on the device to initialize the context.
2. Use the cuda device to decode the video to NV12 format.
3. Use libNPP to convert from NV12 to RGB. We make sure to wait on this cuda event so there are no race conditions in accessing this tensor from the downstream consumer (that is on a different stream than libNPP).

Note that the GPU decodes frames that are not bit-accurate. This is by design and we ensure tensors are approximately equal rather than fully accurate. The actual tensor values depends on the GPU architecture because GPU math is not precise.

Also added a gpu_benchmark with the following results:

```
python benchmarks/decoders/gpu_benchmark.py --video /tmp/frame_numbers_1920x1080_100.mp4
[--------------------- Decode+Resize Time --------------------]
                       |  video=frame_numbers_1920x1080_100.mp4
1 threads: ----------------------------------------------------
      D=cuda R=cuda    |                   12.1                
      D=cuda R=cpu     |                  148.0                
      D=cuda R=native  |                   11.5                
      D=cuda R=none    |                   11.5                
      D=cpu R=cuda     |                   16.9                
      D=cpu R=cpu      |                  134.2                
      D=cpu R=native   |                   23.2                
      D=cpu R=none     |                    9.4                

Times are in seconds (s).

Key: D=Decode, R=Resize
Native resize is done as part of the decode step
none resize means there is no resize step -- native or otherwise

```

Results show that a single NVDec is slower than 22 core CPU without resizing, but faster with resizing.

I also added a "throughput mode" for the benchmark that decodes W videos in parallel using T threads. Results of this "throughput mode" shows that A100 has higher decode throughput than my 22-core CPU:


```
python benchmarks/decoders/gpu_benchmark.py --video /tmp/frame_numbers_1920x1080_100.mp4 --devices=cuda:0,cpu --resize_
devices=none --num_threads 10 --num_videos 10

[---------------------------------- Decode+Resize Time ----------------------------------]
                               |  threads=10 work=10 video=frame_numbers_1920x1080_100.mp4
1 threads: -------------------------------------------------------------------------------
      D=cuda R=none T=10 W=10  |                            29.0                          
      D=cpu R=none T=10 W=10   |                            38.8                          

Times are in seconds (s).

Key: D=Decode, R=Resize T=threads W=work (number of videos to decode)
Native resize is done as part of the decode step
none resize means there is no resize step -- native or otherwise

```

nvidia-smi shows 99% NVDEC utilization :)

```
# gpu         pid   type     sm    mem    enc    dec    jpg    ofa    command 
# Idx           #    C/G      %      %      %      %      %      %    name 
    0    2180816     C     70      5      -     99      -      -    python      
```

This throughput mode is representative of video decoding using the dataloader with multiple threads.
