### PR TITLE
Migrate to linux_job_v2

### DIFF
--- a/.github/workflows/build_ffmpeg.yaml
+++ b/.github/workflows/build_ffmpeg.yaml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         ffmpeg-version: ["4.4.4", "5.1.4", "6.1.1", "7.0.1"]
-    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:
       job-name: Build
       upload-artifact: ffmpeg-lgpl


### PR DESCRIPTION
CC @atalman 

This is the only job that relies on `linux_job`. It doesn't use torch, so I didn't pin the torch version as done in https://github.com/pytorch/vision/pull/8725