### PR TITLE
Add more cuda tests

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -20,3 +20,10 @@ def prevent_leaking_rng():
     random.setstate(builtin_rng_state)
     if torch.cuda.is_available():
         torch.cuda.set_rng_state(cuda_rng_state)
+
+
+def pytest_configure(config):
+    # register an additional marker (see pytest_collection_modifyitems)
+    config.addinivalue_line(
+        "markers", "needs_cuda: mark for tests that rely on a CUDA device"
+    )


### PR DESCRIPTION
This addresses comments:

https://github.com/pytorch/torchcodec/pull/319#discussion_r1822348889
https://github.com/pytorch/torchcodec/pull/319#discussion_r1822353651

1. Add a mark in conftest.py
2. Add a decorator that passes in cpu and cuda devices
3. Adds more tests for cuda, especially batch frame extraction tests
4. Update the tensor_close function to be more tolerant of differences. The default is now 90% of the values should be within 20 of each other.