### PR TITLE
Add ability to build cuda wheels

### DIFF
--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -56,7 +56,7 @@ jobs:
       build-command: "BUILD_AGAINST_ALL_FFMPEG_FROM_S3=1 ENABLE_CUDA=1 python -m build --wheel -vvv --no-isolation"
 
   install-and-test:
-    runs-on: ubuntu-latest
+    runs-on: linux.gcp.a100.large
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -86,9 +86,6 @@ jobs:
       - name: Install PyTorch
         run: |
           python -m pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu${{ env.cuda_version_without_periods }}
-      - name: Install cuda dependencies
-        run: |
-          conda install --yes nvidia::libnpp nvidia::cuda-nvrtc nvidia::cuda-toolkit nvidia::cuda-cudart
       - name: Install torchcodec from the wheel
         run: |
           wheel_path=`find pytorch/torchcodec/dist -type f -name "*.whl"`
@@ -109,6 +106,9 @@ jobs:
           conda install "ffmpeg=${{ matrix.ffmpeg-version-for-tests }}" -c conda-forge
           ffmpeg -version
 
+      - name: Install cuda runtime dependencies
+        run: |
+          conda install --yes nvidia::libnpp nvidia::cuda-nvrtc nvidia::cuda-toolkit nvidia::cuda-cudart
       - name: Install test dependencies
         run: |
           python -m pip install --pre torchvision --index-url https://download.pytorch.org/whl/nightly/cpu

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -106,8 +106,7 @@ jobs:
           source packaging/helpers.sh
           assert_ffmpeg_not_installed
 
-          ${CONDA_RUN} conda install "ffmpeg=${{ matrix.ffmpeg-version-for-tests }}" -c conda-forge
-          ${CONDA_RUN} ffmpeg -version
+          ${CONDA_RUN} conda install --yes conda-forge::ffmpeg=${{ matrix.ffmpeg-version-for-tests }}
 
       - name: Install cuda runtime dependencies
         run: |

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -151,7 +151,7 @@ jobs:
       - name: Smoke test
         run: |
           ${CONDA_RUN} find $CONDA_PREFIX -name libav\*.so | xargs ldd
-          ${CONDA_RUN} find $CONDA_PREFIX -name libav\*.so | readelf -d
+          ${CONDA_RUN} find $CONDA_PREFIX -name libav\*.so | xargs readelf -d
           ${CONDA_RUN} find / -name libnvcuvid\*
           find / -name libnvcuvid\*
           ${CONDA_RUN} find $CONDA_PREFIX -name libtorchcodec\*.so | xargs ldd

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -66,9 +66,13 @@ jobs:
     if: ${{ always() }}
     needs: build
     steps:
+      - name: Setup env vars
+        run: |
+          cuda_version_without_periods=$(echo "${{ matrix.cuda-version }}" | sed 's/\.//g')
+          echo cuda_version_without_periods=${cuda_version_without_periods} >> $GITHUB_ENV
       - uses: actions/download-artifact@v3
         with:
-          name: pytorch_torchcodec__${{ matrix.python-version }}_cu${{ matrix.cuda-version }}_x86_64
+          name: pytorch_torchcodec__${{ matrix.python-version }}_cu${{ env.cuda_version_without_periods }}_x86_64
           path: pytorch/torchcodec/dist/
       - name: Setup conda env
         uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -89,6 +89,7 @@ jobs:
       - name: Install PyTorch
         run: |
           ${CONDA_RUN} python -m pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu${{ env.cuda_version_without_periods }}
+          ${CONDA_RUN} python -c 'import torch; print(f"{torch.cuda.is_available()=}")'
       - name: Install torchcodec from the wheel
         run: |
           wheel_path=`find pytorch/torchcodec/dist -type f -name "*.whl"`

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -105,15 +105,16 @@ jobs:
           # side-effect. It's OK.
           source packaging/helpers.sh
           assert_ffmpeg_not_installed
-
-          ${CONDA_RUN} conda install --yes conda
-          ${CONDA_RUN} conda update --all --yes
-          ${CONDA_RUN} conda config --add channels conda-forge
-          ${CONDA_RUN} conda config --set channel_priority strict
-          ${CONDA_RUN} conda config --show
-          ${CONDA_RUN} $CONDA_PREFIX/bin/conda install --yes ffmpeg=${{ matrix.ffmpeg-version-for-tests }} -c conda-forge
-          ${CONDA_INSTALL} --yes ffmpeg=${{ matrix.ffmpeg-version-for-tests }} -c conda-forge
           ${CONDA_RUN} conda install --yes ffmpeg=${{ matrix.ffmpeg-version-for-tests }} -c conda-forge
+
+          # ${CONDA_RUN} conda install --yes conda
+          # ${CONDA_RUN} conda update --all --yes
+          # ${CONDA_RUN} conda config --add channels conda-forge
+          # ${CONDA_RUN} conda config --set channel_priority strict
+          # ${CONDA_RUN} conda config --show
+          # ${CONDA_RUN} $CONDA_PREFIX/bin/conda install --yes ffmpeg=${{ matrix.ffmpeg-version-for-tests }} -c conda-forge
+          # ${CONDA_INSTALL} --yes ffmpeg=${{ matrix.ffmpeg-version-for-tests }} -c conda-forge
+          # ${CONDA_RUN} conda install --yes ffmpeg=${{ matrix.ffmpeg-version-for-tests }} -c conda-forge
 
       - name: Install cuda runtime dependencies
         run: |
@@ -143,7 +144,7 @@ jobs:
           find $CONDA_PREFIX -name libtorchcodec\*.so | xargs ldd
           find $CONDA_PREFIX -name libcuda\*.so\*
           echo $CONDA_PREFIX
-          python test/decoders/manual_smoke_test.py
+          ${CONDA_RUN} python test/decoders/manual_smoke_test.py
       - name: Run Python tests
         run: |
-          pytest test -vvv
+          ${CONDA_RUN} pytest test -vvv

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -77,7 +77,7 @@ jobs:
           name: pytorch_torchcodec__${{ matrix.python-version }}_cu${{ env.cuda_version_without_periods }}_x86_64
           path: pytorch/torchcodec/dist/
       - name: Setup miniconda using test-infra
