### PR TITLE
Expose `getFramesAtIndices` and `getFramesDisplayedByTimestamps` as public Python methods of VideoDecoder

### DIFF
--- a/src/torchcodec/decoders/_video_decoder.py
+++ b/src/torchcodec/decoders/_video_decoder.py
@@ -181,7 +181,10 @@ class VideoDecoder:
             duration_seconds=duration_seconds.item(),
         )
 
-    def get_frames_at(self, start: int, stop: int, step: int = 1) -> FrameBatch:
+    def get_frames_at(self, indices: list[int]) -> FrameBatch:
+        pass
+
+    def get_frames_in_range(self, start: int, stop: int, step: int = 1) -> FrameBatch:
         """Return multiple frames at the given index range.
 
         Frames are in [start, stop).
@@ -238,7 +241,10 @@ class VideoDecoder:
             duration_seconds=duration_seconds.item(),
         )
 
-    def get_frames_displayed_at(
+    def get_frames_displayed_at(self, seconds: list[float]) -> FrameBatch:
+        pass
+
+    def get_frames_displayed_in_range(
         self, start_seconds: float, stop_seconds: float
     ) -> FrameBatch:
         """Returns multiple frames in the given range.


### PR DESCRIPTION
This is about exposing the 2 C++ methods from https://github.com/pytorch/torchcodec/pull/280 and https://github.com/pytorch/torchcodec/pull/282 into the Python class.

It feels natural to want these methods to be called `get_frames_at()` and `get_frames_displayed_at()`, but these names are already occupied by our "range" function. We may then need to rename these existing "range" functions (see diff).