### PR TITLE
Make C++ compilation strict, treat warnings as errors

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -112,7 +112,7 @@ jobs:
         run: |
           cd docs
           ${CONDA_RUN} make html
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: Built-Docs
           path: docs/build/html/

--- a/src/torchcodec/decoders/_core/CMakeLists.txt
+++ b/src/torchcodec/decoders/_core/CMakeLists.txt
@@ -4,7 +4,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(Torch REQUIRED)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${TORCH_CXX_FLAGS} -Wall -Wextra -pedantic -Werror")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic -Werror ${TORCH_CXX_FLAGS}")
 find_package(Python3 ${PYTHON_VERSION} EXACT COMPONENTS Development)
 
 function(make_torchcodec_library library_name ffmpeg_target)

--- a/src/torchcodec/decoders/_core/CMakeLists.txt
+++ b/src/torchcodec/decoders/_core/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.18)
 project(TorchCodec)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-add_compile_options(-Wall -Wextra -pedantic -Werror -Wparentheses)
+add_compile_options(-Wall -Wextra -pedantic -Werror)
 
 find_package(Torch REQUIRED)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${TORCH_CXX_FLAGS}")

--- a/src/torchcodec/decoders/_core/CMakeLists.txt
+++ b/src/torchcodec/decoders/_core/CMakeLists.txt
@@ -2,10 +2,9 @@ cmake_minimum_required(VERSION 3.18)
 project(TorchCodec)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-add_compile_options(-Wall -Wextra -pedantic -Werror)
 
 find_package(Torch REQUIRED)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${TORCH_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${TORCH_CXX_FLAGS} -Wall -Wextra -pedantic -Werror")
 find_package(Python3 ${PYTHON_VERSION} EXACT COMPONENTS Development)
 
 function(make_torchcodec_library library_name ffmpeg_target)

--- a/src/torchcodec/decoders/_core/CMakeLists.txt
+++ b/src/torchcodec/decoders/_core/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.18)
 project(TorchCodec)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+add_compile_options(-Wall -Wextra -pedantic -Werror -Wparentheses)
 
 find_package(Torch REQUIRED)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${TORCH_CXX_FLAGS}")

