### PR TITLE
[codemod] Remove unused-variable in pytorch/hiveio/hiveio_writer.cpp +3

### DIFF
--- a/src/torchcodec/decoders/_core/VideoDecoder.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoder.cpp
@@ -736,7 +736,6 @@ void VideoDecoder::maybeSeekToBeforeDesiredPts() {
 
 VideoDecoder::RawDecodedOutput VideoDecoder::getDecodedOutputWithFilter(
     std::function<bool(int, AVFrame*)> filterFunction) {
-  auto start = std::chrono::high_resolution_clock::now();
   if (activeStreamIndices_.size() == 0) {
     throw std::runtime_error("No active streams configured.");
   }
@@ -745,7 +744,6 @@ VideoDecoder::RawDecodedOutput VideoDecoder::getDecodedOutputWithFilter(
     maybeSeekToBeforeDesiredPts();
     maybeDesiredPts_ = std::nullopt;
   }
-  auto seekDone = std::chrono::high_resolution_clock::now();
   // Need to get the next frame or error from PopFrame.
   UniqueAVFrame frame(av_frame_alloc());
   int ffmpegStatus = AVSUCCESS;
@@ -835,7 +833,6 @@ VideoDecoder::RawDecodedOutput VideoDecoder::getDecodedOutputWithFilter(
         "Could not receive frame from decoder: " +
         getFFMPEGErrorStringFromErrorCode(ffmpegStatus));
   }
-  auto decodeDone = std::chrono::high_resolution_clock::now();
   // Note that we don't flush the decoder when we reach EOF (even though that's
   // mentioned in https://ffmpeg.org/doxygen/trunk/group__lavc__encdec.html).
   // This is because we may have packets internally in the decoder that we


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code or (b) qualifies the variable with `[[maybe_unused]]`.

See: D66437647

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Differential Revision: D66464240


