### PR TITLE
Refactor VideoDecoder C++ initialization

### DIFF
--- a/src/torchcodec/decoders/_core/VideoDecoder.h
+++ b/src/torchcodec/decoders/_core/VideoDecoder.h
@@ -420,6 +420,8 @@ class VideoDecoder {
   std::unique_ptr<AVIOBytesContext> ioBytesContext_;
   // Whether or not we have already scanned all streams to update the metadata.
   bool scanned_all_streams_ = false;
+  // Tracks that we've already been initialized.
+  bool initialized_ = false;
 };
 
 // --------------------------------------------------------------------------


### PR DESCRIPTION
In the C++ layer, in `VideoDeocder::initializeDecoder()`, we were calling `std::vector::resize()`, adding 1 each time, and then calling `std::vector::back()` to get a reference to the last element and fill it out. That is not how vectors are designed to be used. Instead, in the loop, we just create a struct on the stack, fill it with values, and call `std::vector::push_back()`.