### PR TITLE
Make it clear that the device interface is only for non-CPU devices. This makes the code simpler to reason about

### DIFF
--- a/src/torchcodec/decoders/_core/CPUOnlyDevice.cpp
+++ b/src/torchcodec/decoders/_core/CPUOnlyDevice.cpp
@@ -2,11 +2,12 @@
 
 namespace facebook::torchcodec {
 
-void maybeInitializeDeviceContext(const torch::Device& device) {
-  if (device.type() == torch::kCPU) {
-    return;
-  }
+void throwUnsupportedDeviceError(const torch::Device& device) {
   throw std::runtime_error("Unsupported device: " + device.str());
+}
+
+void maybeInitializeDeviceContext(const torch::Device& device) {
+  throwUnsupportedDeviceError(device);
 }
 
 } // namespace facebook::torchcodec

--- a/src/torchcodec/decoders/_core/CPUOnlyDevice.cpp
+++ b/src/torchcodec/decoders/_core/CPUOnlyDevice.cpp
@@ -2,6 +2,10 @@
 
 namespace facebook::torchcodec {
 
+// This file is linked with the CPU-only version of torchcodec.
+// So all functions will throw an error because they should only be called if
+// the device is not CPU.
+
 void throwUnsupportedDeviceError(const torch::Device& device) {
   throw std::runtime_error("Unsupported device: " + device.str());
 }

--- a/src/torchcodec/decoders/_core/CPUOnlyDevice.cpp
+++ b/src/torchcodec/decoders/_core/CPUOnlyDevice.cpp
@@ -7,6 +7,9 @@ namespace facebook::torchcodec {
 // the device is not CPU.
 
 void throwUnsupportedDeviceError(const torch::Device& device) {
+  TORCH_CHECK(
+      device.type() != torch::kCPU,
+      "Device functions should only be called if the device is not CPU.")
   throw std::runtime_error("Unsupported device: " + device.str());
 }
 

--- a/src/torchcodec/decoders/_core/CPUOnlyDevice.cpp
+++ b/src/torchcodec/decoders/_core/CPUOnlyDevice.cpp
@@ -10,7 +10,7 @@ void throwUnsupportedDeviceError(const torch::Device& device) {
   throw std::runtime_error("Unsupported device: " + device.str());
 }
 
-void maybeInitializeDeviceContext(const torch::Device& device) {
+void initializeDeviceContext(const torch::Device& device) {
   throwUnsupportedDeviceError(device);
 }
 

--- a/src/torchcodec/decoders/_core/CudaDevice.cpp
+++ b/src/torchcodec/decoders/_core/CudaDevice.cpp
@@ -2,16 +2,17 @@
 
 namespace facebook::torchcodec {
 
-void maybeInitializeDeviceContext(const torch::Device& device) {
-  if (device.type() == torch::kCPU) {
-    return;
-  } else if (device.type() == torch::kCUDA) {
+void throwErrorIfNonCudaDevice(const torch::Device& device) {
+  if (device.type() != torch::kCUDA) {
+    throw std::runtime_error("Unsupported device: " + device.str());
+  }
+
+  void maybeInitializeDeviceContext(const torch::Device& device) {
+    throwErrorIfNonCudaDevice(device);
     // TODO: https://github.com/pytorch/torchcodec/issues/238: Implement CUDA
     // device.
     throw std::runtime_error(
         "CUDA device is unimplemented. Follow this issue for tracking progress: https://github.com/pytorch/torchcodec/issues/238");
   }
-  throw std::runtime_error("Unsupported device: " + device.str());
-}
 
 } // namespace facebook::torchcodec

--- a/src/torchcodec/decoders/_core/CudaDevice.cpp
+++ b/src/torchcodec/decoders/_core/CudaDevice.cpp
@@ -7,7 +7,7 @@ void throwErrorIfNonCudaDevice(const torch::Device& device) {
     throw std::runtime_error("Unsupported device: " + device.str());
   }
 
-  void maybeInitializeDeviceContext(const torch::Device& device) {
+  void initializeDeviceContext(const torch::Device& device) {
     throwErrorIfNonCudaDevice(device);
     // TODO: https://github.com/pytorch/torchcodec/issues/238: Implement CUDA
     // device.

--- a/src/torchcodec/decoders/_core/CudaDevice.cpp
+++ b/src/torchcodec/decoders/_core/CudaDevice.cpp
@@ -3,16 +3,20 @@
 namespace facebook::torchcodec {
 
 void throwErrorIfNonCudaDevice(const torch::Device& device) {
+  TORCH_CHECK(
+      device.type() != torch::kCPU,
+      "Device functions should only be called if the device is not CPU.")
   if (device.type() != torch::kCUDA) {
     throw std::runtime_error("Unsupported device: " + device.str());
   }
+}
 
-  void initializeDeviceContext(const torch::Device& device) {
-    throwErrorIfNonCudaDevice(device);
-    // TODO: https://github.com/pytorch/torchcodec/issues/238: Implement CUDA
-    // device.
-    throw std::runtime_error(
-        "CUDA device is unimplemented. Follow this issue for tracking progress: https://github.com/pytorch/torchcodec/issues/238");
-  }
+void initializeDeviceContext(const torch::Device& device) {
+  throwErrorIfNonCudaDevice(device);
+  // TODO: https://github.com/pytorch/torchcodec/issues/238: Implement CUDA
+  // device.
+  throw std::runtime_error(
+      "CUDA device is unimplemented. Follow this issue for tracking progress: https://github.com/pytorch/torchcodec/issues/238");
+}
 
 } // namespace facebook::torchcodec

--- a/src/torchcodec/decoders/_core/DeviceInterface.h
+++ b/src/torchcodec/decoders/_core/DeviceInterface.h
@@ -16,6 +16,10 @@ namespace facebook::torchcodec {
 // Note that all these device functions should only be called if the device is
 // not a CPU device. CPU device functions are already implemented in the
 // VideoDecoder implementation.
+// These functions should only be called from within an if block like this:
+// if (device.type() != torch::kCPU) {
+//   deviceFunction(device, ...);
+// }
 
 // Initialize the hardware device that is specified in `device`. Some builds
 // support CUDA and others only support CPU.

--- a/src/torchcodec/decoders/_core/DeviceInterface.h
+++ b/src/torchcodec/decoders/_core/DeviceInterface.h
@@ -13,8 +13,12 @@
 
 namespace facebook::torchcodec {
 
+// Note that all these device functions should only be called if the device is
+// not a CPU device. CPU device functions are already implemented in the
+// VideoDecoder implementation.
+
 // Initialize the hardware device that is specified in `device`. Some builds
 // support CUDA and others only support CPU.
-void maybeInitializeDeviceContext(const torch::Device& device);
+void initializeDeviceContext(const torch::Device& device);
 
 } // namespace facebook::torchcodec

--- a/src/torchcodec/decoders/_core/VideoDecoder.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoder.cpp
@@ -428,7 +428,9 @@ void VideoDecoder::addVideoStreamDecoder(
   streamInfo.codecContext.reset(codecContext);
   int retVal = avcodec_parameters_to_context(
       streamInfo.codecContext.get(), streamInfo.stream->codecpar);
-  maybeInitializeDeviceContext(options.device);
+  if (options.device.type() != torch::kCPU) {
+    initializeDeviceContext(options.device);
+  }
   TORCH_CHECK_EQ(retVal, AVSUCCESS);
   retVal = avcodec_open2(streamInfo.codecContext.get(), codec, nullptr);
   if (retVal < AVSUCCESS) {


### PR DESCRIPTION
This PR makes it clear that the device interface is only for non-CPU devices.

It should only be called from within an if block like this:

```
if (device.type() != torch::kCPU) {
  deviceFunction();
}
```

CPU code is already contained in VideoDecoder.cpp. So we can directly execute that code for CPU without the control flow going from `VideoDecoder.cpp` to `CPUOnlyDevice.cpp` back to `VideoDecoder.cpp`. That makes the code easier to reason about.

The CPUOnlyDevice.cpp file will throw errors for every function because it is only linked in for CPU-only versions of torchcodec and CPU-only version does not support any non-CPU device.

The main advantage of this structure is that for CPU code, we will remain within VideoDecoder.cpp.

For CUDA we will go from VideoDecoder.cpp to CudaDevice.cpp.

Before this change, for device="cpu" the code would take this path:

`VideoDecoder.cpp -> CPUOnlyDevice.cpp -> VideoDecoder.cpp (for the actual color-conversion, etc.)`

After this change, for device="cpu" we remain within `VideoDecoder.cpp`. We only go outside for non-CPU devices.