### PR TITLE
Add public, nonbatch option for benchmarking

### DIFF
--- a/benchmarks/decoders/benchmark_decoders.py
+++ b/benchmarks/decoders/benchmark_decoders.py
@@ -26,6 +26,7 @@ from benchmark_decoders_library import (
     TorchCodecCoreCompiled,
     TorchCodecCoreNonBatch,
     TorchCodecPublic,
+    TorchCodecPublicNonBatch,
     TorchVision,
 )
 
@@ -49,6 +50,9 @@ decoder_registry = {
         "TorchCodecCoreCompiled", TorchCodecCoreCompiled
     ),
     "torchcodec_public": DecoderKind("TorchCodecPublic", TorchCodecPublic),
+    "torchcodec_public_nonbatch": DecoderKind(
+        "TorchCodecPublicNonBatch", TorchCodecPublicNonBatch
+    ),
     "torchvision": DecoderKind(
         # We don't compare against TorchVision's "pyav" backend because it doesn't support
         # accurate seeks.


### PR DESCRIPTION
Our batch APIs currently don't work when a video stream has variable frame resolution (see #433). This benchmarking option allows us to still benchmark against such videos, in particular since they are forced to use the single-frame APIs.