### PR TITLE
Improve GPU frames accuracy

### DIFF
--- a/src/torchcodec/decoders/_core/CudaDevice.cpp
+++ b/src/torchcodec/decoders/_core/CudaDevice.cpp
@@ -225,7 +225,6 @@ void convertAVFrameToDecodedOutputOnCuda(
   auto start = std::chrono::high_resolution_clock::now();
   NppStatus status;
   if (src->colorspace == AVColorSpace::AVCOL_SPC_BT709) {
-    // status = nppiNV12ToRGB_709HDTV_8u_P2C3R(
     status = nppiNV12ToRGB_709CSC_8u_P2C3R(
         input,
         src->linesize[0],

--- a/src/torchcodec/decoders/_core/CudaDevice.cpp
+++ b/src/torchcodec/decoders/_core/CudaDevice.cpp
@@ -225,7 +225,8 @@ void convertAVFrameToDecodedOutputOnCuda(
   auto start = std::chrono::high_resolution_clock::now();
   NppStatus status;
   if (src->colorspace == AVColorSpace::AVCOL_SPC_BT709) {
-    status = nppiNV12ToRGB_709HDTV_8u_P2C3R(
+    // status = nppiNV12ToRGB_709HDTV_8u_P2C3R(
+    status = nppiNV12ToRGB_709CSC_8u_P2C3R(
         input,
         src->linesize[0],
         static_cast<Npp8u*>(dst.data_ptr()),

--- a/test/decoders/test_video_decoder_ops.py
+++ b/test/decoders/test_video_decoder_ops.py
@@ -37,10 +37,8 @@ from torchcodec.decoders._core import (
 )
 
 from ..utils import (
-    assert_tensor_close_on_at_least,
     assert_tensor_equal,
     cpu_and_cuda,
-    get_frame_compare_function,
     NASA_AUDIO,
     NASA_VIDEO,
     needs_cuda,
@@ -70,50 +68,47 @@ class TestOps:
     def test_seek_and_next(self, device):
         decoder = create_from_file(str(NASA_VIDEO.path))
         add_video_stream(decoder, device=device)
-        frame_compare_function = get_frame_compare_function(device)
         frame0, _, _ = get_next_frame(decoder)
         reference_frame0 = NASA_VIDEO.get_frame_data_by_index(0)
-        frame_compare_function(frame0, reference_frame0.to(device))
+        assert_tensor_equal(frame0, reference_frame0.to(device))
         reference_frame1 = NASA_VIDEO.get_frame_data_by_index(1)
         frame1, _, _ = get_next_frame(decoder)
-        frame_compare_function(frame1, reference_frame1.to(device))
+        assert_tensor_equal(frame1, reference_frame1.to(device))
         seek_to_pts(decoder, 6.0)
         frame_time6, _, _ = get_next_frame(decoder)
         reference_frame_time6 = NASA_VIDEO.get_frame_data_by_index(
             INDEX_OF_FRAME_AT_6_SECONDS
         )
-        frame_compare_function(frame_time6, reference_frame_time6.to(device))
+        assert_tensor_equal(frame_time6, reference_frame_time6.to(device))
 
     @pytest.mark.parametrize("device", cpu_and_cuda())
     def test_seek_to_negative_pts(self, device):
         decoder = create_from_file(str(NASA_VIDEO.path))
         scan_all_streams_to_update_metadata(decoder)
         add_video_stream(decoder, device=device)
-        frame_compare_function = get_frame_compare_function(device)
         frame0, _, _ = get_next_frame(decoder)
         reference_frame0 = NASA_VIDEO.get_frame_data_by_index(0)
-        frame_compare_function(frame0, reference_frame0.to(device))
+        assert_tensor_equal(frame0, reference_frame0.to(device))
 
         seek_to_pts(decoder, -1e-4)
         frame0, _, _ = get_next_frame(decoder)
-        frame_compare_function(frame0, reference_frame0.to(device))
+        assert_tensor_equal(frame0, reference_frame0.to(device))
 
     @pytest.mark.parametrize("device", cpu_and_cuda())
     def test_get_frame_at_pts(self, device):
         decoder = create_from_file(str(NASA_VIDEO.path))
         add_video_stream(decoder, device=device)
-        frame_compare_function = get_frame_compare_function(device)
         # This frame has pts=6.006 and duration=0.033367, so it should be visible
         # at timestamps in the range [6.006, 6.039367) (not including the last timestamp).
         frame6, _, _ = get_frame_at_pts(decoder, 6.006)
         reference_frame6 = NASA_VIDEO.get_frame_data_by_index(
             INDEX_OF_FRAME_AT_6_SECONDS
         )
-        frame_compare_function(frame6, reference_frame6.to(device))
+        assert_tensor_equal(frame6, reference_frame6.to(device))
         frame6, _, _ = get_frame_at_pts(decoder, 6.02)
-        frame_compare_function(frame6, reference_frame6.to(device))
+        assert_tensor_equal(frame6, reference_frame6.to(device))
         frame6, _, _ = get_frame_at_pts(decoder, 6.039366)
-        frame_compare_function(frame6, reference_frame6.to(device))
+        assert_tensor_equal(frame6, reference_frame6.to(device))
         # Note that this timestamp is exactly on a frame boundary, so it should
         # return the next frame since the right boundary of the interval is
         # open.
@@ -121,43 +116,40 @@ class TestOps:
         if device == "cpu":
             # We can only compare exact equality on CPU.
             with pytest.raises(AssertionError):
-                frame_compare_function(next_frame, reference_frame6.to(device))
+                assert_tensor_equal(next_frame, reference_frame6.to(device))
 
     @pytest.mark.parametrize("device", cpu_and_cuda())
     def test_get_frame_at_index(self, device):
         decoder = create_from_file(str(NASA_VIDEO.path))
         scan_all_streams_to_update_metadata(decoder)
         add_video_stream(decoder, device=device)
-        frame_compare_function = get_frame_compare_function(device)
         frame0, _, _ = get_frame_at_index(decoder, stream_index=3, frame_index=0)
         reference_frame0 = NASA_VIDEO.get_frame_data_by_index(0)
-        frame_compare_function(frame0, reference_frame0.to(device))
+        assert_tensor_equal(frame0, reference_frame0.to(device))
         # The frame that is played at 6 seconds is frame 180 from a 0-based index.
         frame6, _, _ = get_frame_at_index(decoder, stream_index=3, frame_index=180)
         reference_frame6 = NASA_VIDEO.get_frame_data_by_index(
             INDEX_OF_FRAME_AT_6_SECONDS
         )
-        frame_compare_function(frame6, reference_frame6.to(device))
+        assert_tensor_equal(frame6, reference_frame6.to(device))
 
     @pytest.mark.parametrize("device", cpu_and_cuda())
     def test_get_frame_with_info_at_index(self, device):
         decoder = create_from_file(str(NASA_VIDEO.path))
         scan_all_streams_to_update_metadata(decoder)
         add_video_stream(decoder, device=device)
-        frame_compare_function = get_frame_compare_function(device)
         frame6, pts, duration = get_frame_at_index(
             decoder, stream_index=3, frame_index=180
         )
         reference_frame6 = NASA_VIDEO.get_frame_data_by_index(
             INDEX_OF_FRAME_AT_6_SECONDS
         )
-        frame_compare_function(frame6, reference_frame6.to(device))
+        assert_tensor_equal(frame6, reference_frame6.to(device))
         assert pts.item() == pytest.approx(6.006, rel=1e-3)
         assert duration.item() == pytest.approx(0.03337, rel=1e-3)
 
     @pytest.mark.parametrize("device", cpu_and_cuda())
     def test_get_frames_at_indices(self, device):
-        frame_compare_function = get_frame_compare_function(device)
         decoder = create_from_file(str(NASA_VIDEO.path))
         scan_all_streams_to_update_metadata(decoder)
         add_video_stream(decoder, device=device)
@@ -168,8 +160,8 @@ class TestOps:
         reference_frame180 = NASA_VIDEO.get_frame_data_by_index(
             INDEX_OF_FRAME_AT_6_SECONDS
         )
-        frame_compare_function(frames0and180[0], reference_frame0.to(device))
-        frame_compare_function(frames0and180[1], reference_frame180.to(device))
+        assert_tensor_equal(frames0and180[0], reference_frame0.to(device))
+        assert_tensor_equal(frames0and180[1], reference_frame180.to(device))
 
     @pytest.mark.parametrize("device", cpu_and_cuda())
     def test_get_frames_at_indices_unsorted_indices(self, device):
@@ -297,7 +289,6 @@ class TestOps:
 
     @pytest.mark.parametrize("device", cpu_and_cuda())
     def test_get_frames_in_range(self, device):
-        frame_compare_function = get_frame_compare_function(device)
         decoder = create_from_file(str(NASA_VIDEO.path))
         scan_all_streams_to_update_metadata(decoder)
         add_video_stream(decoder, device=device)
@@ -305,57 +296,56 @@ class TestOps:
         # ensure that the degenerate case of a range of size 1 works
         ref_frame0 = NASA_VIDEO.get_frame_data_by_range(0, 1)
         bulk_frame0, *_ = get_frames_in_range(decoder, stream_index=3, start=0, stop=1)
-        frame_compare_function(bulk_frame0, ref_frame0.to(device))
+        assert_tensor_equal(bulk_frame0, ref_frame0.to(device))
 
         ref_frame1 = NASA_VIDEO.get_frame_data_by_range(1, 2)
         bulk_frame1, *_ = get_frames_in_range(decoder, stream_index=3, start=1, stop=2)
-        frame_compare_function(bulk_frame1, ref_frame1.to(device))
+        assert_tensor_equal(bulk_frame1, ref_frame1.to(device))
 
         ref_frame389 = NASA_VIDEO.get_frame_data_by_range(389, 390)
         bulk_frame389, *_ = get_frames_in_range(
             decoder, stream_index=3, start=389, stop=390
         )
-        frame_compare_function(bulk_frame389, ref_frame389.to(device))
+        assert_tensor_equal(bulk_frame389, ref_frame389.to(device))
 
         # contiguous ranges
         ref_frames0_9 = NASA_VIDEO.get_frame_data_by_range(0, 9)
         bulk_frames0_9, *_ = get_frames_in_range(
             decoder, stream_index=3, start=0, stop=9
         )
-        frame_compare_function(bulk_frames0_9, ref_frames0_9.to(device))
+        assert_tensor_equal(bulk_frames0_9, ref_frames0_9.to(device))
 
         ref_frames4_8 = NASA_VIDEO.get_frame_data_by_range(4, 8)
         bulk_frames4_8, *_ = get_frames_in_range(
             decoder, stream_index=3, start=4, stop=8
         )
-        frame_compare_function(bulk_frames4_8, ref_frames4_8.to(device))
+        assert_tensor_equal(bulk_frames4_8, ref_frames4_8.to(device))
 
         # ranges with a stride
         ref_frames15_35 = NASA_VIDEO.get_frame_data_by_range(15, 36, 5)
         bulk_frames15_35, *_ = get_frames_in_range(
             decoder, stream_index=3, start=15, stop=36, step=5
         )
-        frame_compare_function(bulk_frames15_35, ref_frames15_35.to(device))
+        assert_tensor_equal(bulk_frames15_35, ref_frames15_35.to(device))
 
         ref_frames0_9_2 = NASA_VIDEO.get_frame_data_by_range(0, 9, 2)
         bulk_frames0_9_2, *_ = get_frames_in_range(
             decoder, stream_index=3, start=0, stop=9, step=2
         )
-        frame_compare_function(bulk_frames0_9_2, ref_frames0_9_2.to(device))
+        assert_tensor_equal(bulk_frames0_9_2, ref_frames0_9_2.to(device))
 
         # an empty range is valid!
         empty_frame, *_ = get_frames_in_range(decoder, stream_index=3, start=5, stop=5)
-        frame_compare_function(empty_frame, NASA_VIDEO.empty_chw_tensor.to(device))
+        assert_tensor_equal(empty_frame, NASA_VIDEO.empty_chw_tensor.to(device))
 
     @pytest.mark.parametrize("device", cpu_and_cuda())
     def test_throws_exception_at_eof(self, device):
         decoder = create_from_file(str(NASA_VIDEO.path))
         add_video_stream(decoder, device=device)
-        frame_compare_function = get_frame_compare_function(device)
         seek_to_pts(decoder, 12.979633)
         last_frame, _, _ = get_next_frame(decoder)
         reference_last_frame = NASA_VIDEO.get_frame_data_by_index(289)
-        frame_compare_function(last_frame, reference_last_frame.to(device))
+        assert_tensor_equal(last_frame, reference_last_frame.to(device))
         with pytest.raises(IndexError, match="no more frames"):
             get_next_frame(decoder)
 
@@ -384,14 +374,13 @@ class TestOps:
         # NB: create needs to happen outside the torch.compile region,
         # for now. Otherwise torch.compile constant-props it.
         decoder = create_from_file(str(NASA_VIDEO.path))
-        frame_compare_function = get_frame_compare_function(device)
         frame0, frame_time6 = get_frame1_and_frame_time6(decoder)
         reference_frame0 = NASA_VIDEO.get_frame_data_by_index(0)
         reference_frame_time6 = NASA_VIDEO.get_frame_data_by_index(
             INDEX_OF_FRAME_AT_6_SECONDS
         )
-        frame_compare_function(frame0, reference_frame0.to(device))
-        frame_compare_function(frame_time6, reference_frame_time6.to(device))
+        assert_tensor_equal(frame0, reference_frame0.to(device))
+        assert_tensor_equal(frame_time6, reference_frame_time6.to(device))
 
     @pytest.mark.parametrize("device", cpu_and_cuda())
     def test_class_based_compile_seek_and_next(self, device):
@@ -406,14 +395,13 @@ class TestOps:
             return frame0, frame_time6
 
         decoder = ReferenceDecoder(device=device)
-        frame_compare_function = get_frame_compare_function(device)
         frame0, frame_time6 = class_based_get_frame1_and_frame_time6(decoder)
         reference_frame0 = NASA_VIDEO.get_frame_data_by_index(0)
         reference_frame_time6 = NASA_VIDEO.get_frame_data_by_index(
             INDEX_OF_FRAME_AT_6_SECONDS
         )
-        frame_compare_function(frame0, reference_frame0.to(device))
-        frame_compare_function(frame_time6, reference_frame_time6.to(device))
+        assert_tensor_equal(frame0, reference_frame0.to(device))
+        assert_tensor_equal(frame_time6, reference_frame_time6.to(device))
 
     @pytest.mark.parametrize("device", cpu_and_cuda())
     @pytest.mark.parametrize("create_from", ("file", "tensor", "bytes"))
@@ -431,19 +419,18 @@ class TestOps:
             decoder = create_from_bytes(video_bytes)
 
         add_video_stream(decoder, device=device)
-        frame_compare_function = get_frame_compare_function(device)
         frame0, _, _ = get_next_frame(decoder)
         reference_frame0 = NASA_VIDEO.get_frame_data_by_index(0)
-        frame_compare_function(frame0, reference_frame0.to(device))
+        assert_tensor_equal(frame0, reference_frame0.to(device))
         reference_frame1 = NASA_VIDEO.get_frame_data_by_index(1)
         frame1, _, _ = get_next_frame(decoder)
-        frame_compare_function(frame1, reference_frame1.to(device))
+        assert_tensor_equal(frame1, reference_frame1.to(device))
         seek_to_pts(decoder, 6.0)
         frame_time6, _, _ = get_next_frame(decoder)
         reference_frame_time6 = NASA_VIDEO.get_frame_data_by_index(
             INDEX_OF_FRAME_AT_6_SECONDS
         )
-        frame_compare_function(frame_time6, reference_frame_time6.to(device))
+        assert_tensor_equal(frame_time6, reference_frame_time6.to(device))
 
     # Keeping the metadata tests below for now, but we should remove them
     # once we remove get_json_metadata().
@@ -703,12 +690,8 @@ class TestOps:
         add_video_stream(decoder, device="cuda")
         frame0, pts, duration = get_next_frame(decoder)
         assert frame0.device.type == "cuda"
-        frame0_cpu = frame0.to("cpu")
         reference_frame0 = NASA_VIDEO.get_frame_data_by_index(0)
-        # GPU decode is not bit-accurate. So we allow some tolerance.
-        assert_tensor_close_on_at_least(frame0_cpu, reference_frame0)
-        diff = (reference_frame0.float() - frame0_cpu.float()).abs()
-        assert (diff > 20).float().mean() <= 0.003
+        assert_tensor_equal(frame0, reference_frame0.to("cuda"))
         assert pts == torch.tensor([0])
         torch.testing.assert_close(
             duration, torch.tensor(0.0334).double(), atol=0, rtol=1e-3

--- a/test/samplers/test_video_clip_sampler.py
+++ b/test/samplers/test_video_clip_sampler.py
@@ -10,7 +10,7 @@ from torchcodec._samplers import (
     VideoClipSampler,
 )
 
-from ..utils import assert_tensor_equal, NASA_VIDEO
+from ..utils import NASA_VIDEO
 
 
 @pytest.mark.parametrize(

--- a/test/samplers/test_video_clip_sampler.py
+++ b/test/samplers/test_video_clip_sampler.py
@@ -36,7 +36,7 @@ def test_sampler(sampler_args):
     video_args = VideoArgs(desired_width=desired_width, desired_height=desired_height)
     sampler = VideoClipSampler(video_args, sampler_args)
     clips = sampler(NASA_VIDEO.to_tensor())
-    assert_tensor_equal(len(clips), sampler_args.clips_per_video)
+    assert len(clips) == sampler_args.clips_per_video
     clip = clips[0]
     if isinstance(sampler_args, TimeBasedSamplerArgs):
         # Note: Looks like we have an API inconsistency.

--- a/test/utils.py
+++ b/test/utils.py
@@ -44,7 +44,7 @@ def assert_tensor_equal(*args, **kwargs):
 
 # Asserts that at least `percentage`% of the values are within the absolute tolerance.
 def assert_tensor_close_on_at_least(
-    actual_tensor, ref_tensor, percentage=90, abs_tolerance=19
+    actual_tensor, ref_tensor, percentage=90, abs_tolerance=5
 ):
     assert (
         actual_tensor.device == ref_tensor.device


### PR DESCRIPTION
We now call `nppiNV12ToRGB_709CSC_8u_P2C3R` for GPU frame color conversion, instead of `nppiNV12ToRGB_709HDTV_8u_P2C3R`, as suggested in https://github.com/pytorch/torchcodec/issues/412

This dramatically improves accuracy of decoded frames, as they are now much closer to the expected CPU ones, within `atol=2` (this is even stricter than our frame comparison for MacOS!).

Closes https://github.com/pytorch/torchcodec/issues/412


Thank you @fmassa for the original hint in https://github.com/pytorch/torchcodec/pull/372#discussion_r1840965468 and @pjs102793 for chasing this up!