-        uses: ahmadsharif1/test-infra/.github/actions/setup-miniconda@14bc3c2
+        uses: ahmadsharif1/test-infra/.github/actions/setup-miniconda@14bc3c29f88d13b0237ab4ddf00aa409e45ade40
         with:
           python-version: "3.9"
           default-packages: ""

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -76,29 +76,24 @@ jobs:
         with:
           name: pytorch_torchcodec__${{ matrix.python-version }}_cu${{ env.cuda_version_without_periods }}_x86_64
           path: pytorch/torchcodec/dist/
-      - name: Setup conda env
-        uses: conda-incubator/setup-miniconda@v2
+      - name: Setup miniconda using test-infra
+        uses: pytorch/test-infra/.github/actions/setup-miniconda@main
         with:
-          auto-update-conda: true
-          miniconda-version: "latest"
-          activate-environment: test
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.9"
       - name: Check env
         run: |
-          env
-          conda info
+          ${CONDA_RUN} env
+          ${CONDA_RUN} conda info
       - name: Update pip
-        run: python -m pip install --upgrade pip
+        run: ${CONDA_RUN} python -m pip install --upgrade pip
       - name: Install PyTorch
         run: |
-          conda activate test
-          python -m pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu${{ env.cuda_version_without_periods }}
+          ${CONDA_RUN} python -m pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu${{ env.cuda_version_without_periods }}
       - name: Install torchcodec from the wheel
         run: |
           wheel_path=`find pytorch/torchcodec/dist -type f -name "*.whl"`
           echo Installing $wheel_path
-          conda activate test
-          python -m pip install $wheel_path -vvv
+          ${CONDA_RUN} python -m pip install $wheel_path -vvv
 
       - name: Check out repo
         uses: actions/checkout@v3

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -53,7 +53,7 @@ jobs:
       package-name: torchcodec
       trigger-event: ${{ github.event_name }}
       build-platform: "python-build-package"
-      build-command: "BUILD_AGAINST_ALL_FFMPEG_FROM_S3=1 ENABLE_CUDA=1 LDFLAGS=\"-Wl,--allow-shlib-undefined -Wl,-rpath,$CONDA_PREFIX/lib -Wl,-rpath-link,$CONDA_PREFIX/lib -L$CONDA_PREFIX/lib\" python -m build --wheel -vvv --no-isolation"
+      build-command: "BUILD_AGAINST_ALL_FFMPEG_FROM_S3=1 ENABLE_CUDA=1 python -m build --wheel -vvv --no-isolation"
 
   install-and-test:
     runs-on: linux.4xlarge.nvidia.gpu

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -142,6 +142,7 @@ jobs:
       - name: Smoke test
         run: |
           find $CONDA_PREFIX -name libtorchcodec\*.so | xargs ldd
+          find $CONDA_PREFIX -name libtorchcodec\*.so | xargs readelf -d
           find $CONDA_PREFIX -name libcuda\*.so\*
           echo $CONDA_PREFIX
           ${CONDA_RUN} python test/decoders/manual_smoke_test.py

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -62,7 +62,7 @@ jobs:
       matrix:
         python-version: ['3.9']
         cuda-version: ['12.4']
-        ffmpeg-version-for-tests: ['5.1.2', '6.1.1', '7.0.1']
+        ffmpeg-version-for-tests: ['5', '6', '7']
     container:
       image: "pytorch/manylinux-builder:cuda${{ matrix.cuda-version }}"
     if: ${{ always() }}

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -139,4 +139,6 @@ jobs:
         run: |
           # We skip test_get_ffmpeg_version because it may not have a micro version.
           ${CONDA_RUN} FAIL_WITHOUT_CUDA=1 pytest test -k "not test_get_ffmpeg_version" -vvv
+      - name: Run Python benchmark
+        run: |
           ${CONDA_RUN} time python benchmarks/decoders/gpu_benchmark.py --devices=cuda:0,cpu --resize_devices=none

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -85,8 +85,7 @@ jobs:
         run: python -m pip install --upgrade pip
       - name: Install PyTorch
         run: |
-          cuda_version_without_periods=$(echo "${{ matrix.cuda-version }}" | sed 's/\.//g')
-          python -m pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu$cuda_version_without_periods
+          python -m pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu${{ env.cuda_version_without_periods }}
       - name: Install cuda dependencies
         run: |
           conda install --yes nvidia::libnpp

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -150,8 +150,8 @@ jobs:
           ls
       - name: Smoke test
         run: |
-          ${CONDA_RUN} find $CONDA_PREFIX -name av\*.so | xargs ldd
-          ${CONDA_RUN} find $CONDA_PREFIX -name av\*.so | readelf -d
+          ${CONDA_RUN} find $CONDA_PREFIX -name libav\*.so | xargs ldd
+          ${CONDA_RUN} find $CONDA_PREFIX -name libav\*.so | readelf -d
           ${CONDA_RUN} find $CONDA_PREFIX -name libtorchcodec\*.so | xargs ldd
           ${CONDA_RUN} find $CONDA_PREFIX -name libtorchcodec\*.so | xargs readelf -d
           ${CONDA_RUN} find $CONDA_PREFIX -name libcuda\*.so\*

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -81,7 +81,7 @@ jobs:
         run: python -m pip install --upgrade pip
       - name: Install PyTorch
         run: |
-          cuda_version_without_periods=$(echo ${{ matrix-cuda-version }} | sed 's/\.//g')
+          cuda_version_without_periods=$(echo "${{ matrix.cuda-version }}" | sed 's/\.//g')
           python -m pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu$cuda_version_without_periods
       - name: Install cuda dependencies
         run: |

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -150,10 +150,12 @@ jobs:
           ls
       - name: Smoke test
         run: |
-          find $CONDA_PREFIX -name libtorchcodec\*.so | xargs ldd
-          find $CONDA_PREFIX -name libtorchcodec\*.so | xargs readelf -d
-          find $CONDA_PREFIX -name libcuda\*.so\*
-          echo $CONDA_PREFIX
+          ${CONDA_RUN} find $CONDA_PREFIX -name av\*.so | xargs ldd
+          ${CONDA_RUN} find $CONDA_PREFIX -name av\*.so | readelf -d
+          ${CONDA_RUN} find $CONDA_PREFIX -name libtorchcodec\*.so | xargs ldd
+          ${CONDA_RUN} find $CONDA_PREFIX -name libtorchcodec\*.so | xargs readelf -d
+          ${CONDA_RUN} find $CONDA_PREFIX -name libcuda\*.so\*
+          ${CONDA_RUN} echo $CONDA_PREFIX
           ${CONDA_RUN} python test/decoders/manual_smoke_test.py
       - name: Run Python tests
         run: |

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -110,6 +110,7 @@ jobs:
           ${CONDA_RUN} conda update --yes conda
           ${CONDA_RUN} conda config --set channel_priority flexible
           ${CONDA_RUN} conda config --show
