### PR TITLE
Add Random time-based sampler

### DIFF
--- a/src/torchcodec/samplers/__init__.py
+++ b/src/torchcodec/samplers/__init__.py
@@ -1,1 +1,5 @@
-from ._implem import clips_at_random_indices, clips_at_regular_indices
+from ._implem import (
+    clips_at_random_indices,
+    clips_at_regular_indices,
+    clips_at_regular_timestamps,
+)

--- a/src/torchcodec/samplers/__init__.py
+++ b/src/torchcodec/samplers/__init__.py
@@ -1,5 +1,6 @@
 from ._implem import (
     clips_at_random_indices,
+    clips_at_random_timestamps,
     clips_at_regular_indices,
     clips_at_regular_timestamps,
 )

--- a/src/torchcodec/samplers/_implem.py
+++ b/src/torchcodec/samplers/_implem.py
@@ -443,23 +443,14 @@ def _build_all_clips_timestamps(
 
     all_clips_timestamps: list[float] = []
     for start_seconds in clip_start_seconds:
-        # clip_timestamps = [
-        #   start_seconds + 0 * seconds_between_frames,
-        #   start_seconds + 1 * seconds_between_frames,
-        #   start_seconds + 2 * seconds_between_frames,
-        #   ...
-        # ]
-        clip_timestamps = torch.full(
-            size=(num_frames_per_clip,), fill_value=start_seconds, dtype=torch.float
-        )
-        clip_timestamps += (
-            torch.arange(num_frames_per_clip, dtype=torch.float)
-            * seconds_between_frames
-        )
+        clip_timestamps = [
+            start_seconds + i * seconds_between_frames
+            for i in range(num_frames_per_clip)
+        ]
+        clip_timestamps = [
+            timestamp for timestamp in clip_timestamps if timestamp < end_stream_seconds
+        ]
 
-        # We clip to valid values, so that we can call the same policies as
-        # for index-based samplers.
-        clip_timestamps = clip_timestamps[clip_timestamps < end_stream_seconds].tolist()
         if len(clip_timestamps) < num_frames_per_clip:
             clip_timestamps = policy_fun(clip_timestamps, num_frames_per_clip)
         all_clips_timestamps += clip_timestamps

--- a/src/torchcodec/samplers/_implem.py
+++ b/src/torchcodec/samplers/_implem.py
@@ -491,6 +491,13 @@ def _decode_all_clips_timestamps(
             and frame_pts_seconds == all_clips_timestamps_sorted[i - 1]
         ):
             # Avoid decoding the same frame twice.
+            # Unfortunatly this is unlikely to lead to speed-up as-is: it's
+            # pretty unlikely that 2 pts will be the same since pts are float
+            # contiguous values. Theoretically the dedup can still happen, but
+            # it would be much more efficient to implement it at the frame index
+            # level. We should do that once we implement that in C++.
+            # See also https://github.com/pytorch/torchcodec/issues/256.
+            #
             # IMPORTANT: this is only correct because a copy of the frame will
             # happen within `_to_framebatch` when we call torch.stack.
             # If a copy isn't made, the same underlying memory will be used for

--- a/src/torchcodec/samplers/_implem.py
+++ b/src/torchcodec/samplers/_implem.py
@@ -549,6 +549,7 @@ def _generic_time_based_sampler(
     )
 
     if kind == "random":
+        assert num_clips is not None  # appease type-checker
         sampling_range_width = sampling_range_end - sampling_range_start
         # torch.rand() returns in [0, 1)
         # which ensures all clip starts are < sampling_range_end
@@ -556,6 +557,7 @@ def _generic_time_based_sampler(
             torch.rand(num_clips) * sampling_range_width + sampling_range_start
         )
     else:
+        assert seconds_between_clip_starts is not None  # appease type-checker
         clip_start_seconds = torch.arange(
             sampling_range_start,
             sampling_range_end,  # excluded

--- a/src/torchcodec/samplers/_implem.py
+++ b/src/torchcodec/samplers/_implem.py
@@ -347,8 +347,7 @@ def _validate_params_time_based(
     if (num_clips is None and seconds_between_clip_starts is None) or (
         num_clips is not None and seconds_between_clip_starts is not None
     ):
-        # This is internal only and should never happen
-        raise ValueError("Bad, bad programmer!")
+        raise ValueError("This is internal only and should never happen.")
 
     if seconds_between_clip_starts is not None and seconds_between_clip_starts <= 0:
         raise ValueError(

--- a/src/torchcodec/samplers/_implem.py
+++ b/src/torchcodec/samplers/_implem.py
@@ -531,7 +531,7 @@ def clips_at_regular_timestamps(
 ) -> List[FrameBatch]:
     # Note: *everywhere*, sampling_range_end denotes the upper bound of where a
     # clip can start. This is an *open* upper bound, i.e. we will make sure no
-    # clip start exactly at (or above) sampling_range_end.
+    # clip starts exactly at (or above) sampling_range_end.
 
     _validate_params(
         decoder=decoder,

--- a/src/torchcodec/samplers/_implem.py
+++ b/src/torchcodec/samplers/_implem.py
@@ -445,9 +445,12 @@ def _build_all_clips_timestamps(
         #   ...
         # ]
         clip_timestamps = torch.full(
-            size=(num_frames_per_clip,), fill_value=start_seconds
+            size=(num_frames_per_clip,), fill_value=start_seconds, dtype=torch.float
         )
-        clip_timestamps += torch.arange(num_frames_per_clip) * seconds_between_frames
+        clip_timestamps += (
+            torch.arange(num_frames_per_clip, dtype=torch.float)
+            * seconds_between_frames
+        )
 
         # We clip to valid values, so that we can call the same policies as
         # for index-based samplers.
@@ -546,6 +549,14 @@ def clips_at_regular_timestamps(
         end_stream_seconds=decoder.metadata.end_stream_seconds,
     )
 
+    # from math import ceil
+    # num_clips = int(ceil((sampling_range_end - sampling_range_start) // seconds_between_clip_starts))
+    # clip_start_seconds = torch.linspace(
+    #     sampling_range_start,
+    #     sampling_range_end - 1e-4,
+    #     steps=num_clips,
+    # )
+    # print(clip_start_seconds)
     clip_start_seconds = torch.arange(
         sampling_range_start,
         sampling_range_end,  # excluded

--- a/test/samplers/test_samplers.py
+++ b/test/samplers/test_samplers.py
@@ -528,13 +528,11 @@ class TestPolicy:
     )
     def test_policy(self, policy, frame_indices, expected_frame_indices):
         policy_fun = _POLICY_FUNCTIONS[policy]
-        assert (
-            policy_fun(frame_indices, num_frames_per_clip=5) == expected_frame_indices
-        )
+        assert policy_fun(frame_indices, desired_len=5) == expected_frame_indices
 
     def test_error_policy(self):
         with pytest.raises(ValueError, match="beyond the number of frames"):
-            _POLICY_FUNCTIONS["error"]([1, 2, 3], num_frames_per_clip=5)
+            _POLICY_FUNCTIONS["error"]([1, 2, 3], desired_len=5)
 
 
 @pytest.mark.parametrize(

--- a/test/samplers/test_samplers.py
+++ b/test/samplers/test_samplers.py
@@ -134,7 +134,6 @@ def test_time_based_sampler(seconds_between_frames):
     )
 
 
-# @pytest.mark.parametrize("sampler", (clips_at_random_indices, clips_at_regular_indices))
 @pytest.mark.parametrize(
     "sampler, sampling_range_start, sampling_range_end, assert_all_equal",
     (

--- a/test/samplers/test_samplers.py
+++ b/test/samplers/test_samplers.py
@@ -274,10 +274,10 @@ def test_sampling_range_default_behavior_random_sampler(sampler):
 
     num_clips = 20
     num_frames_per_clip = 15
-    sampling_range_start = -20 if sampler is clips_at_random_indices else 11.0
+    sampling_range_start = -20 if sampler is clips_at_random_indices else 11
 
     # with default sampling_range_end value
-    clips_default = clips_at_random_indices(
+    clips_default = sampler(
         decoder,
         num_clips=num_clips,
         num_frames_per_clip=num_frames_per_clip,
@@ -288,13 +288,13 @@ def test_sampling_range_default_behavior_random_sampler(sampler):
 
     last_clip_start_default = max([clip.pts_seconds[0] for clip in clips_default])
 
-    # with manual sampling_range_end value set to last frame
-    clips_manual = clips_at_random_indices(
+    # with manual sampling_range_end value set to last frame / end of video
+    clips_manual = sampler(
         decoder,
         num_clips=num_clips,
         num_frames_per_clip=num_frames_per_clip,
         sampling_range_start=sampling_range_start,
-        sampling_range_end=len(decoder),
+        sampling_range_end=1000,
     )
     last_clip_start_manual = max([clip.pts_seconds[0] for clip in clips_manual])
 

--- a/test/samplers/test_samplers.py
+++ b/test/samplers/test_samplers.py
@@ -575,7 +575,7 @@ def test_build_all_clips_indices(
     NUM_FRAMES_PER_CLIP = 5
     all_clips_indices = _build_all_clips_indices(
         clip_start_indices=clip_start_indices,
-        num_frames_per_clip=5,
+        num_frames_per_clip=NUM_FRAMES_PER_CLIP,
         num_indices_between_frames=num_indices_between_frames,
         num_frames_in_video=5,
         policy_fun=_POLICY_FUNCTIONS[policy],
@@ -615,7 +615,7 @@ def test_build_all_clips_timestamps(
     NUM_FRAMES_PER_CLIP = 5
     all_clips_timestamps = _build_all_clips_timestamps(
         clip_start_seconds=clip_start_seconds,
-        num_frames_per_clip=5,
+        num_frames_per_clip=NUM_FRAMES_PER_CLIP,
         seconds_between_frames=seconds_between_frames,
         end_stream_seconds=5.0,
         policy_fun=_POLICY_FUNCTIONS[policy],

--- a/test/samplers/test_samplers.py
+++ b/test/samplers/test_samplers.py
@@ -185,7 +185,7 @@ def test_sampling_range(
     # The test is similar but with different semantics. We set the sampling
     # range to be 1 second or 2 seconds. Since we set
     # seconds_between_clip_starts to 1 we expect exactly one clip with the
-    # sampling range is of size 1, and 2 different clips when teh sampling range
+    # sampling range is of size 1, and 2 different clips when the sampling range
     # is 2 seconds.
 
     # When size=2 there's still a (small) non-zero probability of sampling the
@@ -344,7 +344,8 @@ def test_sampling_range_default_regular_sampler(sampler):
             clips_at_regular_indices, sampling_range_start=-1, sampling_range_end=1000
         ),
         # Note: the hard-coded value of sampling_range_start=13 is because we know
-        # the NASA_VIDEO is 13.01s seconds long
+        # the NASA_VIDEO is ~13.01s seconds long. We just need to clip to start
+        # on, or close to the last frame.
         partial(
             clips_at_regular_timestamps,
             seconds_between_clip_starts=0.1,


### PR DESCRIPTION
This PR adds a random time-based sampler, and also updates our benchmark.

It must take a `num_clips` parameter instead of `seconds_between_clip_starts` like in `clips_at_regular_timestamps()`.

This means the `_generic_time_based_sampler` takes both `num_clips` and `seconds_between_clip_starts` as parameter, and they're mutually exclusive. That is *not* user-facing.


The `_implem.py` file is growing large. When this PR is merged, I think it'll be time to re-organize and split the implementation in different files. Typically the policies could be kept separate.