### PR TITLE
Expose constructors in C++

### DIFF
--- a/src/torchcodec/decoders/_core/VideoDecoder.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoder.cpp
@@ -219,14 +219,17 @@ bool VideoDecoder::SwsContextKey::operator!=(
 VideoDecoder::VideoDecoder(const std::string& videoFilePath) {
   AVInput input = createAVFormatContextFromFilePath(videoFilePath);
   formatContext_ = std::move(input.formatContext);
+
   initializeDecoder();
 }
 
 VideoDecoder::VideoDecoder(const void* buffer, size_t length) {
   TORCH_CHECK(buffer != nullptr, "Video buffer cannot be nullptr!");
+
   AVInput input = createAVFormatContextFromBuffer(buffer, length);
   formatContext_ = std::move(input.formatContext);
   ioBytesContext_ = std::move(input.ioBytesContext);
+
   initializeDecoder();
 }
 

--- a/src/torchcodec/decoders/_core/VideoDecoder.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoder.cpp
@@ -216,7 +216,19 @@ bool VideoDecoder::SwsContextKey::operator!=(
   return !(*this == other);
 }
 
-VideoDecoder::VideoDecoder() {}
+VideoDecoder::VideoDecoder(const std::string& videoFilePath) {
+  AVInput input = createAVFormatContextFromFilePath(videoFilePath);
+  formatContext_ = std::move(input.formatContext);
+  initializeDecoder();
+}
+
+VideoDecoder::VideoDecoder(const void* buffer, size_t length) {
+  TORCH_CHECK(buffer != nullptr, "Video buffer cannot be nullptr!");
+  AVInput input = createAVFormatContextFromBuffer(buffer, length);
+  formatContext_ = std::move(input.formatContext);
+  ioBytesContext_ = std::move(input.ioBytesContext);
+  initializeDecoder();
+}
 
 void VideoDecoder::initializeDecoder() {
   // Some formats don't store enough info in the header so we read/decode a few
@@ -275,28 +287,14 @@ void VideoDecoder::initializeDecoder() {
 }
 
 std::unique_ptr<VideoDecoder> VideoDecoder::createFromFilePath(
-    const std::string& videoFilePath,
-    const VideoDecoder::DecoderOptions& options) {
-  AVInput input = createAVFormatContextFromFilePath(videoFilePath);
-  std::unique_ptr<VideoDecoder> decoder(new VideoDecoder());
-  decoder->formatContext_ = std::move(input.formatContext);
-  decoder->options_ = options;
-  decoder->initializeDecoder();
-  return decoder;
+    const std::string& videoFilePath) {
+  return std::unique_ptr<VideoDecoder>(new VideoDecoder(videoFilePath));
 }
 
 std::unique_ptr<VideoDecoder> VideoDecoder::createFromBuffer(
     const void* buffer,
-    size_t length,
-    const VideoDecoder::DecoderOptions& options) {
-  TORCH_CHECK(buffer != nullptr, "Video buffer cannot be nullptr!");
-  AVInput input = createAVFormatContextFromBuffer(buffer, length);
-  std::unique_ptr<VideoDecoder> decoder(new VideoDecoder());
-  decoder->formatContext_ = std::move(input.formatContext);
-  decoder->ioBytesContext_ = std::move(input.ioBytesContext);
-  decoder->options_ = options;
-  decoder->initializeDecoder();
-  return decoder;
+    size_t length) {
+  return std::unique_ptr<VideoDecoder>(new VideoDecoder(buffer, length));
 }
 
 void VideoDecoder::initializeFilterGraph(

--- a/src/torchcodec/decoders/_core/VideoDecoder.h
+++ b/src/torchcodec/decoders/_core/VideoDecoder.h
@@ -46,27 +46,23 @@ class VideoDecoder {
  public:
   ~VideoDecoder();
 
-  struct DecoderOptions {
-    DecoderOptions() {}
-    // TODO: Add options for the entire decoder here, or remove if not needed.
-  };
-
   // --------------------------------------------------------------------------
   // CONSTRUCTION API
   // --------------------------------------------------------------------------
 
+  explicit VideoDecoder(const std::string& videoFilePath);
+  explicit VideoDecoder(const void* buffer, size_t length);
+
   // Creates a VideoDecoder with the given options for the video in file
   // `videoFilePath`. If it fails, returns an error status.
   static std::unique_ptr<VideoDecoder> createFromFilePath(
-      const std::string& videoFilePath,
-      const DecoderOptions& options = DecoderOptions());
+      const std::string& videoFilePath);
 
   // Creates a VideoDecoder from a given buffer. Note that the buffer is not
   // owned by the VideoDecoder.
   static std::unique_ptr<VideoDecoder> createFromBuffer(
       const void* buffer,
-      size_t length,
-      const DecoderOptions& options = DecoderOptions());
+      size_t length);
 
   // --------------------------------------------------------------------------
   // VIDEO METADATA QUERY API
@@ -349,7 +345,6 @@ class VideoDecoder {
     SwsContextKey swsContextKey;
     UniqueSwsContext swsContext;
   };
-  VideoDecoder();
   // Returns the key frame index of the presentation timestamp using FFMPEG's
   // index. Note that this index may be truncated for some files.
   int getKeyFrameIndexForPtsUsingEncoderIndex(AVStream* stream, int64_t pts)
@@ -409,7 +404,6 @@ class VideoDecoder {
   DecodedOutput getNextFrameOutputNoDemuxInternal(
       std::optional<torch::Tensor> preAllocatedOutputTensor = std::nullopt);
 
-  DecoderOptions options_;
   ContainerMetadata containerMetadata_;
   UniqueAVFormatContext formatContext_;
   std::map<int, StreamInfo> streams_;

--- a/src/torchcodec/decoders/_core/VideoDecoder.h
+++ b/src/torchcodec/decoders/_core/VideoDecoder.h
@@ -50,16 +50,16 @@ class VideoDecoder {
   // CONSTRUCTION API
   // --------------------------------------------------------------------------
 
+  // Creates a VideoDecoder from the video at videoFilePath.
   explicit VideoDecoder(const std::string& videoFilePath);
-  explicit VideoDecoder(const void* buffer, size_t length);
-
-  // Creates a VideoDecoder with the given options for the video in file
-  // `videoFilePath`. If it fails, returns an error status.
-  static std::unique_ptr<VideoDecoder> createFromFilePath(
-      const std::string& videoFilePath);
 
   // Creates a VideoDecoder from a given buffer. Note that the buffer is not
   // owned by the VideoDecoder.
+  explicit VideoDecoder(const void* buffer, size_t length);
+
+  static std::unique_ptr<VideoDecoder> createFromFilePath(
+      const std::string& videoFilePath);
+
   static std::unique_ptr<VideoDecoder> createFromBuffer(
       const void* buffer,
       size_t length);


### PR DESCRIPTION
Prior to this PR, the `VideoDecoder` class in C++ had a single private constructor that did not do anything. The static create family of functions were effectively the constructors because they would set up the fields and do the initialization. We also had an empty `DecoderOptions` struct that was intentioned to be filled with parameters we would need at construction time. This PR:

1. Adds two public, explicit constructors.
2. Implements the create family of functions by calling the constructors.
3. Removes the empty options struct.

The value of doing this:

1. C++ has rich semantics and features around object construction. We were not taking advantage of it, and instead on a path to replicate some it by hand.
2. Before this change, no one could instantiate a `VideoDecoder` object on the stack. There's no need to prevent that use.
3. It's easier to reason about C++ objects when they obey the principle that the object is valid if the constructor has succeeded.