### PR TITLE
Handle videos with begin_stream_seconds > 0

### DIFF
--- a/benchmarks/decoders/benchmark_decoders_library.py
+++ b/benchmarks/decoders/benchmark_decoders_library.py
@@ -494,7 +494,12 @@ def run_benchmarks(
         metadata_label = f"{metadata.codec} {metadata.width}x{metadata.height}, {metadata.duration_seconds}s {metadata.average_fps}fps"
 
         duration = metadata.duration_seconds
-        uniform_pts_list = [i * duration / num_samples for i in range(num_samples)]
+        # The epislon of 1e-6 is added to avoid floating point issues. Otherwise I see error messages like:
+        # RuntimeError: frame pts is 0.015999; must be in range [0.015999, 5.004316).
+        begin = metadata.begin_stream_seconds + 1e-6
+        uniform_pts_list = [
+            i * duration / num_samples + begin for i in range(num_samples)
+        ]
 
         # Note that we are using the same random pts values for all decoders for the same
         # video. However, because we use the duration as part of this calculation, we


### PR DESCRIPTION
Without this PR I get error messages like this:

```
python benchmarks/decoders/benchmark_decoders.py --decoders=torchcodec_core,torchcodec_core:device=cuda --bm_video_paths=/home/ahmads/jupyter/853.mp4 
video_files_paths=['/home/ahmads/jupyter/853.mp4']
video=/home/ahmads/jupyter/853.mp4, decoder=TorchCodecCore:device=cuda
[AVHWDeviceContext @ 0x9799dc0] Using current CUDA context.
Traceback (most recent call last):
  File "/home/ahmads/personal/torchcodec/benchmarks/decoders/benchmark_decoders.py", line 181, in <module>
    main()
  File "/home/ahmads/personal/torchcodec/benchmarks/decoders/benchmark_decoders.py", line 169, in main
    df_data = run_benchmarks(
              ^^^^^^^^^^^^^^^
  File "/home/ahmads/personal/torchcodec/benchmarks/decoders/benchmark_decoders_library.py", line 538, in run_benchmarks
    seeked_result.blocked_autorange(min_run_time=min_runtime_seconds)
  File "/home/ahmads/.conda/envs/tcgpu1/lib/python3.12/site-packages/torch/utils/benchmark/utils/timer.py", line 372, in blocked_autorange
    number = self._estimate_block_size(min_run_time)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ahmads/.conda/envs/tcgpu1/lib/python3.12/site-packages/torch/utils/benchmark/utils/timer.py", line 319, in _estimate_block_size
    time_taken = self._timeit(number)
                 ^^^^^^^^^^^^^^^^^^^^
  File "/home/ahmads/.conda/envs/tcgpu1/lib/python3.12/site-packages/torch/utils/benchmark/utils/timer.py", line 264, in _timeit
    return max(self._timer.timeit(number), 1e-9)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ahmads/.conda/envs/tcgpu1/lib/python3.12/timeit.py", line 180, in timeit
    timing = self.inner(it, self.timer)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<timeit-src>", line 6, in inner
  File "/home/ahmads/personal/torchcodec/benchmarks/decoders/benchmark_decoders_library.py", line 130, in get_frames_from_video
    frames, *_ = get_frames_by_pts(
                 ^^^^^^^^^^^^^^^^^^
  File "/home/ahmads/.conda/envs/tcgpu1/lib/python3.12/site-packages/torch/_ops.py", line 667, in __call__
    return self_._op(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: frame pts is 0.000000; must be in range [0.015999, 5.004316).
```


After this PR, I can run the benchmark on that video:

```
python benchmarks/decoders/benchmark_decoders.py --decoders=torchcodec_core,torchcodec_core:device=cuda --bm_video_paths=/home/ahmads/jupyter/853.mp4 
video_files_paths=['/home/ahmads/jupyter/853.mp4']
video=/home/ahmads/jupyter/853.mp4, decoder=TorchCodecCore
video=/home/ahmads/jupyter/853.mp4, decoder=TorchCodecCore:device=cuda
[AVHWDeviceContext @ 0x7029c00] Using current CUDA context.
[--------------------------------- video=/home/ahmads/jupyter/853.mp4 h264 3840x2160, 4.988317s 59.94005593469701fps ---------------------------------]
                                  |  uniform 10 seek()+next()  |  random 10 seek()+next()  |  1 next()  |  10 next()  |  100 next()  |  create()+next()
1 threads: --------------------------------------------------------------------------------------------------------------------------------------------
      TorchCodecCore              |           1897.6           |           1965.3          |   288.5    |    531.0    |    1701.9    |       279.0     
      TorchCodecCore:device=cuda  |           3260.1           |           2703.9          |   345.7    |    597.0    |    1092.1    |                 

Times are in milliseconds (ms).

```