--- a/src/torchcodec/decoders/_core/CPUOnlyDevice.cpp
+++ b/src/torchcodec/decoders/_core/CPUOnlyDevice.cpp
@@ -16,28 +16,28 @@ namespace facebook::torchcodec {
 
 void convertAVFrameToDecodedOutputOnCuda(
     const torch::Device& device,
-    const VideoDecoder::VideoStreamDecoderOptions& options,
-    VideoDecoder::RawDecodedOutput& rawOutput,
-    VideoDecoder::DecodedOutput& output,
-    std::optional<torch::Tensor> preAllocatedOutputTensor) {
+    [[maybe_unused]] const VideoDecoder::VideoStreamDecoderOptions& options,
+    [[maybe_unused]] VideoDecoder::RawDecodedOutput& rawOutput,
+    [[maybe_unused]] VideoDecoder::DecodedOutput& output,
+    [[maybe_unused]] std::optional<torch::Tensor> preAllocatedOutputTensor) {
   throwUnsupportedDeviceError(device);
 }
 
 void initializeContextOnCuda(
     const torch::Device& device,
-    AVCodecContext* codecContext) {
+    [[maybe_unused]] AVCodecContext* codecContext) {
   throwUnsupportedDeviceError(device);
 }
 
 void releaseContextOnCuda(
     const torch::Device& device,
-    AVCodecContext* codecContext) {
+    [[maybe_unused]] AVCodecContext* codecContext) {
   throwUnsupportedDeviceError(device);
 }
 
 std::optional<AVCodecPtr> findCudaCodec(
     const torch::Device& device,
-    const AVCodecID& codecId) {
+    [[maybe_unused]] const AVCodecID& codecId) {
   throwUnsupportedDeviceError(device);
 }
 

--- a/src/torchcodec/decoders/_core/CudaDevice.cpp
+++ b/src/torchcodec/decoders/_core/CudaDevice.cpp
@@ -265,7 +265,7 @@ std::optional<const AVCodec*> findCudaCodec(
   throwErrorIfNonCudaDevice(device);
 
   void* i = nullptr;
-  const AVCodec** codec = nullptr;
+  std::unique_ptr<const AVCodec*> codec(new AVCodec*);
   while ((*codec = av_codec_iterate(&i)) != nullptr) {
     if ((*codec)->id != codecId || !av_codec_is_decoder(*codec)) {
       continue;

--- a/src/torchcodec/decoders/_core/CudaDevice.cpp
+++ b/src/torchcodec/decoders/_core/CudaDevice.cpp
@@ -266,7 +266,7 @@ std::optional<const AVCodec*> findCudaCodec(
   throwErrorIfNonCudaDevice(device);
 
   void* i = nullptr;
-  while ((const AVCodec* codec = av_codec_iterate(&i))) {
+  while (const AVCodec* codec = av_codec_iterate(&i)) {
     if (codec->id != codecId || !av_codec_is_decoder(codec)) {
       continue;
     }

--- a/src/torchcodec/decoders/_core/CudaDevice.cpp
+++ b/src/torchcodec/decoders/_core/CudaDevice.cpp
@@ -267,14 +267,14 @@ std::optional<const AVCodec*> findCudaCodec(
   void* i = nullptr;
   const AVCodec** codec = nullptr;
   while ((*codec = av_codec_iterate(&i)) != nullptr) {
-    if (*codec->id != codecId || !av_codec_is_decoder(*codec)) {
+    if ((*codec)->id != codecId || !av_codec_is_decoder(*codec)) {
       continue;
     }
 
     const AVCodecHWConfig** config = nullptr;
     for (int j = 0; (*config = avcodec_get_hw_config(*codec, j)) != nullptr;
          ++j) {
-      if (*config->device_type == AV_HWDEVICE_TYPE_CUDA) {
+      if ((*config)->device_type == AV_HWDEVICE_TYPE_CUDA) {
         return *codec;
       }
     }

--- a/src/torchcodec/decoders/_core/CudaDevice.cpp
+++ b/src/torchcodec/decoders/_core/CudaDevice.cpp
@@ -266,13 +266,13 @@ std::optional<const AVCodec*> findCudaCodec(
   throwErrorIfNonCudaDevice(device);
 
   void* i = nullptr;
-  while (const AVCodec* codec = av_codec_iterate(&i)) {
+  while ((AVCodec* codec = av_codec_iterate(&i)) != nullptr) {
     if (codec->id != codecId || !av_codec_is_decoder(codec)) {
       continue;
     }
 
     for (int j = 0;
-         (const AVCodecHWConfig* config = avcodec_get_hw_config(codec, j));
+         (AVCodecHWConfig* config = avcodec_get_hw_config(codec, j)) != nullptr;
          j++) {
       if (config->device_type == AV_HWDEVICE_TYPE_CUDA) {
         return codec;

--- a/src/torchcodec/decoders/_core/CudaDevice.cpp
+++ b/src/torchcodec/decoders/_core/CudaDevice.cpp
@@ -265,17 +265,17 @@ std::optional<const AVCodec*> findCudaCodec(
   throwErrorIfNonCudaDevice(device);
 
   void* i = nullptr;
-  std::unique_ptr<const AVCodec*> codec(new const AVCodec*);
-  while ((*codec = av_codec_iterate(&i)) != nullptr) {
-    if ((*codec)->id != codecId || !av_codec_is_decoder(*codec)) {
+  const AVCodec* codec = nullptr;
+  while ((codec = av_codec_iterate(&i)) != nullptr) {
+    if (codec->id != codecId || !av_codec_is_decoder(codec)) {
       continue;
     }
 
-    const AVCodecHWConfig** config = nullptr;
-    for (int j = 0; (*config = avcodec_get_hw_config(*codec, j)) != nullptr;
+    const AVCodecHWConfig* config = nullptr;
+    for (int j = 0; (config = avcodec_get_hw_config(codec, j)) != nullptr;
          ++j) {
-      if ((*config)->device_type == AV_HWDEVICE_TYPE_CUDA) {
-        return *codec;
+      if (config->device_type == AV_HWDEVICE_TYPE_CUDA) {
+        return codec;
       }
     }
   }

--- a/src/torchcodec/decoders/_core/CudaDevice.cpp
+++ b/src/torchcodec/decoders/_core/CudaDevice.cpp
@@ -267,15 +267,15 @@ std::optional<const AVCodec*> findCudaCodec(
   void* i = nullptr;
   const AVCodec** codec = nullptr;
   while ((*codec = av_codec_iterate(&i)) != nullptr) {
-    if (codec->id != codecId || !av_codec_is_decoder(codec)) {
+    if (*codec->id != codecId || !av_codec_is_decoder(*codec)) {
       continue;
     }
 
     const AVCodecHWConfig** config = nullptr;
-    for (int j = 0; (*config = avcodec_get_hw_config(codec, j)) != nullptr;
+    for (int j = 0; (*config = avcodec_get_hw_config(*codec, j)) != nullptr;
          ++j) {
-      if (config->device_type == AV_HWDEVICE_TYPE_CUDA) {
-        return codec;
+      if (*config->device_type == AV_HWDEVICE_TYPE_CUDA) {
+        return *codec;
       }
     }
   }

--- a/src/torchcodec/decoders/_core/CudaDevice.cpp
+++ b/src/torchcodec/decoders/_core/CudaDevice.cpp
@@ -260,14 +260,13 @@ void convertAVFrameToDecodedOutputOnCuda(
 // we have to do this because of an FFmpeg bug where hardware decoding is not
 // appropriately set, so we just go off and find the matching codec for the CUDA
 // device
-std::optional<AVCodecPtr> findCudaCodec(
+std::optional<const AVCodec*> findCudaCodec(
     const torch::Device& device,
     const AVCodecID& codecId) {
   throwErrorIfNonCudaDevice(device);
 
   void* i = nullptr;
-
-  while ((const AVCodecPtr codec = av_codec_iterate(&i))) {
+  while ((const AVCodec* codec = av_codec_iterate(&i))) {
     if (codec->id != codecId || !av_codec_is_decoder(codec)) {
       continue;
     }

--- a/src/torchcodec/decoders/_core/CudaDevice.cpp
+++ b/src/torchcodec/decoders/_core/CudaDevice.cpp
@@ -265,7 +265,7 @@ std::optional<const AVCodec*> findCudaCodec(
   throwErrorIfNonCudaDevice(device);
 
   void* i = nullptr;
-  std::unique_ptr<const AVCodec*> codec(new AVCodec*);
+  std::unique_ptr<const AVCodec*> codec(new const AVCodec*);
   while ((*codec = av_codec_iterate(&i)) != nullptr) {
     if ((*codec)->id != codecId || !av_codec_is_decoder(*codec)) {
       continue;

--- a/src/torchcodec/decoders/_core/CudaDevice.cpp
+++ b/src/torchcodec/decoders/_core/CudaDevice.cpp
@@ -109,7 +109,7 @@ AVBufferRef* getFFMPEGContextFromExistingCudaContext(
 #else
 
 AVBufferRef* getFFMPEGContextFromNewCudaContext(
-    const torch::Device& device,
+    [[maybe_unused]] const torch::Device& device,
     torch::DeviceIndex nonNegativeDeviceIndex,
     enum AVHWDeviceType type) {
   AVBufferRef* hw_device_ctx = nullptr;

--- a/src/torchcodec/decoders/_core/CudaDevice.cpp
+++ b/src/torchcodec/decoders/_core/CudaDevice.cpp
@@ -265,10 +265,10 @@ std::optional<AVCodecPtr> findCudaCodec(
     const AVCodecID& codecId) {
   throwErrorIfNonCudaDevice(device);
 
-  void* i = NULL;
+  void* i = nullptr;
 
-  AVCodecPtr c;
-  while (c = av_codec_iterate(&i)) {
+  const AVCodecPtr c;
+  while ((c = av_codec_iterate(&i))) {
     const AVCodecHWConfig* config;
 
     if (c->id != codecId || !av_codec_is_decoder(c)) {

--- a/src/torchcodec/decoders/_core/CudaDevice.cpp
+++ b/src/torchcodec/decoders/_core/CudaDevice.cpp
@@ -267,17 +267,16 @@ std::optional<AVCodecPtr> findCudaCodec(
 
   void* i = nullptr;
 
-  const AVCodecPtr c;
-  while ((c = av_codec_iterate(&i))) {
-    const AVCodecHWConfig* config;
-
-    if (c->id != codecId || !av_codec_is_decoder(c)) {
+  while ((const AVCodecPtr codec = av_codec_iterate(&i))) {
+    if (codec->id != codecId || !av_codec_is_decoder(codec)) {
       continue;
     }
 
-    for (int j = 0; config = avcodec_get_hw_config(c, j); j++) {
+    for (int j = 0;
+         (const AVCodecHWConfig* config = avcodec_get_hw_config(codec, j));
+         j++) {
       if (config->device_type == AV_HWDEVICE_TYPE_CUDA) {
-        return c;
+        return codec;
       }
     }
   }

--- a/src/torchcodec/decoders/_core/DeviceInterface.h
+++ b/src/torchcodec/decoders/_core/DeviceInterface.h
@@ -13,10 +13,6 @@
 #include "FFMPEGCommon.h"
 #include "src/torchcodec/decoders/_core/VideoDecoder.h"
 
-extern "C" {
-#include <libavcodec/avcodec.h>
-}
-
 namespace facebook::torchcodec {
 
 // Note that all these device functions should only be called if the device is

--- a/src/torchcodec/decoders/_core/FFMPEGCommon.cpp
+++ b/src/torchcodec/decoders/_core/FFMPEGCommon.cpp
@@ -21,7 +21,7 @@ int64_t getDuration(const UniqueAVFrame& frame) {
 }
 
 int64_t getDuration(const AVFrame* frame) {
-#if LIBAVUTIL_VERSION_MAJOR < 59
+#if LIBAVUTIL_VERSION_MAJOR < 58
   return frame->pkt_duration;
 #else
   return frame->duration;

--- a/src/torchcodec/decoders/_core/FFMPEGCommon.cpp
+++ b/src/torchcodec/decoders/_core/FFMPEGCommon.cpp
@@ -75,7 +75,8 @@ int AVIOBytesContext::read(void* opaque, uint8_t* buf, int buf_size) {
       bufferData->current,
       ", size=",
       bufferData->size);
-  buf_size = FFMIN(buf_size, bufferData->size - bufferData->current);
+  buf_size =
+      FFMIN(buf_size, static_cast<int>(bufferData->size - bufferData->current));
   TORCH_CHECK(
       buf_size >= 0,
       "Tried to read negative bytes: buf_size=",

--- a/src/torchcodec/decoders/_core/VideoDecoder.h
+++ b/src/torchcodec/decoders/_core/VideoDecoder.h
@@ -366,7 +366,7 @@ class VideoDecoder {
   // for more details about the heuristics.
   int getBestStreamIndex(AVMediaType mediaType);
   void initializeDecoder();
-  void validateUserProvidedStreamIndex(uint64_t streamIndex);
+  void validateUserProvidedStreamIndex(int streamIndex);
   void validateScannedAllStreams(const std::string& msg);
   void validateFrameIndex(const StreamInfo& stream, int64_t frameIndex);
   // Creates and initializes a filter graph for a stream. The filter graph can

--- a/src/torchcodec/decoders/_core/VideoDecoderOps.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoderOps.cpp
@@ -396,7 +396,8 @@ std::string get_stream_json_metadata(
     int64_t stream_index) {
   auto videoDecoder = unwrapTensorToGetDecoder(decoder);
   auto streams = videoDecoder->getContainerMetadata().streams;
-  if (stream_index < 0 || stream_index >= streams.size()) {
+  if (stream_index < 0 ||
+      stream_index >= static_cast<int64_t>(streams.size())) {
     throw std::out_of_range(
         "stream_index out of bounds: " + std::to_string(stream_index));
   }


### PR DESCRIPTION
We still sometimes get C++ code that compiles externally that does not compile internally. I think one way to make this less likely is for our CMake builds to be more restrictive. This means compiling with:
```
-Wall -Wextra -pedantic -Werror
```
However, turning that on means we need to fixup a bunch of integer comparisons, so there are a lot of small changes in this PR. It's also worth noting that I still could not reproduce the errors I get on internal builds. I think there will always be the possibility of disagreement because of different compilers.