+          ${CONDA_INSTALL} --yes ffmpeg=${{ matrix.ffmpeg-version-for-tests }} -c conda-forge
           ${CONDA_RUN} conda install --yes ffmpeg=${{ matrix.ffmpeg-version-for-tests }} -c conda-forge
 
       - name: Install cuda runtime dependencies

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -108,7 +108,7 @@ jobs:
 
       - name: Install cuda runtime dependencies
         run: |
-          conda install --yes nvidia::libnpp nvidia::cuda-nvrtc nvidia::cuda-toolkit nvidia::cuda-cudart
+          conda install --yes nvidia::libnpp= nvidia::cuda-nvrtc nvidia::cuda-toolkit nvidia::cuda-cudart nvidia::cuda-driver-dev
       - name: Install test dependencies
         run: |
           python -m pip install --pre torchvision --index-url https://download.pytorch.org/whl/nightly/cpu
@@ -133,6 +133,9 @@ jobs:
         run: |
           find $CONDA_PREFIX -name libtorchcodec\*.so | xargs ldd
           find $CONDA_PREFIX -name libcuda\*.so\*
+          echo $CONDA_PREFIX
+          find / -name libcuda.so
+          find / -name libcuda.so.1
           python test/decoders/manual_smoke_test.py
       - name: Run Python tests
         run: |

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -89,7 +89,7 @@ jobs:
       - name: Install PyTorch
         run: |
           ${CONDA_RUN} python -m pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu${{ env.cuda_version_without_periods }}
-          ${CONDA_RUN} python -c 'import torch; print(f"{torch.cuda.is_available()=}")'
+          ${CONDA_RUN} python -c 'import torch; print(f"{torch.__version__}"); print(f"{torch.cuda.is_available()=}")'
       - name: Install torchcodec from the wheel
         run: |
           wheel_path=`find pytorch/torchcodec/dist -type f -name "*.whl"`

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -77,9 +77,10 @@ jobs:
           name: pytorch_torchcodec__${{ matrix.python-version }}_cu${{ env.cuda_version_without_periods }}_x86_64
           path: pytorch/torchcodec/dist/
       - name: Setup miniconda using test-infra
-        uses: pytorch/test-infra/.github/actions/setup-miniconda@main
+        uses: ahmadsharif1/test-infra/.github/actions/setup-miniconda@14bc3c2
         with:
           python-version: "3.9"
+          default-packages: ""
       - name: Check env
         run: |
           ${CONDA_RUN} env
@@ -88,7 +89,8 @@ jobs:
         run: ${CONDA_RUN} python -m pip install --upgrade pip
       - name: Install PyTorch
         run: |
-          ${CONDA_RUN} python -m pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu${{ env.cuda_version_without_periods }}
+          # ${CONDA_RUN} python -m pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu${{ env.cuda_version_without_periods }}
+          ${CONDA_RUN} python -m pip install torch torchvision torchaudio
           ${CONDA_RUN} python -c 'import torch; print(f"{torch.__version__}"); print(f"{torch.__file__}"); print(f"{torch.cuda.is_available()=}")'
       - name: Install torchcodec from the wheel
         run: |
@@ -106,7 +108,7 @@ jobs:
           # side-effect. It's OK.
           source packaging/helpers.sh
           assert_ffmpeg_not_installed
-          ${CONDA_RUN} conda install --yes ffmpeg=${{ matrix.ffmpeg-version-for-tests }} -c conda-forge
+          ${CONDA_RUN} conda install --yes ffmpeg=${{ matrix.ffmpeg-version-for-tests }} -c conda-forge -vvv
 
           # ${CONDA_RUN} conda install --yes conda
           # ${CONDA_RUN} conda update --all --yes

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -131,6 +131,8 @@ jobs:
           ls
       - name: Smoke test
         run: |
+          find $CONDA_PREFIX -name libtorchcodec\*.so | xargs ldd
+          find $CONDA_PREFIX -name libcuda\*.so\*
           python test/decoders/manual_smoke_test.py
       - name: Run Python tests
         run: |

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -106,7 +106,7 @@ jobs:
           source packaging/helpers.sh
           assert_ffmpeg_not_installed
 
-          ${CONDA_RUN} conda install --yes ffmpeg=${{ matrix.ffmpeg-version-for-tests }} -c conda-forge
+          ${CONDA_RUN} conda install --yes zlib ffmpeg=${{ matrix.ffmpeg-version-for-tests }} -c conda-forge
 
       - name: Install cuda runtime dependencies
         run: |

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -60,6 +60,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+          # 3.9 corresponds to the minimum python version for which we build
+          # the wheel unless the label cliflow/binaries/all is present in the
+          # PR.
+          # For the actual release we should add that label and change this to
+          # include more python versions.
         python-version: ['3.9']
         cuda-version: ['12.4']
         ffmpeg-version-for-tests: ['5', '6', '7']
@@ -75,8 +80,6 @@ jobs:
           echo cuda_version_without_periods=${cuda_version_without_periods} >> $GITHUB_ENV
       - uses: actions/download-artifact@v3
         with:
-          # We use 3.9 because it's the minimum version we build.
-          # We test version 3.9 against all other python versions in the matrix.
           name: pytorch_torchcodec__3.9_cu${{ env.cuda_version_without_periods }}_x86_64
           path: pytorch/torchcodec/dist/
       - name: Setup miniconda using test-infra
@@ -133,4 +136,4 @@ jobs:
       - name: Run Python tests
         run: |
           ${CONDA_RUN} FAIL_WITHOUT_CUDA=1 pytest test -vvv
-          ${CONDA_RUN} python benchmarks/decoders/gpu_benchmark.py --devices=cuda:0,cpu --resize_devices=none
+          ${CONDA_RUN} time python benchmarks/decoders/gpu_benchmark.py --devices=cuda:0,cpu --resize_devices=none

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -35,6 +35,7 @@ jobs:
       with-xpu: disable
       with-rocm: disable
       with-cuda: enable
