### PR TITLE
[codemod] Remove unused-variable in /fbcode/pytorch/torchcodec/src/torchcodec/decoders/_core/VideoDecoder.cpp

### DIFF
--- a/src/torchcodec/decoders/_core/VideoDecoder.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoder.cpp
@@ -835,10 +835,6 @@ VideoDecoder::RawDecodedOutput VideoDecoder::getDecodedOutputWithFilter(
   StreamInfo& activeStream = streams_[frameStreamIndex];
   activeStream.currentPts = frame->pts;
   activeStream.currentDuration = getDuration(frame);
-  auto startToSeekDone =
-      std::chrono::duration_cast<std::chrono::milliseconds>(seekDone - start);
-  auto seekToDecodeDone = std::chrono::duration_cast<std::chrono::milliseconds>(
-      decodeDone - seekDone);
   RawDecodedOutput rawOutput;
   rawOutput.streamIndex = frameStreamIndex;
   rawOutput.frame = std::move(frame);
@@ -1390,7 +1386,6 @@ torch::Tensor VideoDecoder::convertFrameToTensorUsingFilterGraph(
   };
   torch::Tensor tensor = torch::from_blob(
       filteredFramePtr->data[0], shape, strides, deleter, {torch::kUInt8});
-  StreamInfo& activeStream = streams_[streamIndex];
   return tensor;
 }
 


### PR DESCRIPTION
Summary:
[codemod] Remove unused-variable in {filename}


LLVM-15 has a warning `-Wunused-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code or (b) qualifies the variable with `[[maybe_unused]]`.

#buildsonlynotests - Builds are sufficient to verify
 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: scotts

Differential Revision: D65445691


