### PR TITLE
Relax test constraint for ffmpeg versions as they can be arbitrary

### DIFF
--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -135,8 +135,7 @@ jobs:
           ${CONDA_RUN} python test/decoders/manual_smoke_test.py
       - name: Run Python tests
         run: |
-          # We skip test_get_ffmpeg_version because it may not have a micro version.
-          ${CONDA_RUN} FAIL_WITHOUT_CUDA=1 pytest test -k "not test_get_ffmpeg_version" -vvv
+          ${CONDA_RUN} FAIL_WITHOUT_CUDA=1 pytest test -vvv
       - name: Run Python benchmark
         run: |
           ${CONDA_RUN} time python benchmarks/decoders/gpu_benchmark.py --devices=cuda:0,cpu --resize_devices=none

--- a/test/decoders/test_video_decoder_ops.py
+++ b/test/decoders/test_video_decoder_ops.py
@@ -423,9 +423,7 @@ class TestOps:
         # The earliest libavutil version is 50 as per:
         # https://www.ffmpeg.org/olddownload.html
         assert ffmpeg_dict["libavutil"][0] > 50
-        ffmpeg_version = ffmpeg_dict["ffmpeg_version"]
-        split_ffmpeg_version = [int(num) for num in ffmpeg_version.split(".")]
-        assert len(split_ffmpeg_version) == 3
+        assert "ffmpeg_version" in ffmpeg_dict
 
     def test_frame_pts_equality(self):
         decoder = create_from_file(str(NASA_VIDEO.path))


### PR DESCRIPTION
ffmpeg could be built from source in which case the version may not be a release version and the version could just be a short hash.

Moreover some ffmepg versions on conda-forge don't have a minor or micro version.