### PR TITLE
Add a call to ffmpeg in CUDA wheels as an assertion

### DIFF
--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -96,6 +96,9 @@ jobs:
           ${CONDA_RUN} conda info
           ${CONDA_RUN} nvidia-smi
           ${CONDA_RUN} conda list
+      - name: Assert ffmpeg exists
+        run: |
+          ${CONDA_RUN} ffmpeg -buildconf
       - name: Update pip
         run: ${CONDA_RUN} python -m pip install --upgrade pip
       - name: Install PyTorch


### PR DESCRIPTION
We're sometimes getting failures during smoke tests that ffmpeg libraries can't be found. If that's a problem, let's fail earlier in an explicit step for checking that.