### PR TITLE
Remove preAllocatedTensor from getFrameAtIndex

### DIFF
--- a/src/torchcodec/decoders/_core/VideoDecoder.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoder.cpp
@@ -1007,10 +1007,8 @@ void VideoDecoder::validateFrameIndex(
 
 VideoDecoder::DecodedOutput VideoDecoder::getFrameAtIndex(
     int streamIndex,
-    int64_t frameIndex,
-    std::optional<torch::Tensor> preAllocatedOutputTensor) {
-  auto output = getFrameAtIndexInternal(
-      streamIndex, frameIndex, preAllocatedOutputTensor);
+    int64_t frameIndex) {
+  auto output = getFrameAtIndexInternal(streamIndex, frameIndex);
   output.frame = MaybePermuteHWC2CHW(streamIndex, output.frame);
   return output;
 }

--- a/src/torchcodec/decoders/_core/VideoDecoder.h
+++ b/src/torchcodec/decoders/_core/VideoDecoder.h
@@ -227,8 +227,7 @@ class VideoDecoder {
 
   DecodedOutput getFrameAtIndex(
       int streamIndex,
-      int64_t frameIndex,
-      std::optional<torch::Tensor> preAllocatedOutputTensor = std::nullopt);
+      int64_t frameIndex);
   struct BatchDecodedOutput {
     torch::Tensor frames;
     torch::Tensor ptsSeconds;

--- a/src/torchcodec/decoders/_core/VideoDecoder.h
+++ b/src/torchcodec/decoders/_core/VideoDecoder.h
@@ -226,6 +226,10 @@ class VideoDecoder {
   DecodedOutput getFramePlayedAtTimestampNoDemux(double seconds);
 
   DecodedOutput getFrameAtIndex(int streamIndex, int64_t frameIndex);
+  DecodedOutput getFrameAtIndexInternal(
+      int streamIndex,
+      int64_t frameIndex,
+      std::optional<torch::Tensor> preAllocatedOutputTensor = std::nullopt);
   struct BatchDecodedOutput {
     torch::Tensor frames;
     torch::Tensor ptsSeconds;
@@ -384,10 +388,6 @@ class VideoDecoder {
       DecodedOutput& output,
       std::optional<torch::Tensor> preAllocatedOutputTensor = std::nullopt);
 
-  DecodedOutput getFrameAtIndexInternal(
-      int streamIndex,
-      int64_t frameIndex,
-      std::optional<torch::Tensor> preAllocatedOutputTensor = std::nullopt);
   DecodedOutput getNextFrameOutputNoDemuxInternal(
       std::optional<torch::Tensor> preAllocatedOutputTensor = std::nullopt);
 

--- a/src/torchcodec/decoders/_core/VideoDecoder.h
+++ b/src/torchcodec/decoders/_core/VideoDecoder.h
@@ -226,6 +226,9 @@ class VideoDecoder {
   DecodedOutput getFramePlayedAtTimestampNoDemux(double seconds);
 
   DecodedOutput getFrameAtIndex(int streamIndex, int64_t frameIndex);
+  // This is morally private but needs to be exposed for C++ tests. Once
+  // getFrameAtIndex supports the preAllocatedOutputTensor parameter, we can
+  // move it back to private.
   DecodedOutput getFrameAtIndexInternal(
       int streamIndex,
       int64_t frameIndex,

--- a/src/torchcodec/decoders/_core/VideoDecoder.h
+++ b/src/torchcodec/decoders/_core/VideoDecoder.h
@@ -225,9 +225,7 @@ class VideoDecoder {
   // seconds=5.999, etc.
   DecodedOutput getFramePlayedAtTimestampNoDemux(double seconds);
 
-  DecodedOutput getFrameAtIndex(
-      int streamIndex,
-      int64_t frameIndex);
+  DecodedOutput getFrameAtIndex(int streamIndex, int64_t frameIndex);
   struct BatchDecodedOutput {
     torch::Tensor frames;
     torch::Tensor ptsSeconds;

--- a/test/decoders/VideoDecoderTest.cpp
+++ b/test/decoders/VideoDecoderTest.cpp
@@ -400,7 +400,7 @@ TEST_P(VideoDecoderTest, PreAllocatedTensorFilterGraph) {
       bestVideoStreamIndex,
       VideoDecoder::VideoStreamDecoderOptions(
           "color_conversion_library=filtergraph"));
-  auto output = ourDecoder->getFrameAtIndex(
+  auto output = ourDecoder->getFrameAtIndexInternal(
       bestVideoStreamIndex, 0, preAllocatedOutputTensor);
   EXPECT_EQ(output.frame.data_ptr(), preAllocatedOutputTensor.data_ptr());
 }
@@ -418,7 +418,7 @@ TEST_P(VideoDecoderTest, PreAllocatedTensorSwscale) {
       bestVideoStreamIndex,
       VideoDecoder::VideoStreamDecoderOptions(
           "color_conversion_library=swscale"));
-  auto output = ourDecoder->getFrameAtIndex(
+  auto output = ourDecoder->getFrameAtIndexInternal(
       bestVideoStreamIndex, 0, preAllocatedOutputTensor);
   EXPECT_EQ(output.frame.data_ptr(), preAllocatedOutputTensor.data_ptr());
 }


### PR DESCRIPTION
This is a small clean-up that I forgot to do in https://github.com/pytorch/torchcodec/pull/317

`getFrameAtIndex()` was / is never called with its optional `preAllocatedTensorOutput` parameter, so this PR removes it. This makes `getFrameAtIndex()` consistent with the other high-level entry-points, which do not accept `preAllocatedTensorOutput` either.


In the future, we'll probably want to put back this parameter for users to pass their own pre-allocated tensors, but we should add that consistently across all entry-points.