### PR TITLE
Lazily init filtergraph so it can respect raw decoded resolution

### DIFF
--- a/src/torchcodec/decoders/_core/VideoDecoder.h
+++ b/src/torchcodec/decoders/_core/VideoDecoder.h
@@ -157,7 +157,7 @@ class VideoDecoder {
       int streamIndex,
       const AudioStreamDecoderOptions& options = AudioStreamDecoderOptions());
 
-  torch::Tensor MaybePermuteHWC2CHW(int streamIndex, torch::Tensor& hwcTensor);
+  torch::Tensor maybePermuteHWC2CHW(int streamIndex, torch::Tensor& hwcTensor);
 
   // ---- SINGLE FRAME SEEK AND DECODING API ----
   // Places the cursor at the first frame on or after the position in seconds.
@@ -377,8 +377,8 @@ class VideoDecoder {
   // Creates and initializes a filter graph for a stream. The filter graph can
   // do rescaling and color conversion.
   void initializeFilterGraphForStream(
-      int streamIndex,
-      const VideoStreamDecoderOptions& options);
+      StreamInfo& streamInfo,
+      const AVFrame& frame);
   void maybeSeekToBeforeDesiredPts();
   RawDecodedOutput getDecodedOutputWithFilter(
       std::function<bool(int, AVFrame*)>);
@@ -436,7 +436,7 @@ class VideoDecoder {
 // We always allocate [N]HWC tensors. The low-level decoding functions all
 // assume HWC tensors, since this is what FFmpeg natively handles. It's up to
 // the high-level decoding entry-points to permute that back to CHW, by calling
-// MaybePermuteHWC2CHW().
+// maybePermuteHWC2CHW().
 //
 // Also, importantly, the way we figure out the the height and width of the
 // output frame tensor varies, and depends on the decoding entry-point. In

--- a/src/torchcodec/decoders/_core/VideoDecoder.h
+++ b/src/torchcodec/decoders/_core/VideoDecoder.h
@@ -376,9 +376,10 @@ class VideoDecoder {
   void validateFrameIndex(const StreamInfo& stream, int64_t frameIndex);
   // Creates and initializes a filter graph for a stream. The filter graph can
   // do rescaling and color conversion.
-  void initializeFilterGraphForStream(
+  void initializeFilterGraph(
       StreamInfo& streamInfo,
-      const AVFrame& frame);
+      int expectedOutputHeight,
+      int expectedOutputWidth);
   void maybeSeekToBeforeDesiredPts();
   RawDecodedOutput getDecodedOutputWithFilter(
       std::function<bool(int, AVFrame*)>);


### PR DESCRIPTION
We've encountered runtime errors with some videos where the resolution in the stream metadata disagrees with the resolution of the raw decoded frame. Because we have been initializing filtergraph so early, we've had to rely on the stream metadata. This PR does the initialization laziily, so we can use the resolution of the raw decoded frame.

Note that we still rely on the stream metadata for the batch APIs - they can run into the same problem. Dealing with that case will be more involved, since we'll need to do a sacrificial decode to discover what the size of the tensors should be. We should create an issue to track that case.

Note that I did consider just obeying whatever the stream metadata was. However, for swscale, we're also using the raw decoded frame to determine what the width should be. We should maintain the same behavior no matter which method we're using for the color space conversion.

This change seems to be performance neutral. Running:

```
python benchmarks/decoders/benchmark_decoders.py --decoders decord,decord_batch,torchcodec_public,torchcodec_core,torchaudio --min-run-seconds 20
```
I get:
```
[- video=/home/scottas/github/torchcodec/benchmarks/decoders/../../test/resources/nasa_13013.mp4 h264 480x270, 13.013s 29.97002997002997fps -]
                           |  decode 10 uniform frames  |  decode 10 random frames  |  first 1 frames  |  first 10 frames  |  first 100 frames
1 threads: -----------------------------------------------------------------------------------------------------------------------------------
      DecordAccurate       |            54.6            |           121.3           |       13.0       |        18.5       |        65.8      
      TorchAudio           |           187.1            |           200.1           |       11.6       |        13.1       |        32.6      
      TorchCodecPublic     |            49.2            |            44.8           |       14.1       |        14.8       |        29.1      
      DecordAccurateBatch  |            52.6            |           118.1           |       13.2       |        16.2       |        48.3      
      TorchCodecCore       |            49.5            |            44.6           |       15.7       |        18.3       |        45.7      
                                                             
Times are in milliseconds (ms).  
```
Which compares favorably with what I reported in #431.