### PR TITLE
Add batch decoding support to CUDA

### DIFF
--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -89,7 +89,7 @@ jobs:
           # For some reason nvidia::libnpp=12.4 doesn't install but nvidia/label/cuda-12.4.0::libnpp does.
           # So we use the latter convention for libnpp.
           # We install conda packages at the start because otherwise conda may have conflicts with dependencies.
-          default-packages: "nvidia/label/cuda-${{ matrix.cuda-version }}.0::libnpp nvidia::cuda-nvrtc=${{ matrix.cuda-version }} nvidia::cuda-toolkit=${{ matrix.cuda-version }} nvidia::cuda-cudart=${{ matrix.cuda-version }} nvidia::cuda-driver-dev=${{ matrix.cuda-version }} conda-forge::ffmpeg=${{ matrix.ffmpeg-version-for-tests }} conda-forge::xorg-libxau"
+          default-packages: "nvidia/label/cuda-${{ matrix.cuda-version }}.0::libnpp nvidia::cuda-nvrtc=${{ matrix.cuda-version }} nvidia::cuda-toolkit=${{ matrix.cuda-version }} nvidia::cuda-cudart=${{ matrix.cuda-version }} nvidia::cuda-driver-dev=${{ matrix.cuda-version }} conda-forge::ffmpeg=${{ matrix.ffmpeg-version-for-tests }}"
       - name: Check env
         run: |
           ${CONDA_RUN} env

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -89,7 +89,7 @@ jobs:
           # For some reason nvidia::libnpp=12.4 doesn't install but nvidia/label/cuda-12.4.0::libnpp does.
           # So we use the latter convention for libnpp.
           # We install conda packages at the start because otherwise conda may have conflicts with dependencies.
-          default-packages: "nvidia/label/cuda-${{ matrix.cuda-version }}.0::libnpp nvidia::cuda-nvrtc=${{ matrix.cuda-version }} nvidia::cuda-toolkit=${{ matrix.cuda-version }} nvidia::cuda-cudart=${{ matrix.cuda-version }} nvidia::cuda-driver-dev=${{ matrix.cuda-version }} conda-forge::ffmpeg=${{ matrix.ffmpeg-version-for-tests }}"
+          default-packages: "nvidia/label/cuda-${{ matrix.cuda-version }}.0::libnpp nvidia::cuda-nvrtc=${{ matrix.cuda-version }} nvidia::cuda-toolkit=${{ matrix.cuda-version }} nvidia::cuda-cudart=${{ matrix.cuda-version }} nvidia::cuda-driver-dev=${{ matrix.cuda-version }} conda-forge::ffmpeg=${{ matrix.ffmpeg-version-for-tests }} conda-forge::xorg-libxau"
       - name: Check env
         run: |
           ${CONDA_RUN} env

--- a/benchmarks/samplers/benchmark_samplers.py
+++ b/benchmarks/samplers/benchmark_samplers.py
@@ -1,3 +1,4 @@
+import argparse
 from pathlib import Path
 from time import perf_counter_ns
 
@@ -45,8 +46,7 @@ def report_stats(times, num_frames, unit="ms"):
     return med, fps
 
 
-def sample(sampler, **kwargs):
-    decoder = VideoDecoder(VIDEO_PATH)
+def sample(decoder, sampler, **kwargs):
     return sampler(
         decoder,
         num_frames_per_clip=10,
@@ -54,42 +54,64 @@ def sample(sampler, **kwargs):
     )
 
 
-VIDEO_PATH = Path(__file__).parent / "../../test/resources/nasa_13013.mp4"
-NUM_EXP = 30
+def main(device, video):
+    NUM_EXP = 30
 
-for num_clips in (1, 50):
-    print("-" * 10)
-    print(f"{num_clips = }")
+    for num_clips in (1, 50):
+        print("-" * 10)
+        print(f"{num_clips = }")
 
-    print("clips_at_random_indices     ", end="")
-    times, num_frames = bench(
-        sample, clips_at_random_indices, num_clips=num_clips, num_exp=NUM_EXP, warmup=2
-    )
-    report_stats(times, num_frames, unit="ms")
+        print("clips_at_random_indices     ", end="")
+        decoder = VideoDecoder(video, device=device)
+        times, num_frames = bench(
+            sample,
+            decoder,
+            clips_at_random_indices,
+            num_clips=num_clips,
+            num_exp=NUM_EXP,
+            warmup=2,
+        )
+        report_stats(times, num_frames, unit="ms")
 
