### PR TITLE
Fix Python version in CUDA wheel name

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -67,7 +67,7 @@ jobs:
           echo cuda_version_without_periods=${cuda_version_without_periods} >> $GITHUB_ENV
       - uses: actions/download-artifact@v3
         with:
-          name: pytorch_torchcodec__3.9_cu${{ env.cuda_version_without_periods }}_x86_64
+          name: pytorch_torchcodec__${{ matrix.python-version }}_cu${{ env.cuda_version_without_periods }}_x86_64
           path: pytorch/torchcodec/dist/
       - name: Setup miniconda using test-infra
         uses: pytorch/test-infra/.github/actions/setup-miniconda@main

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -79,7 +79,7 @@ jobs:
           echo cuda_version_without_periods=${cuda_version_without_periods} >> $GITHUB_ENV
       - uses: actions/download-artifact@v3
         with:
-          name: pytorch_torchcodec__3.9_cu${{ env.cuda_version_without_periods }}_x86_64
+          name: pytorch_torchcodec__${{ matrix.python-version }}_cu${{ env.cuda_version_without_periods }}_x86_64
           path: pytorch/torchcodec/dist/
       - name: Setup miniconda using test-infra
         uses: pytorch/test-infra/.github/actions/setup-miniconda@main


### PR DESCRIPTION
This is what is causing the existing errors like

```
ERROR: TorchCodec-0.0.4+cu118-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl is not a supported wheel on this platform.
```

in our release branch https://github.com/pytorch/torchcodec/actions/runs/11901772712/job/33165767469?pr=389

I'll land this on main and cherry-pick for the release branch