+      build-python-only: "disable"
   build:
     needs: generate-matrix
     strategy:
@@ -60,7 +61,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         cuda-version: ['12.4']
         ffmpeg-version-for-tests: ['6']
     container:
@@ -108,7 +109,7 @@ jobs:
           # side-effect. It's OK.
           source packaging/helpers.sh
           assert_ffmpeg_not_installed
-          ${CONDA_RUN} conda install --yes ffmpeg=${{ matrix.ffmpeg-version-for-tests }} -c conda-forge -vvv
+          ${CONDA_RUN} conda install --yes ffmpeg=${{ matrix.ffmpeg-version-for-tests }} -vv
 
           # ${CONDA_RUN} conda install --yes conda
           # ${CONDA_RUN} conda update --all --yes

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -53,7 +53,7 @@ jobs:
       package-name: torchcodec
       trigger-event: ${{ github.event_name }}
       build-platform: "python-build-package"
-      build-command: "BUILD_AGAINST_ALL_FFMPEG_FROM_S3=1 ENABLE_CUDA=1 python -m build --wheel -vvv --no-isolation"
+      build-command: "BUILD_AGAINST_ALL_FFMPEG_FROM_S3=1 ENABLE_CUDA=1 LDFLAGS=\"-Wl,--allow-shlib-undefined -Wl,-rpath,$CONDA_PREFIX/lib -Wl,-rpath-link,$CONDA_PREFIX/lib -L$CONDA_PREFIX/lib\" python -m build --wheel -vvv --no-isolation"
 
   install-and-test:
     runs-on: linux.4xlarge.nvidia.gpu

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -66,7 +66,7 @@ jobs:
         ffmpeg-version-for-tests: ['6']
     container:
       image: "pytorch/manylinux-builder:cuda${{ matrix.cuda-version }}"
-      options: "--gpus all"
+      options: "--gpus all,capabilities=all"
     if: ${{ always() }}
     needs: build
     steps:

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -107,6 +107,7 @@ jobs:
           assert_ffmpeg_not_installed
 
           ${CONDA_RUN} conda update --all --yes
+          ${CONDA_RUN} conda config --show
           ${CONDA_RUN} conda install --yes ffmpeg=${{ matrix.ffmpeg-version-for-tests }} -c conda-forge
 
       - name: Install cuda runtime dependencies

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -84,15 +84,15 @@ jobs:
           activate-environment: test
           python-version: ${{ matrix.python-version }}
       - name: Update pip
-        run: python -m pip install --upgrade pip
+        run: ${CONDA_RUN} python -m pip install --upgrade pip
       - name: Install PyTorch
         run: |
-          python -m pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu${{ env.cuda_version_without_periods }}
+          ${CONDA_RUN} python -m pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu${{ env.cuda_version_without_periods }}
       - name: Install torchcodec from the wheel
         run: |
           wheel_path=`find pytorch/torchcodec/dist -type f -name "*.whl"`
           echo Installing $wheel_path
-          python -m pip install $wheel_path -vvv
+          ${CONDA_RUN} python -m pip install $wheel_path -vvv
 
       - name: Check out repo
         uses: actions/checkout@v3
@@ -105,17 +105,17 @@ jobs:
           source packaging/helpers.sh
           assert_ffmpeg_not_installed
 
-          conda install "ffmpeg=${{ matrix.ffmpeg-version-for-tests }}" -c conda-forge
-          ffmpeg -version
+          ${CONDA_RUN} conda install "ffmpeg=${{ matrix.ffmpeg-version-for-tests }}" -c conda-forge
+          ${CONDA_RUN} ffmpeg -version
 
       - name: Install cuda runtime dependencies
         run: |
-          conda install --yes nvidia::libnpp nvidia::cuda-nvrtc=12.4 nvidia::cuda-toolkit=12.4 nvidia::cuda-cudart=12.4 nvidia::cuda-driver-dev=12.4
+          ${CONDA_RUN} conda install --yes nvidia::libnpp nvidia::cuda-nvrtc=12.4 nvidia::cuda-toolkit=12.4 nvidia::cuda-cudart=12.4 nvidia::cuda-driver-dev=12.4
       - name: Install test dependencies
         run: |
-          python -m pip install --pre torchvision --index-url https://download.pytorch.org/whl/nightly/cpu
+          ${CONDA_RUN} python -m pip install --pre torchvision --index-url https://download.pytorch.org/whl/nightly/cpu
           # Ideally we would find a way to get those dependencies from pyproject.toml
-          python -m pip install numpy pytest pillow
+          ${CONDA_RUN} python -m pip install numpy pytest pillow
 
       - name: Delete the src/ folder just for fun
         run: |

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -109,7 +109,9 @@ jobs:
 
       - name: Install cuda runtime dependencies
         run: |
-          ${CONDA_RUN} conda install --yes nvidia::libnpp=${{ matrix.cuda-version }} nvidia::cuda-nvrtc=${{ matrix.cuda-version }} nvidia::cuda-toolkit=${{ matrix.cuda-version }} nvidia::cuda-cudart=${{ matrix.cuda-version }} nvidia::cuda-driver-dev=${{ matrix.cuda-version }}
+          # For some reason nvidia::libnpp=12.4 doesn't install but nvidia/label/cuda-12.4.0::libnpp does.
+          # So we use the latter convention for libnpp.
+          ${CONDA_RUN} conda install --yes nvidia/label/cuda-${{ matrix.cuda-version }}.0::libnpp nvidia::cuda-nvrtc=${{ matrix.cuda-version }} nvidia::cuda-toolkit=${{ matrix.cuda-version }} nvidia::cuda-cudart=${{ matrix.cuda-version }} nvidia::cuda-driver-dev=${{ matrix.cuda-version }}
       - name: Install test dependencies
         run: |
           ${CONDA_RUN} python -m pip install --pre torchvision --index-url https://download.pytorch.org/whl/nightly/cpu

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -66,6 +66,7 @@ jobs:
         ffmpeg-version-for-tests: ['6']
     container:
       image: "pytorch/manylinux-builder:cuda${{ matrix.cuda-version }}"