-    print("clips_at_regular_indices    ", end="")
-    times, num_frames = bench(
-        sample, clips_at_regular_indices, num_clips=num_clips, num_exp=NUM_EXP, warmup=2
-    )
-    report_stats(times, num_frames, unit="ms")
+        print("clips_at_regular_indices    ", end="")
+        times, num_frames = bench(
+            sample,
+            decoder,
+            clips_at_regular_indices,
+            num_clips=num_clips,
+            num_exp=NUM_EXP,
+            warmup=2,
+        )
+        report_stats(times, num_frames, unit="ms")
 
-    print("clips_at_random_timestamps  ", end="")
-    times, num_frames = bench(
-        sample,
-        clips_at_random_timestamps,
-        num_clips=num_clips,
-        num_exp=NUM_EXP,
-        warmup=2,
-    )
-    report_stats(times, num_frames, unit="ms")
+        print("clips_at_random_timestamps  ", end="")
+        times, num_frames = bench(
+            sample,
+            decoder,
+            clips_at_random_timestamps,
+            num_clips=num_clips,
+            num_exp=NUM_EXP,
+            warmup=2,
+        )
+        report_stats(times, num_frames, unit="ms")
 
-    print("clips_at_regular_timestamps ", end="")
-    seconds_between_clip_starts = 13 / num_clips  # approximate. video is 13s long
-    times, num_frames = bench(
-        sample,
-        clips_at_regular_timestamps,
-        seconds_between_clip_starts=seconds_between_clip_starts,
-        num_exp=NUM_EXP,
-        warmup=2,
-    )
-    report_stats(times, num_frames, unit="ms")
+        print("clips_at_regular_timestamps ", end="")
+        seconds_between_clip_starts = 13 / num_clips  # approximate. video is 13s long
+        times, num_frames = bench(
+            sample,
+            decoder,
+            clips_at_regular_timestamps,
+            seconds_between_clip_starts=seconds_between_clip_starts,
+            num_exp=NUM_EXP,
+            warmup=2,
+        )
+        report_stats(times, num_frames, unit="ms")
+
+
+if __name__ == "__main__":
+    DEFAULT_VIDEO_PATH = Path(__file__).parent / "../../test/resources/nasa_13013.mp4"
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--device", type=str, default="cpu")
+    parser.add_argument("--video", type=str, default=str(DEFAULT_VIDEO_PATH))
+    args = parser.parse_args()
+    main(args.device, args.video)

--- a/benchmarks/samplers/benchmark_samplers.py
+++ b/benchmarks/samplers/benchmark_samplers.py
@@ -54,7 +54,7 @@ def sample(decoder, sampler, **kwargs):
     )
 
 
-def main(device, video):
+def run_sampler_benchmarks(device, video):
     NUM_EXP = 30
 
     for num_clips in (1, 50):
@@ -108,10 +108,14 @@ def main(device, video):
         report_stats(times, num_frames, unit="ms")
 
 
-if __name__ == "__main__":
+def main():
     DEFAULT_VIDEO_PATH = Path(__file__).parent / "../../test/resources/nasa_13013.mp4"
     parser = argparse.ArgumentParser()
     parser.add_argument("--device", type=str, default="cpu")
     parser.add_argument("--video", type=str, default=str(DEFAULT_VIDEO_PATH))
     args = parser.parse_args()
-    main(args.device, args.video)
+    run_sampler_benchmarks(args.device, args.video)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/torchcodec/decoders/_core/CPUOnlyDevice.cpp
+++ b/src/torchcodec/decoders/_core/CPUOnlyDevice.cpp
@@ -19,7 +19,8 @@ void convertAVFrameToDecodedOutputOnCuda(
     const VideoDecoder::VideoStreamDecoderOptions& options,
     AVCodecContext* codecContext,
     VideoDecoder::RawDecodedOutput& rawOutput,
-    VideoDecoder::DecodedOutput& output) {
+    VideoDecoder::DecodedOutput& output,
+    std::optional<torch::Tensor> preAllocatedOutputTensor) {
   throwUnsupportedDeviceError(device);
 }
 

