### PR TITLE
Fix cuda builds for lower than 6.1 ffmpeg versions

### DIFF
--- a/.github/workflows/cuda_tests.yaml
+++ b/.github/workflows/cuda_tests.yaml
@@ -16,7 +16,8 @@ jobs:
         python_version: ["3.9"]
         # TODO: Add more cuda versions.
         cuda_arch_version: ["12.4"]
-        ffmpeg_version: ["origin/release/4.4", "origin/release/5.1", "origin/release/6.1", "origin/release/7.1"]
+        # TODO: Get ffmpeg 4 to work. Currently fails to build with nvcc.
+        ffmpeg_version: ["origin/release/5.1", "origin/release/6.1", "origin/release/7.1"]
       fail-fast: false
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:

--- a/.github/workflows/cuda_tests.yaml
+++ b/.github/workflows/cuda_tests.yaml
@@ -16,7 +16,7 @@ jobs:
         python_version: ["3.9"]
         # TODO: Add more cuda versions.
         cuda_arch_version: ["12.4"]
-        ffmpeg_version: ["origin/release/6.1"]
+        ffmpeg_version: ["origin/release/4.4", "origin/release/5.1", "origin/release/6.1", "origin/release/7.1"]
       fail-fast: false
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:

--- a/src/torchcodec/decoders/_core/CudaDevice.cpp
+++ b/src/torchcodec/decoders/_core/CudaDevice.cpp
@@ -77,6 +77,8 @@ AVBufferRef* getFromCache(const torch::Device& device) {
   return nullptr;
 }
 
+#if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(58, 26, 100)
+
 AVBufferRef* getFFMPEGContextFromExistingCudaContext(
     const torch::Device& device,
     torch::DeviceIndex nonNegativeDeviceIndex,
@@ -105,6 +107,8 @@ AVBufferRef* getFFMPEGContextFromExistingCudaContext(
   return hw_device_ctx;
 }
 
+#else
+
 AVBufferRef* getFFMPEGContextFromNewCudaContext(
     const torch::Device& device,
     torch::DeviceIndex nonNegativeDeviceIndex,
@@ -121,6 +125,8 @@ AVBufferRef* getFFMPEGContextFromNewCudaContext(
   }
   return hw_device_ctx;
 }
+
+#endif
 
 AVBufferRef* getCudaContext(const torch::Device& device) {
   enum AVHWDeviceType type = av_hwdevice_find_type_by_name("cuda");


### PR DESCRIPTION
Previously we were always compiling code that contained a macro introduced in a new ffmpeg version. That would fail because that macro was not defined.

This change guards `getFFMPEGContextFromExistingCudaContext` for older libavutil versions because it contains a macro that's introduced in FFMPEG 6 onwards.

Also add more builders for different ffmpeg versions