### PR TITLE
Indicate `num_ffmpeg_threads` is only relevant on CPU

### DIFF
--- a/src/torchcodec/decoders/_video_decoder.py
+++ b/src/torchcodec/decoders/_video_decoder.py
@@ -43,11 +43,11 @@ class VideoDecoder:
                 cheap no-copy operation that allows these frames to be
                 transformed using the `torchvision transforms
                 <https://pytorch.org/vision/stable/transforms.html>`_.
-        num_ffmpeg_threads (int, optional): The number of threads to use for decoding.
+        num_ffmpeg_threads (int, optional): The number of threads to use for CPU decoding.
             Use 1 for single-threaded decoding which may be best if you are running multiple
             instances of ``VideoDecoder`` in parallel. Use a higher number for multi-threaded
             decoding which is best if you are running a single instance of ``VideoDecoder``.
-            Default: 1.
+            Default: 1. Ignored if ``device`` is not "cpu".
         device (str or torch.device, optional): The device to use for decoding. Default: "cpu".
 
 


### PR DESCRIPTION
I could be wrong!
But if I'm not, I think we should just indicate that it's ignored on CPU. I don't think it's worth raising an error if users pass `num_ffmpeg_threads=3, device="cuda"` because it makes it really annoying to run "generic" loop and comparisons, e.g. stuff like

```py
for device in ("cuda", "cpu"):
    decoder = VideoDecoder(..., num_ffmpeg_threads=1, device=device)  # no point errorring here
```