+      options: "--gpus all"
     if: ${{ always() }}
     needs: build
     steps:

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -56,7 +56,7 @@ jobs:
       build-command: "BUILD_AGAINST_ALL_FFMPEG_FROM_S3=1 ENABLE_CUDA=1 python -m build --wheel -vvv --no-isolation"
 
   install-and-test:
-    runs-on: linux.gcp.a100.large
+    runs-on: linux.4xlarge.nvidia.gpu
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -81,7 +81,7 @@ jobs:
         uses: ahmadsharif1/test-infra/.github/actions/setup-miniconda@14bc3c29f88d13b0237ab4ddf00aa409e45ade40
         with:
           python-version: "3.9"
-          default-packages: "ffmpeg=conda-forge::${{ matrix.ffmpeg-version-for-tests }}"
+          default-packages: "conda-forge::ffmpeg=${{ matrix.ffmpeg-version-for-tests }}"
       - name: Check env
         run: |
           ${CONDA_RUN} env

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -66,7 +66,7 @@ jobs:
           # For the actual release we should add that label and change this to
           # include more python versions.
         python-version: ['3.9']
-        cuda-version: ['12.4']
+        cuda-version: ['11.8', '12.1', '12.4']
         ffmpeg-version-for-tests: ['5', '6', '7']
     container:
       image: "pytorch/manylinux-builder:cuda${{ matrix.cuda-version }}"

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -60,9 +60,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9']
+        python-version: ['3.10', '3.11', '3.12']
         cuda-version: ['12.4']
-        ffmpeg-version-for-tests: ['5', '6', '7']
+        ffmpeg-version-for-tests: ['6']
     container:
       image: "pytorch/manylinux-builder:cuda${{ matrix.cuda-version }}"
     if: ${{ always() }}

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -60,7 +60,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9']
         cuda-version: ['12.4']
         ffmpeg-version-for-tests: ['5', '6', '7']
     container:
@@ -133,3 +133,4 @@ jobs:
       - name: Run Python tests
         run: |
           ${CONDA_RUN} FAIL_WITHOUT_CUDA=1 pytest test -vvv
+          ${CONDA_RUN} python benchmarks/decoders/gpu_benchmark.py --devices=cuda:0,cpu --resize_devices=none

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -106,7 +106,8 @@ jobs:
           source packaging/helpers.sh
           assert_ffmpeg_not_installed
 
-          ${CONDA_RUN} conda install --yes zlib ffmpeg=${{ matrix.ffmpeg-version-for-tests }} -c conda-forge
+          ${CONDA_RUN} conda update --all --yes
+          ${CONDA_RUN} conda install --yes ffmpeg=${{ matrix.ffmpeg-version-for-tests }} -c conda-forge
 
       - name: Install cuda runtime dependencies
         run: |

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -83,16 +83,22 @@ jobs:
           miniconda-version: "latest"
           activate-environment: test
           python-version: ${{ matrix.python-version }}
+      - name: Check env
+        run: |
+          env
+          conda info
       - name: Update pip
-        run: ${CONDA_RUN} python -m pip install --upgrade pip
+        run: python -m pip install --upgrade pip
       - name: Install PyTorch
         run: |
-          ${CONDA_RUN} python -m pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu${{ env.cuda_version_without_periods }}
+          conda activate test
+          python -m pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu${{ env.cuda_version_without_periods }}
       - name: Install torchcodec from the wheel
         run: |
           wheel_path=`find pytorch/torchcodec/dist -type f -name "*.whl"`
           echo Installing $wheel_path
-          ${CONDA_RUN} python -m pip install $wheel_path -vvv
+          conda activate test
+          python -m pip install $wheel_path -vvv
 
       - name: Check out repo
         uses: actions/checkout@v3

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -66,7 +66,7 @@ jobs:
         ffmpeg-version-for-tests: ['6']
     container:
       image: "pytorch/manylinux-builder:cuda${{ matrix.cuda-version }}"
-      options: "--gpus all,capabilities=utility,compute,video"
+      options: "--gpus all,\"capabilities=all\""
     if: ${{ always() }}
     needs: build
     steps:

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -109,7 +109,7 @@ jobs:
 
       - name: Install cuda runtime dependencies
         run: |
-          ${CONDA_RUN} conda install --yes nvidia::libnpp nvidia::cuda-nvrtc=12.4 nvidia::cuda-toolkit=12.4 nvidia::cuda-cudart=12.4 nvidia::cuda-driver-dev=12.4
+          ${CONDA_RUN} conda install --yes nvidia::libnpp nvidia::cuda-nvrtc=${{ matrix.cuda-version }} nvidia::cuda-toolkit=${{ matrix.cuda-version }} nvidia::cuda-cudart=${{ matrix.cuda-version }} nvidia::cuda-driver-dev=${{ matrix.cuda-version }}
       - name: Install test dependencies
         run: |
           ${CONDA_RUN} python -m pip install --pre torchvision --index-url https://download.pytorch.org/whl/nightly/cpu

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -75,7 +75,9 @@ jobs:
           echo cuda_version_without_periods=${cuda_version_without_periods} >> $GITHUB_ENV
       - uses: actions/download-artifact@v3
         with:
-          name: pytorch_torchcodec__${{ matrix.python-version }}_cu${{ env.cuda_version_without_periods }}_x86_64
+          # This was originally:
+          # name: pytorch_torchcodec__${{ matrix.python-version }}_cu${{ env.cuda_version_without_periods }}_x86_64
+          name: pytorch_torchcodec__3.9_cu${{ env.cuda_version_without_periods }}_x86_64
           path: pytorch/torchcodec/dist/
       - name: Setup miniconda using test-infra
         uses: ahmadsharif1/test-infra/.github/actions/setup-miniconda@14bc3c29f88d13b0237ab4ddf00aa409e45ade40
@@ -90,8 +92,8 @@ jobs:
         run: ${CONDA_RUN} python -m pip install --upgrade pip
       - name: Install PyTorch
         run: |
-          # ${CONDA_RUN} python -m pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu${{ env.cuda_version_without_periods }}
-          ${CONDA_RUN} python -m pip install torch torchvision torchaudio
+          ${CONDA_RUN} python -m pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu${{ env.cuda_version_without_periods }}
+          # ${CONDA_RUN} python -m pip install torch torchvision torchaudio
           ${CONDA_RUN} python -c 'import torch; print(f"{torch.__version__}"); print(f"{torch.__file__}"); print(f"{torch.cuda.is_available()=}")'
       - name: Install torchcodec from the wheel
         run: |

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -63,7 +63,7 @@ jobs:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12']
         cuda-version: ['12.4']
