### PR TITLE
Rename `prevFrame` into `prevFrameContext`

### DIFF
--- a/src/torchcodec/decoders/_core/VideoDecoder.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoder.cpp
@@ -939,9 +939,10 @@ void VideoDecoder::convertAVFrameToDecodedOutputOnCPU(
       outputTensor = preAllocatedOutputTensor.value_or(allocateEmptyHWCTensor(
           expectedOutputHeight, expectedOutputWidth, torch::kCPU));
 
-      if (!streamInfo.swsContext || streamInfo.prevFrame != frameContext) {
+      if (!streamInfo.swsContext ||
+          streamInfo.prevFrameContext != frameContext) {
         createSwsContext(streamInfo, frameContext, frame->colorspace);
-        streamInfo.prevFrame = frameContext;
+        streamInfo.prevFrameContext = frameContext;
       }
       int resultHeight =
           convertFrameToTensorUsingSwsScale(streamIndex, frame, outputTensor);
@@ -960,10 +961,10 @@ void VideoDecoder::convertAVFrameToDecodedOutputOnCPU(
         streamInfo.colorConversionLibrary ==
         ColorConversionLibrary::FILTERGRAPH) {
       if (!streamInfo.filterState.filterGraph ||
-          streamInfo.prevFrame != frameContext) {
+          streamInfo.prevFrameContext != frameContext) {
         createFilterGraph(
             streamInfo, expectedOutputHeight, expectedOutputWidth);
-        streamInfo.prevFrame = frameContext;
+        streamInfo.prevFrameContext = frameContext;
       }
       outputTensor = convertFrameToTensorUsingFilterGraph(streamIndex, frame);
 

--- a/src/torchcodec/decoders/_core/VideoDecoder.h
+++ b/src/torchcodec/decoders/_core/VideoDecoder.h
@@ -342,7 +342,7 @@ class VideoDecoder {
     ColorConversionLibrary colorConversionLibrary = FILTERGRAPH;
     std::vector<FrameInfo> keyFrames;
     std::vector<FrameInfo> allFrames;
-    DecodedFrameContext prevFrame;
+    DecodedFrameContext prevFrameContext;
     UniqueSwsContext swsContext;
   };
   // Returns the key frame index of the presentation timestamp using FFMPEG's


### PR DESCRIPTION
Minor suggestion following https://github.com/pytorch/torchcodec/pull/436, to rename `prevFrame` into `prevFrameContext`. This clarify that this field is a `DecodedFrameContext`, and not e.g. a `FrameInfo` (like `keyFrames` or `allFrames`).