### PR TITLE
Refactor seeking to only store pts as int64 timestamp

### DIFF
--- a/src/torchcodec/decoders/_core/VideoDecoder.h
+++ b/src/torchcodec/decoders/_core/VideoDecoder.h
@@ -367,6 +367,7 @@ class VideoDecoder {
   void convertAVFrameToDecodedOutputOnCPU(
       RawDecodedOutput& rawOutput,
       DecodedOutput& output);
+  void setCursorPts(int64_t pts);
 
   DecoderOptions options_;
   ContainerMetadata containerMetadata_;
@@ -375,9 +376,9 @@ class VideoDecoder {
   // Stores the stream indices of the active streams, i.e. the streams we are
   // decoding and returning to the user.
   std::set<int> activeStreamIndices_;
-  // Set when the user wants to seek and stores the desired pts that the user
-  // wants to seek to.
-  std::optional<double> maybeDesiredPts_;
+  // True when the user wants to seek. The actual pts values to seek to are
+  // stored in the per-stream metadata in discardFramesBeforePts.
+  bool hasDesiredPts_;
 
   // Stores various internal decoding stats.
   DecodeStats decodeStats_;


### PR DESCRIPTION
Refactor that:

1. Replaces `std::optional<double> maybeDesiredPts_` in `VideoDecoder` with:
  a. `bool hasDesiredPts_` in `VideoDecoder`; and
  b. setting each stream info's `discardFramesBeforePts` directly in `VideoDecoder::setCursorPtsInSeconds(double second)`.
2. Adds `VideoDecoder::setCursorPts(int64_t pts)` which we can call when we have an int-based pts that came directly from FFmpeg. This is a private API, meant only to be used when we're round-tripping pts values from FFmpeg. We don't expose it to users.

Note the `FIXME` comment. It seems like we're "consuming" the values of `discardFramesBeforePts` in `maybeSeekToBeforeDesiredPts()`. We reset `hasDesiredPts_` after calling it (and we previously reset `maybeDesiredPts_`). It seems like we should also reset all of the `discardFramesBeforePts` values.