### PR TITLE
Improve color accuracy of BT709 frames on CUDA

### DIFF
--- a/test/decoders/test_video_decoder_ops.py
+++ b/test/decoders/test_video_decoder_ops.py
@@ -118,8 +118,10 @@ class TestOps:
         # return the next frame since the right boundary of the interval is
         # open.
         next_frame, _, _ = get_frame_at_pts(decoder, 6.039367)
-        with pytest.raises(AssertionError):
-            frame_compare_function(next_frame, reference_frame6.to(device))
+        if device == "cpu":
+            # We can only compare exact equality on CPU.
+            with pytest.raises(AssertionError):
+                frame_compare_function(next_frame, reference_frame6.to(device))
 
     @pytest.mark.parametrize("device", cpu_and_cuda())
     def test_get_frame_at_index(self, device):

--- a/test/utils.py
+++ b/test/utils.py
@@ -44,7 +44,7 @@ def assert_tensor_equal(*args, **kwargs):
 
 # Asserts that at least `percentage`% of the values are within the absolute tolerance.
 def assert_tensor_close_on_at_least(
-    actual_tensor, ref_tensor, percentage=90, abs_tolerance=20
+    actual_tensor, ref_tensor, percentage=90, abs_tolerance=19
 ):
     assert (
         actual_tensor.device == ref_tensor.device


### PR DESCRIPTION
libnpp actually has a specialized function to handle images with BT709 colorspace. So we use that instead of the generic one when appropriate. This improves the color accuracy of the image slightly.

Hat tip to @fmassa 

Drive-by: fixed a test that doesn't make sense on CUDA -- we can only expect exactly equal frames on CPU.

Visual inspection. Before on the left and after on the right:

![image](https://github.com/user-attachments/assets/96375e00-50d6-4c1d-a631-81121fd25aa3)

