### PR TITLE
Account for current pointer being outside of the buffer

### DIFF
--- a/src/torchcodec/decoders/_core/FFMPEGCommon.cpp
+++ b/src/torchcodec/decoders/_core/FFMPEGCommon.cpp
@@ -69,6 +69,12 @@ AVIOContext* AVIOBytesContext::getAVIO() {
 int AVIOBytesContext::read(void* opaque, uint8_t* buf, int buf_size) {
   struct AVIOBufferData* bufferData =
       static_cast<struct AVIOBufferData*>(opaque);
+  TORCH_CHECK(
+      bufferData->current <= bufferData->size,
+      "Tried to read outside of the buffer: current=",
+      bufferData->current,
+      ", size=",
+      bufferData->size);
   buf_size = FFMIN(buf_size, bufferData->size - bufferData->current);
   TORCH_CHECK(
       buf_size >= 0,


### PR DESCRIPTION
Summary:
D60461269 added `TORCH_CHECK` to catch negative values. This would catch the input argument `buf_size` being negative.

However, it never caught the case of `bufferData->current` pointer being past `bufferData->size`. This is due to intricacies of C++ type rules. Both `current` and `size` are `size_t` (unsigned integers), which causes the subtraction to always be non-negative.

[This example](https://www.programiz.com/online-compiler/3zokStBbD2TeP) demonstrates above well.

If we only had `read` method the `current` would never be able to go past `size`, but we have `seek` method that can set `current` to arbitrary values.

The diff here makes sure that we actually catch these negative values and fail with reasonable error instead of segfaulting trying to read memory outside of the buffer.

Differential Revision: D65118896


