### PR TITLE
Make ffmpeg build workflow execute when script changes

### DIFF
--- a/.github/workflows/build_ffmpeg.yaml
+++ b/.github/workflows/build_ffmpeg.yaml
@@ -11,6 +11,9 @@ name: Build non-GPL FFmpeg from source
 
 on:
   workflow_dispatch:
+  pull_request:
+    paths:
+      - packaging/build_ffmpeg.sh
   schedule:
     - cron: '0 0 * * 0'  # on sunday
 
@@ -46,13 +49,12 @@ jobs:
       fail-fast: false
       matrix:
         ffmpeg-version: ["4.4.4", "5.1.4", "6.1.1", "7.0.1"]
-        runner: ["macos-m1-stable"]
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
     with:
       job-name: Build
       upload-artifact: ffmpeg-lgpl
       repository: pytorch/torchcodec
-      runner: "${{ matrix.runner }}"
+      runner: macos-14-xlarge
       script: |
         export FFMPEG_VERSION="${{ matrix.ffmpeg-version }}"
         export FFMPEG_ROOT="${PWD}/ffmpeg"


### PR DESCRIPTION
Before this, we were hacking the workflow definition to execute on a PR to test it. We don't want this running on _every_ PR, because that would be wasteful and noisy. But we can easily make it run when the FFMpeg building script has changed, which is what we wanted before.

Previous versions of this PR had a trivial change to trigger CI. One of those runs: https://github.com/pytorch/torchcodec/actions/runs/11560100235?pr=313. The current one does not have that trivial change to the script, and the test does not run.