### PR TITLE
Refactor benchmark options

### DIFF
--- a/benchmarks/decoders/benchmark_decoders.py
+++ b/benchmarks/decoders/benchmark_decoders.py
@@ -91,7 +91,7 @@ def main() -> None:
     parser.add_argument(
         "--bm_video_creation",
         help="Benchmark large video creation memory",
-        default=True,
+        default=False,
         action=argparse.BooleanOptionalAction,
     )
     parser.add_argument(
@@ -101,13 +101,13 @@ def main() -> None:
         action=argparse.BooleanOptionalAction,
     )
     parser.add_argument(
-        "--bm_video_speed_min_run_seconds",
+        "--min_run_seconds",
         help="Benchmark minimum run time, in seconds, to wait per datapoint",
         type=float,
         default=2.0,
     )
     parser.add_argument(
-        "--bm_video_paths",
+        "--video_paths",
         help="Comma-separated paths to videos that you want to benchmark.",
         type=str,
         default=get_test_resource_path("nasa_13013.mp4"),
@@ -130,7 +130,7 @@ def main() -> None:
         ),
     )
     parser.add_argument(
-        "--bm_video_dir",
+        "--video_dir",
         help="Directory where video files reside. We will run benchmarks on all .mp4 files in this directory.",
         type=str,
         default="",
@@ -139,7 +139,7 @@ def main() -> None:
         "--plot_path",
         help="Path where the generated plot is stored, if non-empty",
         type=str,
-        default="",
+        default="benchmarks.png",
     )
 
     args = parser.parse_args()
@@ -163,10 +163,10 @@ def main() -> None:
         kind = decoder_registry[decoder].kind
         decoders_to_run[display] = kind(**options)
 
-    video_paths = args.bm_video_paths.split(",")
-    if args.bm_video_dir:
+    video_paths = args.video_paths.split(",")
+    if args.video_dir:
         video_paths = []
-        for entry in os.scandir(args.bm_video_dir):
+        for entry in os.scandir(args.video_dir):
             if entry.is_file() and entry.name.endswith(".mp4"):
                 video_paths.append(entry.path)
 
@@ -175,9 +175,8 @@ def main() -> None:
         video_paths,
         num_uniform_samples,
         num_sequential_frames_from_start=[1, 10, 100],
-        min_runtime_seconds=args.bm_video_speed_min_run_seconds,
+        min_runtime_seconds=args.min_run_seconds,
         benchmark_video_creation=args.bm_video_creation,
-        batch_parameters=BatchParameters(num_threads=8, batch_size=40),
     )
     data = {
         "experiments": results,


### PR DESCRIPTION
Benchmark refactoring. A bunch of minor option-name changes to make them shorter. Bigger change is removing `batch_parameters` as an option from the core runner. The problem is that we apply it to all other benchmark scenarios - except the data loading benchmark scenario, since that is in fact a kind of batch scenario. This is confusing and not easy to extend.

We should figure out a way to generalize how to specify and run more scenarios, but I think a principle we should apply is that scenarios are self-contained. We don't want to have a scenario that implicitly applies itself to other scenarios.