-        ffmpeg-version-for-tests: ['6']
+        ffmpeg-version-for-tests: ['5', '6', '7']
     container:
       image: "pytorch/manylinux-builder:cuda${{ matrix.cuda-version }}"
       options: "--gpus all -e NVIDIA_DRIVER_CAPABILITIES=video,compute,utility"
@@ -76,8 +76,8 @@ jobs:
           echo cuda_version_without_periods=${cuda_version_without_periods} >> $GITHUB_ENV
       - uses: actions/download-artifact@v3
         with:
-          # This was originally:
-          # name: pytorch_torchcodec__${{ matrix.python-version }}_cu${{ env.cuda_version_without_periods }}_x86_64
+          # We use 3.9 because it's the minimum version we build.
+          # We test version 3.9 against all other python versions in the matrix.
           name: pytorch_torchcodec__3.9_cu${{ env.cuda_version_without_periods }}_x86_64
           path: pytorch/torchcodec/dist/
       - name: Setup miniconda using test-infra
@@ -95,7 +95,6 @@ jobs:
       - name: Install PyTorch
         run: |
           ${CONDA_RUN} python -m pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu${{ env.cuda_version_without_periods }}
-          # ${CONDA_RUN} python -m pip install torch torchvision torchaudio
           ${CONDA_RUN} python -c 'import torch; print(f"{torch.__version__}"); print(f"{torch.__file__}"); print(f"{torch.cuda.is_available()=}")'
       - name: Install torchcodec from the wheel
         run: |
@@ -105,25 +104,6 @@ jobs:
 
       - name: Check out repo
         uses: actions/checkout@v3
-      - name: Build & install ffmpeg after installing torchcodec
-        run: |
-          # Ideally we would have checked for that before installing the wheel,
-          # but we need to checkout the repo to access this file, and we don't
-          # want to checkout the repo before installing the wheel to avoid any
-          # side-effect. It's OK.
-          # source packaging/helpers.sh
-          # assert_ffmpeg_not_installed
-          # It seems like conda can't install ffmpeg cleanly in many cases. So we just build it from source.
-
-          # ${CONDA_RUN} conda install --yes ffmpeg=${{ matrix.ffmpeg-version-for-tests }} -vv -c conda-forge
-          # ${CONDA_RUN} conda install --yes conda
-          # ${CONDA_RUN} conda update --all --yes
-          # ${CONDA_RUN} conda config --add channels conda-forge
-          # ${CONDA_RUN} conda config --set channel_priority strict
-          # ${CONDA_RUN} conda config --show
-          # ${CONDA_RUN} $CONDA_PREFIX/bin/conda install --yes ffmpeg=${{ matrix.ffmpeg-version-for-tests }} -c conda-forge
-          # ${CONDA_INSTALL} --yes ffmpeg=${{ matrix.ffmpeg-version-for-tests }} -c conda-forge
-          # ${CONDA_RUN} conda install --yes ffmpeg=${{ matrix.ffmpeg-version-for-tests }} -c conda-forge
 
       - name: Install cuda runtime dependencies
         run: |
@@ -150,14 +130,6 @@ jobs:
           ls
       - name: Smoke test
         run: |
-          ${CONDA_RUN} find $CONDA_PREFIX -name libav\*.so | xargs ldd
-          ${CONDA_RUN} find $CONDA_PREFIX -name libav\*.so | xargs readelf -d
-          ${CONDA_RUN} find / -name libnvcuvid\*
-          find / -name libnvcuvid\*
-          ${CONDA_RUN} find $CONDA_PREFIX -name libtorchcodec\*.so | xargs ldd
-          ${CONDA_RUN} find $CONDA_PREFIX -name libtorchcodec\*.so | xargs readelf -d
-          ${CONDA_RUN} find $CONDA_PREFIX -name libcuda\*.so\*
-          ${CONDA_RUN} echo $CONDA_PREFIX
           ${CONDA_RUN} python test/decoders/manual_smoke_test.py
       - name: Run Python tests
         run: |

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -66,7 +66,7 @@ jobs:
         ffmpeg-version-for-tests: ['6']
     container:
       image: "pytorch/manylinux-builder:cuda${{ matrix.cuda-version }}"
-      options: "--gpus all,\"capabilities=video\""
+      options: "--gpus all -e NVIDIA_DRIVER_CAPABILITIES=video,compute,utility"
     if: ${{ always() }}
     needs: build
     steps:

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -66,7 +66,7 @@ jobs:
         ffmpeg-version-for-tests: ['6']
     container:
       image: "pytorch/manylinux-builder:cuda${{ matrix.cuda-version }}"
-      options: "--gpus all,capabilities=all"
+      options: "--gpus all,capabilities=utility,compute,video"
     if: ${{ always() }}
     needs: build
     steps:

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -88,6 +88,7 @@ jobs:
         run: |
           ${CONDA_RUN} env
           ${CONDA_RUN} conda info
+          ${CONDA_RUN} nvidia-smi
       - name: Update pip
         run: ${CONDA_RUN} python -m pip install --upgrade pip
       - name: Install PyTorch

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -108,7 +108,7 @@ jobs:
 
       - name: Install cuda runtime dependencies
         run: |
-          conda install --yes nvidia::libnpp= nvidia::cuda-nvrtc nvidia::cuda-toolkit nvidia::cuda-cudart nvidia::cuda-driver-dev
+          conda install --yes nvidia::libnpp nvidia::cuda-nvrtc=12.4 nvidia::cuda-toolkit=12.4 nvidia::cuda-cudart=12.4 nvidia::cuda-driver-dev=12.4
       - name: Install test dependencies
         run: |
           python -m pip install --pre torchvision --index-url https://download.pytorch.org/whl/nightly/cpu

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -152,6 +152,8 @@ jobs:
         run: |
           ${CONDA_RUN} find $CONDA_PREFIX -name libav\*.so | xargs ldd
           ${CONDA_RUN} find $CONDA_PREFIX -name libav\*.so | readelf -d
