### PR TITLE
Use std::string_view instead of c10::string_view because the latter is being deprecated

### DIFF
--- a/src/torchcodec/decoders/_core/VideoDecoderOps.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoderOps.cpp
@@ -94,7 +94,7 @@ OpsBatchDecodedOutput makeOpsBatchDecodedOutput(
 // Implementations for the operators
 // ==============================
 
-at::Tensor create_from_file(c10::string_view filename) {
+at::Tensor create_from_file(std::string_view filename) {
   std::string filenameStr(filename);
   std::unique_ptr<VideoDecoder> uniqueDecoder =
       VideoDecoder::createFromFilePath(filenameStr);
@@ -121,9 +121,9 @@ void add_video_stream(
     std::optional<int64_t> width,
     std::optional<int64_t> height,
     std::optional<int64_t> num_threads,
-    std::optional<c10::string_view> dimension_order,
+    std::optional<std::string_view> dimension_order,
     std::optional<int64_t> stream_index,
-    std::optional<c10::string_view> device) {
+    std::optional<std::string_view> device) {
   _add_video_stream(
       decoder,
       width,
@@ -139,10 +139,10 @@ void _add_video_stream(
     std::optional<int64_t> width,
     std::optional<int64_t> height,
     std::optional<int64_t> num_threads,
-    std::optional<c10::string_view> dimension_order,
+    std::optional<std::string_view> dimension_order,
     std::optional<int64_t> stream_index,
-    std::optional<c10::string_view> device,
-    std::optional<c10::string_view> color_conversion_library) {
+    std::optional<std::string_view> device,
+    std::optional<std::string_view> color_conversion_library) {
   VideoDecoder::VideoStreamDecoderOptions options;
   options.width = width;
   options.height = height;

--- a/src/torchcodec/decoders/_core/VideoDecoderOps.h
+++ b/src/torchcodec/decoders/_core/VideoDecoderOps.h
@@ -20,7 +20,7 @@ namespace facebook::torchcodec {
 // auto decoderTensor = createDecoderOp.call(videoPath);
 
 // Create a VideoDecoder from file and wrap the pointer in a tensor.
-at::Tensor create_from_file(c10::string_view filename);
+at::Tensor create_from_file(std::string_view filename);
 
 at::Tensor create_from_tensor(at::Tensor video_tensor);
 
@@ -34,19 +34,19 @@ void add_video_stream(
     std::optional<int64_t> width = std::nullopt,
     std::optional<int64_t> height = std::nullopt,
     std::optional<int64_t> num_threads = std::nullopt,
-    std::optional<c10::string_view> dimension_order = std::nullopt,
+    std::optional<std::string_view> dimension_order = std::nullopt,
     std::optional<int64_t> stream_index = std::nullopt,
-    std::optional<c10::string_view> device = std::nullopt);
+    std::optional<std::string_view> device = std::nullopt);
 
 void _add_video_stream(
     at::Tensor& decoder,
     std::optional<int64_t> width = std::nullopt,
     std::optional<int64_t> height = std::nullopt,
     std::optional<int64_t> num_threads = std::nullopt,
-    std::optional<c10::string_view> dimension_order = std::nullopt,
+    std::optional<std::string_view> dimension_order = std::nullopt,
     std::optional<int64_t> stream_index = std::nullopt,
-    std::optional<c10::string_view> device = std::nullopt,
-    std::optional<c10::string_view> color_conversion_library = std::nullopt);
+    std::optional<std::string_view> device = std::nullopt,
+    std::optional<std::string_view> color_conversion_library = std::nullopt);
 
 // Seek to a particular presentation timestamp in the video in seconds.
 void seek_to_pts(at::Tensor& decoder, double seconds);


### PR DESCRIPTION
Summary: `c10::string_view` is being removed, so we need to migrate.

Differential Revision: D65830279


