### PR TITLE
Fix indentation

### DIFF
--- a/benchmarks/decoders/benchmark_decoders_library.py
+++ b/benchmarks/decoders/benchmark_decoders_library.py
@@ -369,5 +369,5 @@ def run_benchmarks(
                     min_run_time=2.0,
                 )
             )
-        compare = benchmark.Compare(results)
-        compare.print()
+    compare = benchmark.Compare(results)
+    compare.print()


### PR DESCRIPTION
Otherwise with more than 1 decoders it keeps printing results in a loop as it gathers them.

This was missed in PR: https://github.com/pytorch/torchcodec/pull/290

I tested this:

```
python benchmarks/decoders/benchmark_decoders.py --decoders=tcoptions:color_conversion_library=swscale,tcoptions:color_conversion
_library=filtergraph,tcoptions:num_threads=1+color_conversion_library=swscale,tcoptions:num_threads=1+color_conversion_library=filtergraph --bm_video_speed_min_run_seconds=0.1
video=/home/ahmads/personal/torchcodec/benchmarks/decoders/../../test/resources/nasa_13013.mp4, decoder=TorchcodecNonCompiled:num_threads=1+color_conversion_library=filtergraph

video=/home/ahmads/personal/torchcodec/benchmarks/decoders/../../test/resources/nasa_13013.mp4, decoder=TorchcodecNonCompiled:num_threads=1+color_conversion_library=swscale
[-- video=/home/ahmads/personal/torchcodec/benchmarks/decoders/../../test/resources/nasa_13013.mp4 h264 480x270, 13.013s 29.97002997002997fps ---]
                                                                                |  10 seek()+next()  |  1 next()  |  10 next()  |  create()+next()
1 threads: ---------------------------------------------------------------------------------------------------------------------------------------
      TorchcodecNonCompiled:num_threads=1+color_conversion_library=filtergraph  |       122.0        |     7.3    |     14.8    |                 
      TorchcodecNonCompiled                                                     |                    |            |             |        22.8     
      TorchcodecNonCompiled:color_conversion_library=swscale                    |        65.1        |    21.6    |     26.5    |                 
      TorchcodecNonCompiled:color_conversion_library=filtergraph                |        68.4        |    30.8    |     33.5    |                 
      TorchcodecNonCompiled:num_threads=1+color_conversion_library=swscale      |       126.2        |     7.1    |     10.9    |                 
```