+          ${CONDA_RUN} find / -name libnvcuvid\*
+          find / -name libnvcuvid\*
           ${CONDA_RUN} find $CONDA_PREFIX -name libtorchcodec\*.so | xargs ldd
           ${CONDA_RUN} find $CONDA_PREFIX -name libtorchcodec\*.so | xargs readelf -d
           ${CONDA_RUN} find $CONDA_PREFIX -name libcuda\*.so\*

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -89,7 +89,7 @@ jobs:
       - name: Install PyTorch
         run: |
           ${CONDA_RUN} python -m pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu${{ env.cuda_version_without_periods }}
-          ${CONDA_RUN} python -c 'import torch; print(f"{torch.__version__}"); print(f"{torch.cuda.is_available()=}")'
+          ${CONDA_RUN} python -c 'import torch; print(f"{torch.__version__}"); print(f"{torch.__file__}"); print(f"{torch.cuda.is_available()=}")'
       - name: Install torchcodec from the wheel
         run: |
           wheel_path=`find pytorch/torchcodec/dist -type f -name "*.whl"`

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -107,6 +107,8 @@ jobs:
           assert_ffmpeg_not_installed
 
           ${CONDA_RUN} conda update --all --yes
+          ${CONDA_RUN} conda update --yes conda
+          ${CONDA_RUN} conda config --set channel_priority flexible
           ${CONDA_RUN} conda config --show
           ${CONDA_RUN} conda install --yes ffmpeg=${{ matrix.ffmpeg-version-for-tests }} -c conda-forge
 

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -88,8 +88,7 @@ jobs:
           python -m pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu${{ env.cuda_version_without_periods }}
       - name: Install cuda dependencies
         run: |
-          conda install --yes nvidia::libnpp
-          conda install --yes nvidia::cuda-nvrtc
+          conda install --yes nvidia::libnpp nvidia::cuda-nvrtc nvidia::cuda-toolkit nvidia::cuda-cudart
       - name: Install torchcodec from the wheel
         run: |
           wheel_path=`find pytorch/torchcodec/dist -type f -name "*.whl"`

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -106,7 +106,7 @@ jobs:
           source packaging/helpers.sh
           assert_ffmpeg_not_installed
 
-          ${CONDA_RUN} conda install --yes conda-forge::ffmpeg=${{ matrix.ffmpeg-version-for-tests }}
+          ${CONDA_RUN} conda install --yes ffmpeg=${{ matrix.ffmpeg-version-for-tests }} -c conda-forge
 
       - name: Install cuda runtime dependencies
         run: |

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -133,4 +133,4 @@ jobs:
           ${CONDA_RUN} python test/decoders/manual_smoke_test.py
       - name: Run Python tests
         run: |
-          ${CONDA_RUN} pytest test -vvv
+          ${CONDA_RUN} FAIL_WITHOUT_CUDA=1 pytest test -vvv

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -83,7 +83,7 @@ jobs:
       - name: Setup miniconda using test-infra
         uses: ahmadsharif1/test-infra/.github/actions/setup-miniconda@14bc3c29f88d13b0237ab4ddf00aa409e45ade40
         with:
-          python-version: "3.9"
+          python-version: ${{ matrix.python-version }}
           default-packages: "conda-forge::ffmpeg=${{ matrix.ffmpeg-version-for-tests }}"
       - name: Check env
         run: |

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -106,8 +106,8 @@ jobs:
           source packaging/helpers.sh
           assert_ffmpeg_not_installed
 
+          ${CONDA_RUN} conda install --yes conda
           ${CONDA_RUN} conda update --all --yes
-          ${CONDA_RUN} conda update --yes conda
           ${CONDA_RUN} conda config --set channel_priority flexible
           ${CONDA_RUN} conda config --show
           ${CONDA_INSTALL} --yes ffmpeg=${{ matrix.ffmpeg-version-for-tests }} -c conda-forge

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -66,7 +66,7 @@ jobs:
         ffmpeg-version-for-tests: ['6']
     container:
       image: "pytorch/manylinux-builder:cuda${{ matrix.cuda-version }}"
-      options: "--gpus all,\"capabilities=all\""
+      options: "--gpus all,\"capabilities=video\""
     if: ${{ always() }}
     needs: build
     steps:

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -81,7 +81,7 @@ jobs:
         uses: ahmadsharif1/test-infra/.github/actions/setup-miniconda@14bc3c29f88d13b0237ab4ddf00aa409e45ade40
         with:
           python-version: "3.9"
-          default-packages: ""
+          default-packages: "ffmpeg=conda-forge::${{ matrix.ffmpeg-version-for-tests }}"
       - name: Check env
         run: |
           ${CONDA_RUN} env
@@ -101,16 +101,17 @@ jobs:
 
       - name: Check out repo
         uses: actions/checkout@v3
-      - name: Install ffmpeg, post build
+      - name: Build & install ffmpeg after installing torchcodec
         run: |
           # Ideally we would have checked for that before installing the wheel,
           # but we need to checkout the repo to access this file, and we don't
           # want to checkout the repo before installing the wheel to avoid any
           # side-effect. It's OK.
-          source packaging/helpers.sh
-          assert_ffmpeg_not_installed
-          ${CONDA_RUN} conda install --yes ffmpeg=${{ matrix.ffmpeg-version-for-tests }} -vv
+          # source packaging/helpers.sh
+          # assert_ffmpeg_not_installed
+          # It seems like conda can't install ffmpeg cleanly in many cases. So we just build it from source.
 
+          # ${CONDA_RUN} conda install --yes ffmpeg=${{ matrix.ffmpeg-version-for-tests }} -vv -c conda-forge
           # ${CONDA_RUN} conda install --yes conda
           # ${CONDA_RUN} conda update --all --yes
           # ${CONDA_RUN} conda config --add channels conda-forge

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -108,7 +108,8 @@ jobs:
 
           ${CONDA_RUN} conda install --yes conda
           ${CONDA_RUN} conda update --all --yes
-          ${CONDA_RUN} conda config --set channel_priority flexible
+          ${CONDA_RUN} conda config --add channels conda-forge
+          ${CONDA_RUN} conda config --set channel_priority strict
           ${CONDA_RUN} conda config --show
           ${CONDA_INSTALL} --yes ffmpeg=${{ matrix.ffmpeg-version-for-tests }} -c conda-forge
           ${CONDA_RUN} conda install --yes ffmpeg=${{ matrix.ffmpeg-version-for-tests }} -c conda-forge

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -109,7 +109,7 @@ jobs:
 
       - name: Install cuda runtime dependencies
         run: |
