### PR TITLE
displayed -> played

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ decoder.get_frames_in_range(start=10, stop=30, step=5)
 #   duration_seconds: tensor([0.0400, 0.0400, 0.0400, 0.0400])
 
 # Time-based indexing with PTS and duration info
-decoder.get_frame_displayed_at(pts_seconds=2)
+decoder.get_frame_played_at(pts_seconds=2)
 # Frame:
 #   data (shape): torch.Size([3, 400, 640])
 #   pts_seconds: 2.0

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -4,7 +4,7 @@ Glossary
 .. glossary::
 
     pts
-       Presentation Time Stamp. The time at which a frame should be displayed.
+       Presentation Time Stamp. The time at which a frame should be played.
        In TorchCodec, pts are expressed in seconds.
 
     best stream

--- a/examples/basic_example.py
+++ b/examples/basic_example.py
@@ -150,18 +150,18 @@ plot(middle_frames.data, "Middle frames")
 # -------------------------
 #
 # So far, we have retrieved frames based on their index. We can also retrieve
-# frames based on *when* they are displayed with
-# :meth:`~torchcodec.decoders.VideoDecoder.get_frame_displayed_at` and
-# :meth:`~torchcodec.decoders.VideoDecoder.get_frames_displayed_in_range`, which
+# frames based on *when* they are played with
+# :meth:`~torchcodec.decoders.VideoDecoder.get_frame_played_at` and
+# :meth:`~torchcodec.decoders.VideoDecoder.get_frames_played_in_range`, which
 # also returns :class:`~torchcodec.Frame` and :class:`~torchcodec.FrameBatch`
 # respectively.
 
-frame_at_2_seconds = decoder.get_frame_displayed_at(seconds=2)
+frame_at_2_seconds = decoder.get_frame_played_at(seconds=2)
 print(f"{type(frame_at_2_seconds) = }")
 print(frame_at_2_seconds)
 
 # %%
-first_two_seconds = decoder.get_frames_displayed_in_range(
+first_two_seconds = decoder.get_frames_played_in_range(
     start_seconds=0,
     stop_seconds=2,
 )
@@ -169,5 +169,5 @@ print(f"{type(first_two_seconds) = }")
 print(first_two_seconds)
 
 # %%
-plot(frame_at_2_seconds.data, "Frame displayed at 2 seconds")
-plot(first_two_seconds.data, "Frames displayed during [0, 2) seconds")
+plot(frame_at_2_seconds.data, "Frame played at 2 seconds")
+plot(first_two_seconds.data, "Frames played during [0, 2) seconds")

--- a/src/torchcodec/decoders/_core/VideoDecoder.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoder.cpp
@@ -947,7 +947,7 @@ void VideoDecoder::convertAVFrameToDecodedOutputOnCPU(
   }
 }
 
