### PR TITLE
Unbreak benchmark_decoders.py

### DIFF
--- a/benchmarks/decoders/benchmark_decoders_library.py
+++ b/benchmarks/decoders/benchmark_decoders_library.py
@@ -496,6 +496,7 @@ def run_batch_using_threads(
     for _ in range(batch_parameters.batch_size):
         futures.append(executor.submit(function, *args))
     for f in futures:
+        # TODO: Add a stronger check here based on arguments to the function.
         assert len(f.result()) > 0
     executor.shutdown(wait=True)
 

--- a/benchmarks/decoders/benchmark_decoders_library.py
+++ b/benchmarks/decoders/benchmark_decoders_library.py
@@ -496,7 +496,7 @@ def run_batch_using_threads(
     for _ in range(batch_parameters.batch_size):
         futures.append(executor.submit(function, *args))
     for f in futures:
-        assert f.result()
+        assert len(f.result()) > 0
     executor.shutdown(wait=True)
 
 


### PR DESCRIPTION
benchmark_decoders.py was broken by #359 

This PR unbreaks it. Longer term we could add a stronger check but this is good enough for now (and better than the non-throughput checks which doesn't even check for the length of the returned list or tensor).

Tested using:

```
python benchmarks/decoders/benchmark_decoders.py --bm_video_speed_min_run_seconds 1 --decoders=torchcodec_core_batch,torchcodec_core
video_files_paths=['/home/ahmads/personal/torchcodec/benchmarks/decoders/../../test/resources/nasa_13013.mp4']
video=/home/ahmads/personal/torchcodec/benchmarks/decoders/../../test/resources/nasa_13013.mp4, decoder=TorchCodecCore
video=/home/ahmads/personal/torchcodec/benchmarks/decoders/../../test/resources/nasa_13013.mp4, decoder=TorchCodecCoreBatch
[------------------------------------------------------------------ video=/home/ahmads/personal/torchcodec/benchmarks/decoders/../../test/resources/nasa_13013.mp4 h264 480x270, 13.013s 29.97002997002997fps ------------------------------------------------------------------]
                           |  uniform 10 seek()+next()  |  batch uniform 10 seek()+next()  |  random 10 seek()+next()  |  batch random 10 seek()+next()  |  1 next()  |  batch 1 next()  |  10 next()  |  batch 10 next()  |  100 next()  |  batch 100 next()  |  create()+next()
1 threads: ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      TorchCodecCore       |            77.6            |              1001.7              |            53.7           |              722.6              |    17.5    |      246.0       |     22.6    |       228.0       |     67.2     |       777.4        |        20.4     
      TorchCodecCoreBatch  |            67.9            |               978.2              |            66.9           |              813.5              |    24.5    |      279.9       |     26.1    |       255.8       |     76.3     |       765.7        |                 

Times are in milliseconds (ms).
```