### PR TITLE
Restore comment about getting stream info

### DIFF
--- a/src/torchcodec/decoders/_core/VideoDecoder.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoder.cpp
@@ -237,6 +237,11 @@ VideoDecoder::VideoDecoder(const void* buffer, size_t length) {
 void VideoDecoder::initializeDecoder() {
   TORCH_CHECK(!initialized_, "Attempted double initialization.");
 
+  // In principle, the AVFormatContext should be filled in by the call to
+  // avformat_open_input() which reads the header. However, some formats do not
+  // store enough info in the header, so we call avformat_find_stream_info()
+  // which decodes a few frames to get missing info. For more, see:
+  //   https://ffmpeg.org/doxygen/7.0/group__lavf__decoding.html
   int ffmpegStatus = avformat_find_stream_info(formatContext_.get(), nullptr);
   if (ffmpegStatus < 0) {
     throw std::runtime_error(


### PR DESCRIPTION
PR #435 removed a version of this comment, and @NicolasHug pointed out that it's still relevant in https://github.com/pytorch/torchcodec/pull/435/files#r1907517932. This PR restores the relevant parts.