-VideoDecoder::DecodedOutput VideoDecoder::getFrameDisplayedAtTimestampNoDemux(
+VideoDecoder::DecodedOutput VideoDecoder::getFramePlayedAtTimestampNoDemux(
     double seconds) {
   for (auto& [streamIndex, stream] : streams_) {
     double frameStartTime = ptsToSeconds(stream.currentPts, stream.timeBase);
@@ -1090,13 +1090,13 @@ VideoDecoder::BatchDecodedOutput VideoDecoder::getFramesAtIndices(
   return output;
 }
 
-VideoDecoder::BatchDecodedOutput VideoDecoder::getFramesDisplayedByTimestamps(
+VideoDecoder::BatchDecodedOutput VideoDecoder::getFramesPlayedByTimestamps(
     int streamIndex,
     const std::vector<double>& timestamps) {
   validateUserProvidedStreamIndex(streamIndex);
-  validateScannedAllStreams("getFramesDisplayedByTimestamps");
+  validateScannedAllStreams("getFramesPlayedByTimestamps");
 
-  // The frame displayed at timestamp t and the one displayed at timestamp `t +
+  // The frame played at timestamp t and the one played at timestamp `t +
   // eps` are probably the same frame, with the same index. The easiest way to
   // avoid decoding that unique frame twice is to convert the input timestamps
   // to indices, and leverage the de-duplication logic of getFramesAtIndices.
@@ -1168,12 +1168,12 @@ VideoDecoder::BatchDecodedOutput VideoDecoder::getFramesInRange(
 }
 
 VideoDecoder::BatchDecodedOutput
-VideoDecoder::getFramesDisplayedByTimestampInRange(
+VideoDecoder::getFramesPlayedByTimestampInRange(
     int streamIndex,
     double startSeconds,
     double stopSeconds) {
   validateUserProvidedStreamIndex(streamIndex);
-  validateScannedAllStreams("getFramesDisplayedByTimestampInRange");
+  validateScannedAllStreams("getFramesPlayedByTimestampInRange");
 
   const auto& streamMetadata = containerMetadata_.streams[streamIndex];
   double minSeconds = streamMetadata.minPtsSecondsFromScan.value();
@@ -1224,7 +1224,7 @@ VideoDecoder::getFramesDisplayedByTimestampInRange(
   // abstract player displays frames starting at the pts for that frame until
   // the pts for the next frame. There are two consequences:
   //
-  //   1. We ignore the duration for a frame. A frame is displayed until the
+  //   1. We ignore the duration for a frame. A frame is played until the
   //   next frame replaces it. This model is robust to durations being 0 or
   //   incorrect; our source of truth is the pts for frames. If duration is
   //   accurate, the nextPts for a frame would be equivalent to pts + duration.

--- a/src/torchcodec/decoders/_core/VideoDecoder.h
+++ b/src/torchcodec/decoders/_core/VideoDecoder.h
@@ -222,7 +222,7 @@ class VideoDecoder {
   // duration of 1.0s, it will be visible in the timestamp range [5.0, 6.0).
   // i.e. it will be returned when this function is called with seconds=5.0 or
   // seconds=5.999, etc.
-  DecodedOutput getFrameDisplayedAtTimestampNoDemux(double seconds);
+  DecodedOutput getFramePlayedAtTimestampNoDemux(double seconds);
 
   DecodedOutput getFrameAtIndex(
       int streamIndex,
@@ -244,7 +244,7 @@ class VideoDecoder {
       int streamIndex,
       const std::vector<int64_t>& frameIndices);
 
-  BatchDecodedOutput getFramesDisplayedByTimestamps(
+  BatchDecodedOutput getFramesPlayedByTimestamps(
       int streamIndex,
       const std::vector<double>& timestamps);
 
@@ -265,7 +265,7 @@ class VideoDecoder {
   // frame. Otherwise, the moment in time immediately before stopSeconds is in
   // the range, and that time maps to the same frame as stopSeconds.
   //
-  // The frames returned are the frames that would be displayed by our abstract
+  // The frames returned are the frames that would be played by our abstract
   // player. Our abstract player displays frames based on pts only. It displays
   // frame i starting at the pts for frame i, and stops at the pts for frame
   // i+1. This model ignores a frame's reported duration.
@@ -273,7 +273,7 @@ class VideoDecoder {
   // Valid values for startSeconds and stopSeconds are:
   //
   //   [minPtsSecondsFromScan, maxPtsSecondsFromScan)
-  BatchDecodedOutput getFramesDisplayedByTimestampInRange(
+  BatchDecodedOutput getFramesPlayedByTimestampInRange(
       int streamIndex,
       double startSeconds,
       double stopSeconds);

--- a/src/torchcodec/decoders/_core/VideoDecoderOps.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoderOps.cpp
@@ -207,7 +207,7 @@ OpsDecodedOutput get_next_frame(at::Tensor& decoder) {
 
 OpsDecodedOutput get_frame_at_pts(at::Tensor& decoder, double seconds) {
   auto videoDecoder = unwrapTensorToGetDecoder(decoder);
-  auto result = videoDecoder->getFrameDisplayedAtTimestampNoDemux(seconds);
+  auto result = videoDecoder->getFramePlayedAtTimestampNoDemux(seconds);
   return makeOpsDecodedOutput(result);
 }
 
@@ -249,7 +249,7 @@ OpsBatchDecodedOutput get_frames_by_pts(
   auto videoDecoder = unwrapTensorToGetDecoder(decoder);
   std::vector<double> timestampsVec(timestamps.begin(), timestamps.end());
   auto result =
-      videoDecoder->getFramesDisplayedByTimestamps(stream_index, timestampsVec);
+      videoDecoder->getFramesPlayedByTimestamps(stream_index, timestampsVec);
   return makeOpsBatchDecodedOutput(result);
 }
 
@@ -259,7 +259,7 @@ OpsBatchDecodedOutput get_frames_by_pts_in_range(
     double start_seconds,
     double stop_seconds) {
   auto videoDecoder = unwrapTensorToGetDecoder(decoder);
-  auto result = videoDecoder->getFramesDisplayedByTimestampInRange(
+  auto result = videoDecoder->getFramesPlayedByTimestampInRange(
       stream_index, start_seconds, stop_seconds);
   return makeOpsBatchDecodedOutput(result);
 }

--- a/src/torchcodec/decoders/_core/_metadata.py
+++ b/src/torchcodec/decoders/_core/_metadata.py
@@ -46,8 +46,8 @@ class VideoStreamMetadata:
     """End of the stream, in seconds (float or None).
     Conceptually, this corresponds to last_frame.pts + last_frame.duration. It
     is computed as max(frame.pts + frame.duration) across all frames in the
-    stream. Note that no frame is displayed at this time value, so calling
-    :meth:`~torchcodec.decoders.VideoDecoder.get_frame_displayed_at` with
+    stream. Note that no frame is played at this time value, so calling
+    :meth:`~torchcodec.decoders.VideoDecoder.get_frame_played_at` with
     this value would result in an error. Retrieving the last frame is best done
     by simply indexing the :class:`~torchcodec.decoders.VideoDecoder`
     object with ``[-1]``.

--- a/src/torchcodec/decoders/_video_decoder.py
+++ b/src/torchcodec/decoders/_video_decoder.py
@@ -240,14 +240,14 @@ class VideoDecoder:
         )
         return FrameBatch(*frames)
 
-    def get_frame_displayed_at(self, seconds: float) -> Frame:
-        """Return a single frame displayed at the given timestamp in seconds.
+    def get_frame_played_at(self, seconds: float) -> Frame:
+        """Return a single frame played at the given timestamp in seconds.
 
         Args:
-            seconds (float): The time stamp in seconds when the frame is displayed.
+            seconds (float): The time stamp in seconds when the frame is played.
 
         Returns:
-            Frame: The frame that is displayed at ``seconds``.
+            Frame: The frame that is played at ``seconds``.
         """
         if not self._begin_stream_seconds <= seconds < self._end_stream_seconds:
             raise IndexError(
@@ -264,21 +264,21 @@ class VideoDecoder:
             duration_seconds=duration_seconds.item(),
         )
 
-    def get_frames_displayed_at(self, seconds: list[float]) -> FrameBatch:
-        """Return frames displayed at the given timestamps in seconds.
+    def get_frames_played_at(self, seconds: list[float]) -> FrameBatch:
+        """Return frames played at the given timestamps in seconds.
 
         .. note::
 
             Calling this method is more efficient that repeated individual calls
-            to :meth:`~torchcodec.decoders.VideoDecoder.get_frame_displayed_at`.
+            to :meth:`~torchcodec.decoders.VideoDecoder.get_frame_played_at`.
             This method makes sure not to decode the same frame twice, and also
             avoids "backwards seek" operations, which are slow.
 
         Args:
-            seconds (list of float): The timestamps in seconds when the frames are displayed.
+            seconds (list of float): The timestamps in seconds when the frames are played.
 
         Returns:
-            FrameBatch: The frames that are displayed at ``seconds``.
+            FrameBatch: The frames that are played at ``seconds``.
         """
         data, pts_seconds, duration_seconds = core.get_frames_by_pts(
             self._decoder, timestamps=seconds, stream_index=self.stream_index
@@ -289,7 +289,7 @@ class VideoDecoder:
             duration_seconds=duration_seconds,
         )
 
-    def get_frames_displayed_in_range(
+    def get_frames_played_in_range(
         self, start_seconds: float, stop_seconds: float
     ) -> FrameBatch:
         """Returns multiple frames in the given range.

--- a/src/torchcodec/samplers/_time_based.py
+++ b/src/torchcodec/samplers/_time_based.py
@@ -209,7 +209,7 @@ def _generic_time_based_sampler(
         policy_fun=_POLICY_FUNCTIONS[policy],
     )
 
-    frames = decoder.get_frames_displayed_at(seconds=all_clips_timestamps)
+    frames = decoder.get_frames_played_at(seconds=all_clips_timestamps)
     return _reshape_4d_framebatch_into_5d(
         frames=frames,
         num_clips=num_clips,

--- a/test/decoders/VideoDecoderTest.cpp
+++ b/test/decoders/VideoDecoderTest.cpp
@@ -261,24 +261,23 @@ TEST_P(VideoDecoderTest, SeeksCloseToEof) {
   EXPECT_THROW(ourDecoder->getNextDecodedOutputNoDemux(), std::exception);
 }
 
-TEST_P(VideoDecoderTest, GetsFrameDisplayedAtTimestamp) {
+TEST_P(VideoDecoderTest, GetsFramePlayedAtTimestamp) {
   std::string path = getResourcePath("nasa_13013.mp4");
   std::unique_ptr<VideoDecoder> ourDecoder =
       createDecoderFromPath(path, GetParam());
   ourDecoder->addVideoStreamDecoder(-1);
-  auto output = ourDecoder->getFrameDisplayedAtTimestampNoDemux(6.006);
+  auto output = ourDecoder->getFramePlayedAtTimestampNoDemux(6.006);
   EXPECT_EQ(output.ptsSeconds, 6.006);
   // The frame's duration is 0.033367 according to ffprobe,
-  // so the next frame is displayed at timestamp=6.039367.
+  // so the next frame is played at timestamp=6.039367.
   const double kNextFramePts = 6.039366666666667;
-  // The frame that is displayed a microsecond before the next frame is still
+  // The frame that is played a microsecond before the next frame is still
   // the previous frame.
-  output =
-      ourDecoder->getFrameDisplayedAtTimestampNoDemux(kNextFramePts - 1e-6);
+  output = ourDecoder->getFramePlayedAtTimestampNoDemux(kNextFramePts - 1e-6);
   EXPECT_EQ(output.ptsSeconds, 6.006);
-  // The frame that is displayed at the exact pts of the frame is the next
+  // The frame that is played at the exact pts of the frame is the next
   // frame.
-  output = ourDecoder->getFrameDisplayedAtTimestampNoDemux(kNextFramePts);
+  output = ourDecoder->getFramePlayedAtTimestampNoDemux(kNextFramePts);
   EXPECT_EQ(output.ptsSeconds, kNextFramePts);
 
   // This is the timestamp of the last frame in this video.
@@ -288,7 +287,7 @@ TEST_P(VideoDecoderTest, GetsFrameDisplayedAtTimestamp) {
       kPtsOfLastFrameInVideoStream + kDurationOfLastFrameInVideoStream;
   // Sanity check: make sure duration is strictly positive.
   EXPECT_GT(kPtsPlusDurationOfLastFrame, kPtsOfLastFrameInVideoStream);
-  output = ourDecoder->getFrameDisplayedAtTimestampNoDemux(
+  output = ourDecoder->getFramePlayedAtTimestampNoDemux(
       kPtsPlusDurationOfLastFrame - 1e-6);
   EXPECT_EQ(output.ptsSeconds, kPtsOfLastFrameInVideoStream);
 }

--- a/test/decoders/test_video_decoder.py
+++ b/test/decoders/test_video_decoder.py
@@ -388,32 +388,32 @@ class TestVideoDecoder:
         with pytest.raises(RuntimeError, match="Expected a value of type"):
             decoder.get_frames_at([0.3])
 
-    def test_get_frame_displayed_at(self):
+    def test_get_frame_played_at(self):
         decoder = VideoDecoder(NASA_VIDEO.path)
 
         ref_frame6 = NASA_VIDEO.get_frame_by_name("time6.000000")
-        assert_tensor_equal(ref_frame6, decoder.get_frame_displayed_at(6.006).data)
-        assert_tensor_equal(ref_frame6, decoder.get_frame_displayed_at(6.02).data)
-        assert_tensor_equal(ref_frame6, decoder.get_frame_displayed_at(6.039366).data)
-        assert isinstance(decoder.get_frame_displayed_at(6.02).pts_seconds, float)
-        assert isinstance(decoder.get_frame_displayed_at(6.02).duration_seconds, float)
+        assert_tensor_equal(ref_frame6, decoder.get_frame_played_at(6.006).data)
+        assert_tensor_equal(ref_frame6, decoder.get_frame_played_at(6.02).data)
+        assert_tensor_equal(ref_frame6, decoder.get_frame_played_at(6.039366).data)
+        assert isinstance(decoder.get_frame_played_at(6.02).pts_seconds, float)
+        assert isinstance(decoder.get_frame_played_at(6.02).duration_seconds, float)
 
-    def test_get_frame_displayed_at_h265(self):
+    def test_get_frame_played_at_h265(self):
         # Non-regression test for https://github.com/pytorch/torchcodec/issues/179
         decoder = VideoDecoder(H265_VIDEO.path)
         ref_frame6 = H265_VIDEO.get_frame_data_by_index(5)
-        assert_tensor_equal(ref_frame6, decoder.get_frame_displayed_at(0.5).data)
+        assert_tensor_equal(ref_frame6, decoder.get_frame_played_at(0.5).data)
 
-    def test_get_frame_displayed_at_fails(self):
+    def test_get_frame_played_at_fails(self):
         decoder = VideoDecoder(NASA_VIDEO.path)
 
         with pytest.raises(IndexError, match="Invalid pts in seconds"):
-            frame = decoder.get_frame_displayed_at(-1.0)  # noqa
+            frame = decoder.get_frame_played_at(-1.0)  # noqa
 
         with pytest.raises(IndexError, match="Invalid pts in seconds"):
-            frame = decoder.get_frame_displayed_at(100.0)  # noqa
+            frame = decoder.get_frame_played_at(100.0)  # noqa
 
-    def test_get_frames_displayed_at(self):
+    def test_get_frames_played_at(self):
 
         decoder = VideoDecoder(NASA_VIDEO.path)
 
@@ -421,7 +421,7 @@ class TestVideoDecoder:
         # index 35. We use those indices as reference to test against.
         seconds = [0.84, 1.17, 0.85]
         reference_indices = [25, 35, 25]
-        frames = decoder.get_frames_displayed_at(seconds)
+        frames = decoder.get_frames_played_at(seconds)
 
         assert isinstance(frames, FrameBatch)
 
@@ -446,17 +446,17 @@ class TestVideoDecoder:
             frames.duration_seconds, expected_duration_seconds, atol=1e-4, rtol=0
         )
 
-    def test_get_frames_displayed_at_fails(self):
+    def test_get_frames_played_at_fails(self):
         decoder = VideoDecoder(NASA_VIDEO.path)
 
         with pytest.raises(RuntimeError, match="must be in range"):
-            decoder.get_frames_displayed_at([-1])
+            decoder.get_frames_played_at([-1])
 
         with pytest.raises(RuntimeError, match="must be in range"):
-            decoder.get_frames_displayed_at([14])
+            decoder.get_frames_played_at([14])
 
         with pytest.raises(RuntimeError, match="Expected a value of type"):
-            decoder.get_frames_displayed_at(["bad"])
+            decoder.get_frames_played_at(["bad"])
 
     @pytest.mark.parametrize("stream_index", [0, 3, None])
     def test_get_frames_in_range(self, stream_index):
@@ -551,9 +551,9 @@ class TestVideoDecoder:
             lambda decoder: decoder.get_frame_at(0).data,
             lambda decoder: decoder.get_frames_at([0, 1]).data,
             lambda decoder: decoder.get_frames_in_range(0, 4).data,
-            lambda decoder: decoder.get_frame_displayed_at(0).data,
-            lambda decoder: decoder.get_frames_displayed_at([0, 1]).data,
-            lambda decoder: decoder.get_frames_displayed_in_range(0, 1).data,
+            lambda decoder: decoder.get_frame_played_at(0).data,
+            lambda decoder: decoder.get_frames_played_at([0, 1]).data,
+            lambda decoder: decoder.get_frames_played_in_range(0, 1).data,
         ),
     )
     def test_dimension_order(self, dimension_order, frame_getter):
@@ -581,7 +581,7 @@ class TestVideoDecoder:
         decoder = VideoDecoder(NASA_VIDEO.path, stream_index=stream_index)
 
         # Note that we are comparing the results of VideoDecoder's method:
-        #   get_frames_displayed_in_range()
+        #   get_frames_played_in_range()
         # With the testing framework's method:
         #   get_frame_data_by_range()
         # That is, we are testing the correctness of a pts-based range against an index-
@@ -598,7 +598,7 @@ class TestVideoDecoder:
         # value for frame 5 that we have access to on the Python side is slightly less than the pts
         # value on the C++ side. This test still produces the correct result because a slightly
         # less value still falls into the correct window.
-        frames0_4 = decoder.get_frames_displayed_in_range(
+        frames0_4 = decoder.get_frames_played_in_range(
             decoder.get_frame_at(0).pts_seconds, decoder.get_frame_at(5).pts_seconds
         )
         assert_tensor_equal(
@@ -607,7 +607,7 @@ class TestVideoDecoder:
         )
 
         # Range where the stop seconds is about halfway between pts values for two frames.
-        also_frames0_4 = decoder.get_frames_displayed_in_range(
+        also_frames0_4 = decoder.get_frames_played_in_range(
             decoder.get_frame_at(0).pts_seconds,
             decoder.get_frame_at(4).pts_seconds + HALF_DURATION,
         )
@@ -615,7 +615,7 @@ class TestVideoDecoder:
 
         # Again, the intention here is to provide the exact values we care about. In practice, our
         # pts values are slightly smaller, so we nudge the start upwards.
-        frames5_9 = decoder.get_frames_displayed_in_range(
+        frames5_9 = decoder.get_frames_played_in_range(
             decoder.get_frame_at(5).pts_seconds,
             decoder.get_frame_at(10).pts_seconds,
         )
@@ -627,7 +627,7 @@ class TestVideoDecoder:
         # Range where we provide start_seconds and stop_seconds that are different, but
         # also should land in the same window of time between two frame's pts values. As
         # a result, we should only get back one frame.
-        frame6 = decoder.get_frames_displayed_in_range(
+        frame6 = decoder.get_frames_played_in_range(
             decoder.get_frame_at(6).pts_seconds,
             decoder.get_frame_at(6).pts_seconds + HALF_DURATION,
         )
@@ -637,7 +637,7 @@ class TestVideoDecoder:
         )
 
         # Very small range that falls in the same frame.
-        frame35 = decoder.get_frames_displayed_in_range(
+        frame35 = decoder.get_frames_played_in_range(
             decoder.get_frame_at(35).pts_seconds,
             decoder.get_frame_at(35).pts_seconds + 1e-10,
         )
@@ -649,7 +649,7 @@ class TestVideoDecoder:
         # Single frame where the start seconds is before frame i's pts, and the stop is
         # after frame i's pts, but before frame i+1's pts. In that scenario, we expect
         # to see frames i-1 and i.
-        frames7_8 = decoder.get_frames_displayed_in_range(
+        frames7_8 = decoder.get_frames_played_in_range(
             NASA_VIDEO.get_frame_info(8, stream_index=stream_index).pts_seconds
             - HALF_DURATION,
             NASA_VIDEO.get_frame_info(8, stream_index=stream_index).pts_seconds
@@ -661,7 +661,7 @@ class TestVideoDecoder:
         )
 
         # Start and stop seconds are the same value, which should not return a frame.
-        empty_frame = decoder.get_frames_displayed_in_range(
+        empty_frame = decoder.get_frames_played_in_range(
             NASA_VIDEO.get_frame_info(4, stream_index=stream_index).pts_seconds,
             NASA_VIDEO.get_frame_info(4, stream_index=stream_index).pts_seconds,
         )
@@ -677,7 +677,7 @@ class TestVideoDecoder:
         )
 
         # Start and stop seconds land within the first frame.
-        frame0 = decoder.get_frames_displayed_in_range(
+        frame0 = decoder.get_frames_played_in_range(
             NASA_VIDEO.get_frame_info(0, stream_index=stream_index).pts_seconds,
             NASA_VIDEO.get_frame_info(0, stream_index=stream_index).pts_seconds
             + HALF_DURATION,
@@ -689,7 +689,7 @@ class TestVideoDecoder:
 
         # We should be able to get all frames by giving the beginning and ending time
         # for the stream.
-        all_frames = decoder.get_frames_displayed_in_range(
+        all_frames = decoder.get_frames_played_in_range(
             decoder.metadata.begin_stream_seconds, decoder.metadata.end_stream_seconds
         )
         assert_tensor_equal(all_frames.data, decoder[:])
@@ -698,13 +698,13 @@ class TestVideoDecoder:
         decoder = VideoDecoder(NASA_VIDEO.path)
 
         with pytest.raises(ValueError, match="Invalid start seconds"):
-            frame = decoder.get_frames_displayed_in_range(100.0, 1.0)  # noqa
+            frame = decoder.get_frames_played_in_range(100.0, 1.0)  # noqa
 
         with pytest.raises(ValueError, match="Invalid start seconds"):
-            frame = decoder.get_frames_displayed_in_range(20, 23)  # noqa
+            frame = decoder.get_frames_played_in_range(20, 23)  # noqa
 
         with pytest.raises(ValueError, match="Invalid stop seconds"):
-            frame = decoder.get_frames_displayed_in_range(0, 23)  # noqa
+            frame = decoder.get_frames_played_in_range(0, 23)  # noqa
 
 
 if __name__ == "__main__":

--- a/test/decoders/test_video_decoder_ops.py
+++ b/test/decoders/test_video_decoder_ops.py
@@ -96,7 +96,7 @@ class TestOps:
         frame0, _, _ = get_frame_at_index(decoder, stream_index=3, frame_index=0)
         reference_frame0 = NASA_VIDEO.get_frame_data_by_index(0)
         assert_tensor_equal(frame0, reference_frame0)
-        # The frame that is displayed at 6 seconds is frame 180 from a 0-based index.
+        # The frame that is played at 6 seconds is frame 180 from a 0-based index.
         frame6, _, _ = get_frame_at_index(decoder, stream_index=3, frame_index=180)
         reference_frame6 = NASA_VIDEO.get_frame_by_name("time6.000000")
         assert_tensor_equal(frame6, reference_frame6)


### PR DESCRIPTION
This PR renames all our "displayed" names into "played". This is in preparation for adding audio decoder where "displayed" wouldn't be a good unified name.

```
~/dev/torchcodec (played_at*) » git grep -i displayed | wc -l       
0
```