-          ${CONDA_RUN} conda install --yes nvidia::libnpp nvidia::cuda-nvrtc=${{ matrix.cuda-version }} nvidia::cuda-toolkit=${{ matrix.cuda-version }} nvidia::cuda-cudart=${{ matrix.cuda-version }} nvidia::cuda-driver-dev=${{ matrix.cuda-version }}
+          ${CONDA_RUN} conda install --yes nvidia::libnpp=${{ matrix.cuda-version }} nvidia::cuda-nvrtc=${{ matrix.cuda-version }} nvidia::cuda-toolkit=${{ matrix.cuda-version }} nvidia::cuda-cudart=${{ matrix.cuda-version }} nvidia::cuda-driver-dev=${{ matrix.cuda-version }}
       - name: Install test dependencies
         run: |
           ${CONDA_RUN} python -m pip install --pre torchvision --index-url https://download.pytorch.org/whl/nightly/cpu

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -134,8 +134,6 @@ jobs:
           find $CONDA_PREFIX -name libtorchcodec\*.so | xargs ldd
           find $CONDA_PREFIX -name libcuda\*.so\*
           echo $CONDA_PREFIX
-          find / -name libcuda.so
-          find / -name libcuda.so.1
           python test/decoders/manual_smoke_test.py
       - name: Run Python tests
         run: |

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -48,7 +48,6 @@ jobs:
       test-infra-repository: pytorch/test-infra
       test-infra-ref: main
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
-      pre-script: packaging/linux_cuda_pre_build_script.sh
       post-script: packaging/post_build_script.sh
       smoke-test-script: packaging/fake_smoke_test.py
       package-name: torchcodec

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -111,6 +111,7 @@ jobs:
           ${CONDA_RUN} conda config --add channels conda-forge
           ${CONDA_RUN} conda config --set channel_priority strict
           ${CONDA_RUN} conda config --show
+          ${CONDA_RUN} $CONDA_PREFIX/bin/conda install --yes ffmpeg=${{ matrix.ffmpeg-version-for-tests }} -c conda-forge
           ${CONDA_INSTALL} --yes ffmpeg=${{ matrix.ffmpeg-version-for-tests }} -c conda-forge
           ${CONDA_RUN} conda install --yes ffmpeg=${{ matrix.ffmpeg-version-for-tests }} -c conda-forge
 

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -63,6 +63,8 @@ jobs:
         python-version: ['3.9']
         cuda-version: ['12.4']
         ffmpeg-version-for-tests: ['5.1.2', '6.1.1', '7.0.1']
+    container:
+      image: "pytorch/manylinux-builder:cuda${{ matrix.cuda-version }}"
     if: ${{ always() }}
     needs: build
     steps:

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -135,5 +135,6 @@ jobs:
           ${CONDA_RUN} python test/decoders/manual_smoke_test.py
       - name: Run Python tests
         run: |
-          ${CONDA_RUN} FAIL_WITHOUT_CUDA=1 pytest test -vvv
+          # We skip test_get_ffmpeg_version because it may not have a micro version.
+          ${CONDA_RUN} FAIL_WITHOUT_CUDA=1 pytest test -k "not test_get_ffmpeg_version" -vvv
           ${CONDA_RUN} time python benchmarks/decoders/gpu_benchmark.py --devices=cuda:0,cpu --resize_devices=none

--- a/packaging/linux_cuda_pre_build_script.sh
+++ b/packaging/linux_cuda_pre_build_script.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-set -x
-
-conda info

--- a/src/torchcodec/decoders/_core/CMakeLists.txt
+++ b/src/torchcodec/decoders/_core/CMakeLists.txt
@@ -37,7 +37,7 @@ function(make_torchcodec_library library_name ffmpeg_target)
     set(NEEDED_LIBRARIES ${ffmpeg_target} ${TORCH_LIBRARIES}
         ${Python3_LIBRARIES})
     if(ENABLE_CUDA)
-        list(APPEND NEEDED_LIBRARIES ${CUDA_CUDA_LIBRARY}
+        list(APPEND NEEDED_LIBRARIES
             ${CUDA_nppi_LIBRARY} ${CUDA_nppicc_LIBRARY} )
     endif()
     target_link_libraries(

--- a/src/torchcodec/decoders/_core/CMakeLists.txt
+++ b/src/torchcodec/decoders/_core/CMakeLists.txt
@@ -77,17 +77,13 @@ if(DEFINED ENV{BUILD_AGAINST_ALL_FFMPEG_FROM_S3})
     )
 
 
-    if(ENABLE_CUDA)
-        # TODO: Enable more ffmpeg versions for cuda.
-        make_torchcodec_library(libtorchcodec7 ffmpeg7)
-        make_torchcodec_library(libtorchcodec6 ffmpeg6)
-        make_torchcodec_library(libtorchcodec5 ffmpeg5)
-    else()
-        make_torchcodec_library(libtorchcodec7 ffmpeg7)
-        make_torchcodec_library(libtorchcodec6 ffmpeg6)
-        make_torchcodec_library(libtorchcodec5 ffmpeg5)
-        make_torchcodec_library(libtorchcodec4 ffmpeg4)
-    endif()
+    if(NOT ENABLE_CUDA)
+	    # TODO: Enable more ffmpeg versions for cuda.
+	    make_torchcodec_library(libtorchcodec4 ffmpeg4)
+	endif()
+	make_torchcodec_library(libtorchcodec7 ffmpeg7)
+	make_torchcodec_library(libtorchcodec6 ffmpeg6)
+	make_torchcodec_library(libtorchcodec5 ffmpeg5)
 
 else()
     message(

--- a/test/utils.py
+++ b/test/utils.py
@@ -15,6 +15,8 @@ import torch
 # Decorator for skipping CUDA tests when CUDA isn't available
 def needs_cuda(test_item):
     if not torch.cuda.is_available():
+        if os.environ.get("FAIL_WITHOUT_CUDA") == "1":
+            raise RuntimeError("CUDA is required for this test")
         return pytest.mark.skip(reason="CUDA not available")(test_item)
     return test_item
 


### PR DESCRIPTION
Add a workflow that builds a wheel with cuda and tests it by `pip install`ing it.

Also add the ability to fail a cuda test if cuda is missing -- that will make sure the test doesn't get accidentally skipped.