### PR TITLE
Use test-infra's main branch now that https://github.com/pytorch/test-infra/pull/5789 is merged

### DIFF
--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -82,7 +82,7 @@ jobs:
           name: pytorch_torchcodec__3.9_cu${{ env.cuda_version_without_periods }}_x86_64
           path: pytorch/torchcodec/dist/
       - name: Setup miniconda using test-infra
-        uses: ahmadsharif1/test-infra/.github/actions/setup-miniconda@14bc3c29f88d13b0237ab4ddf00aa409e45ade40
+        uses: pytorch/test-infra/.github/actions/setup-miniconda@main
         with:
           python-version: ${{ matrix.python-version }}
           default-packages: "conda-forge::ffmpeg=${{ matrix.ffmpeg-version-for-tests }}"


### PR DESCRIPTION
We were only using my fork because https://github.com/pytorch/test-infra/pull/5789 was not merged