--- a/src/torchcodec/decoders/_core/DeviceInterface.h
+++ b/src/torchcodec/decoders/_core/DeviceInterface.h
@@ -37,7 +37,8 @@ void convertAVFrameToDecodedOutputOnCuda(
     const VideoDecoder::VideoStreamDecoderOptions& options,
     AVCodecContext* codecContext,
     VideoDecoder::RawDecodedOutput& rawOutput,
-    VideoDecoder::DecodedOutput& output);
+    VideoDecoder::DecodedOutput& output,
+    std::optional<torch::Tensor> preAllocatedOutputTensor = std::nullopt);
 
 void releaseContextOnCuda(
     const torch::Device& device,

--- a/src/torchcodec/decoders/_core/VideoDecoder.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoder.cpp
@@ -855,11 +855,11 @@ VideoDecoder::DecodedOutput VideoDecoder::convertAVFrameToDecodedOutput(
   output.duration = getDuration(frame);
   output.durationSeconds = ptsToSeconds(
       getDuration(frame), formatContext_->streams[streamIndex]->time_base);
+  // TODO: we should fold preAllocatedOutputTensor into RawDecodedOutput.
   if (streamInfo.options.device.type() == torch::kCPU) {
     convertAVFrameToDecodedOutputOnCPU(
         rawOutput, output, preAllocatedOutputTensor);
   } else if (streamInfo.options.device.type() == torch::kCUDA) {
-    // TODO: we should fold preAllocatedOutputTensor into RawDecodedOutput.
     convertAVFrameToDecodedOutputOnCuda(
         streamInfo.options.device,
         streamInfo.options,

--- a/src/torchcodec/decoders/_video_decoder.py
+++ b/src/torchcodec/decoders/_video_decoder.py
@@ -8,7 +8,7 @@ import numbers
 from pathlib import Path
 from typing import Literal, Optional, Tuple, Union
 
-from torch import Tensor
+from torch import device, Tensor
 
 from torchcodec import Frame, FrameBatch
 from torchcodec.decoders import _core as core
@@ -41,6 +41,8 @@ class VideoDecoder:
             instances of ``VideoDecoder`` in parallel. Use a higher number for multi-threaded
             decoding which is best if you are running a single instance of ``VideoDecoder``.
             Default: 1.
+        device (str or torch.device, optional): The device to use for decoding.
+
 
             .. note::
 
@@ -64,6 +66,7 @@ class VideoDecoder:
         stream_index: Optional[int] = None,
         dimension_order: Literal["NCHW", "NHWC"] = "NCHW",
         num_ffmpeg_threads: int = 1,
+        device: Optional[Union[str, device]] = "cpu",
     ):
         if isinstance(source, str):
             self._decoder = core.create_from_file(source)
@@ -92,6 +95,7 @@ class VideoDecoder:
             stream_index=stream_index,
             dimension_order=dimension_order,
             num_threads=num_ffmpeg_threads,
+            device=device,
         )
 
         self.metadata, self.stream_index = _get_and_validate_stream_metadata(

--- a/src/torchcodec/decoders/_video_decoder.py
+++ b/src/torchcodec/decoders/_video_decoder.py
@@ -36,14 +36,6 @@ class VideoDecoder:
             This can be either "NCHW" (default) or "NHWC", where N is the batch
             size, C is the number of channels, H is the height, and W is the
             width of the frames.
-        num_ffmpeg_threads (int, optional): The number of threads to use for decoding.
-            Use 1 for single-threaded decoding which may be best if you are running multiple
-            instances of ``VideoDecoder`` in parallel. Use a higher number for multi-threaded
-            decoding which is best if you are running a single instance of ``VideoDecoder``.
-            Default: 1.
-        device (str or torch.device, optional): The device to use for decoding.
-
-
             .. note::
 
                 Frames are natively decoded in NHWC format by the underlying
@@ -51,6 +43,13 @@ class VideoDecoder:
                 cheap no-copy operation that allows these frames to be
                 transformed using the `torchvision transforms
                 <https://pytorch.org/vision/stable/transforms.html>`_.
+        num_ffmpeg_threads (int, optional): The number of threads to use for decoding.
+            Use 1 for single-threaded decoding which may be best if you are running multiple
+            instances of ``VideoDecoder`` in parallel. Use a higher number for multi-threaded
+            decoding which is best if you are running a single instance of ``VideoDecoder``.
+            Default: 1.
+        device (str or torch.device, optional): The device to use for decoding. Default: "cpu".
+
 
     Attributes:
         metadata (VideoStreamMetadata): Metadata of the video stream.

--- a/test/decoders/test_video_decoder_ops.py
+++ b/test/decoders/test_video_decoder_ops.py
@@ -222,6 +222,40 @@ class TestOps:
         with pytest.raises(AssertionError):
             assert_tensor_equal(frames[0], frames[-1])
 
+    # TODO: Figure out how to parameterize this test to run on both CPU and CUDA.abs
+    # The question is how to have the @needs_cuda decorator with the pytest.mark.parametrize
+    # decorator on the same test.
+    @needs_cuda
+    def test_get_frames_by_pts_with_cuda(self):
+        decoder = create_from_file(str(NASA_VIDEO.path))
+        _add_video_stream(decoder, device="cuda")
+        scan_all_streams_to_update_metadata(decoder)
+        stream_index = 3
+
+        # Note: 13.01 should give the last video frame for the NASA video
+        timestamps = [2, 0, 1, 0 + 1e-3, 13.01, 2 + 1e-3]
+
+        expected_frames = [
+            get_frame_at_pts(decoder, seconds=pts)[0] for pts in timestamps
+        ]
+
+        frames, *_ = get_frames_by_pts(
+            decoder,
+            stream_index=stream_index,
+            timestamps=timestamps,
+        )
+        for frame, expected_frame in zip(frames, expected_frames):
+            assert_tensor_equal(frame, expected_frame)
+
+        # first and last frame should be equal, at pts=2 [+ eps]. We then modify
+        # the first frame and assert that it's now different from the last
+        # frame. This ensures a copy was properly made during the de-duplication
+        # logic.
+        assert_tensor_equal(frames[0], frames[-1])
+        frames[0] += 20
+        with pytest.raises(AssertionError):
+            assert_tensor_equal(frames[0], frames[-1])
+
     def test_pts_apis_against_index_ref(self):
         # Non-regression test for https://github.com/pytorch/torchcodec/pull/287
         # Get all frames in the video, then query all frames with all time-based

--- a/test/decoders/test_video_decoder_ops.py
+++ b/test/decoders/test_video_decoder_ops.py
@@ -36,7 +36,13 @@ from torchcodec.decoders._core import (
     seek_to_pts,
 )
 
-from ..utils import assert_tensor_equal, NASA_AUDIO, NASA_VIDEO, needs_cuda
+from ..utils import (
+    assert_tensor_equal,
+    assert_tensor_nearly_equal,
+    NASA_AUDIO,
+    NASA_VIDEO,
+    needs_cuda,
+)
 
 torch._dynamo.config.capture_dynamic_output_shape_ops = True
 
@@ -55,12 +61,6 @@ class ReferenceDecoder:
     def seek(self, pts: float):
         assert self.decoder is not None
         seek_to_pts(self.decoder, pts)
-
-
-# Asserts that at most percentage of the elements are different by more than abs_tolerance.
-def assert_tensor_nearly_equal(frame1, frame2, percentage=0.3, abs_tolerance=20):
-    diff = (frame2.float() - frame1.float()).abs()
-    assert (diff > abs_tolerance).float().mean() <= percentage / 100.0
 
 
 class TestOps:

--- a/test/decoders/test_video_decoder_ops.py
+++ b/test/decoders/test_video_decoder_ops.py
@@ -37,8 +37,8 @@ from torchcodec.decoders._core import (
 )
 
 from ..utils import (
+    assert_tensor_close_on_at_least,
     assert_tensor_equal,
-    assert_tensor_nearly_equal,
     NASA_AUDIO,
     NASA_VIDEO,
     needs_cuda,
@@ -156,8 +156,8 @@ class TestOps:
             INDEX_OF_FRAME_AT_6_SECONDS
         )
         assert frames0and180.device.type == "cuda"
-        assert_tensor_nearly_equal(frames0and180[0].to("cpu"), reference_frame0)
-        assert_tensor_nearly_equal(
+        assert_tensor_close_on_at_least(frames0and180[0].to("cpu"), reference_frame0)
+        assert_tensor_close_on_at_least(
             frames0and180[1].to("cpu"), reference_frame180, 0.3, 30
         )
 
@@ -716,7 +716,7 @@ class TestOps:
         frame0_cpu = frame0.to("cpu")
         reference_frame0 = NASA_VIDEO.get_frame_data_by_index(0)
         # GPU decode is not bit-accurate. So we allow some tolerance.
-        assert_tensor_nearly_equal(frame0_cpu, reference_frame0)
+        assert_tensor_close_on_at_least(frame0_cpu, reference_frame0)
         diff = (reference_frame0.float() - frame0_cpu.float()).abs()
         assert (diff > 20).float().mean() <= 0.003
         assert pts == torch.tensor([0])

--- a/test/utils.py
+++ b/test/utils.py
@@ -33,10 +33,11 @@ def assert_tensor_equal(*args, **kwargs):
     torch.testing.assert_close(*args, **kwargs, atol=absolute_tolerance, rtol=0)
 
 
-# Asserts that at most percentage of the elements are different by more than abs_tolerance.
-def assert_tensor_nearly_equal(frame1, frame2, percentage=0.3, abs_tolerance=20):
+# Asserts that at least `percentage`% of the values are within the absolute tolerance.
+def assert_tensor_close_on_at_least(frame1, frame2, percentage=99.7, abs_tolerance=20):
     diff = (frame2.float() - frame1.float()).abs()
-    assert (diff > abs_tolerance).float().mean() <= percentage / 100.0
+    diff_percentage = 100.0 - percentage
+    assert (diff > abs_tolerance).float().mean() <= diff_percentage / 100.0
 
 
 # For use with floating point metadata, or in other instances where we are not confident

--- a/test/utils.py
+++ b/test/utils.py
@@ -33,6 +33,12 @@ def assert_tensor_equal(*args, **kwargs):
     torch.testing.assert_close(*args, **kwargs, atol=absolute_tolerance, rtol=0)
 
 
+# Asserts that at most percentage of the elements are different by more than abs_tolerance.
+def assert_tensor_nearly_equal(frame1, frame2, percentage=0.3, abs_tolerance=20):
+    diff = (frame2.float() - frame1.float()).abs()
+    assert (diff > abs_tolerance).float().mean() <= percentage / 100.0
+
+
 # For use with floating point metadata, or in other instances where we are not confident
 # that reference and test tensors can be exactly equal. This is true for pts and duration
 # in seconds, as the reference values are from ffprobe's JSON output. In that case, it is


### PR DESCRIPTION
1. Allocate a batch tensor on the correct device. When cuda is passed in it uses that now.
2. Pass in the batch tensor's view to the color conversion function `convertAVFrameToDecodedOutputOnCuda()`.
3. Add a test to test frame contents.
4. Added a TODO to eventually merge preAllocatedOutputTesnor into RawDecodedOutput because it doesn't make sense to pass in two output data pointers.
5. Add device to VideoDecoder class
6. Update sampler benchmark to take in device and video arguments from the commandline

Sampler benchmark results:

```
CPU:
python benchmarks/samplers/benchmark_samplers.py --device=cpu
----------
num_clips = 1
clips_at_random_indices     med = 23.16ms +- 16.18  med fps = 431.8
clips_at_regular_indices    med = 5.67ms +- 0.43  med fps = 1764.3
clips_at_random_timestamps  med = 22.54ms +- 16.21  med fps = 443.7
clips_at_regular_timestamps med = 7.46ms +- 5.66  med fps = 1339.7
----------
num_clips = 50
clips_at_random_indices     med = 2400.86ms +- 803.05  med fps = 208.3
clips_at_regular_indices    med = 1343.50ms +- 288.18  med fps = 372.2
clips_at_random_timestamps  med = 1170.24ms +- 727.77  med fps = 427.3
clips_at_regular_timestamps med = 950.92ms +- 294.30  med fps = 515.3

CUDA:
python benchmarks/samplers/benchmark_samplers.py --device=cuda:0
----------
num_clips = 1
[AVHWDeviceContext @ 0x8793680] Using current CUDA context.
clips_at_random_indices     med = 245.46ms +- 116.64  med fps = 40.7
clips_at_regular_indices    med = 284.49ms +- 39.86  med fps = 35.2
clips_at_random_timestamps  med = 264.93ms +- 115.74  med fps = 37.7
clips_at_regular_timestamps med = 283.26ms +- 9.99  med fps = 35.3
----------
num_clips = 50
[AVHWDeviceContext @ 0x8d0d680] Using current CUDA context.
clips_at_random_indices     med = 308.00ms +- 104.52  med fps = 1623.4
clips_at_regular_indices    med = 286.54ms +- 12.69  med fps = 1744.9
clips_at_random_timestamps  med = 368.12ms +- 105.73  med fps = 1358.3
clips_at_regular_timestamps med = 285.32ms +- 13.19  med fps = 1717.4
```

CUDA is only worth it for lots of decoding (and could win at throughput) and potentially for higher resolution videos.

Also interestingly enough the variability in CUDA is quite low.