### PR TITLE
Remove use of AVCodecPtr in interface definition

### DIFF
--- a/src/torchcodec/decoders/_core/CPUOnlyDevice.cpp
+++ b/src/torchcodec/decoders/_core/CPUOnlyDevice.cpp
@@ -35,7 +35,7 @@ void releaseContextOnCuda(
   throwUnsupportedDeviceError(device);
 }
 
-std::optional<AVCodecPtrBestStream> findCudaCodec(
+std::optional<const AVCodec*> findCudaCodec(
     const torch::Device& device,
     [[maybe_unused]] const AVCodecID& codecId) {
   throwUnsupportedDeviceError(device);

--- a/src/torchcodec/decoders/_core/CPUOnlyDevice.cpp
+++ b/src/torchcodec/decoders/_core/CPUOnlyDevice.cpp
@@ -35,7 +35,7 @@ void releaseContextOnCuda(
   throwUnsupportedDeviceError(device);
 }
 
-std::optional<const AVCodec*> findCudaCodec(
+std::optional<AVCodecPtrBestStream> findCudaCodec(
     const torch::Device& device,
     [[maybe_unused]] const AVCodecID& codecId) {
   throwUnsupportedDeviceError(device);

--- a/src/torchcodec/decoders/_core/CPUOnlyDevice.cpp
+++ b/src/torchcodec/decoders/_core/CPUOnlyDevice.cpp
@@ -35,7 +35,7 @@ void releaseContextOnCuda(
   throwUnsupportedDeviceError(device);
 }
 
-std::optional<AVCodecPtr> findCudaCodec(
+std::optional<const AVCodec*> findCudaCodec(
     const torch::Device& device,
     [[maybe_unused]] const AVCodecID& codecId) {
   throwUnsupportedDeviceError(device);

--- a/src/torchcodec/decoders/_core/CudaDevice.cpp
+++ b/src/torchcodec/decoders/_core/CudaDevice.cpp
@@ -259,7 +259,7 @@ void convertAVFrameToDecodedOutputOnCuda(
 // we have to do this because of an FFmpeg bug where hardware decoding is not
 // appropriately set, so we just go off and find the matching codec for the CUDA
 // device
-std::optional<AVCodecPtrBestStream> findCudaCodec(
+std::optional<const AVCodec*> findCudaCodec(
     const torch::Device& device,
     const AVCodecID& codecId) {
   throwErrorIfNonCudaDevice(device);
@@ -275,7 +275,7 @@ std::optional<AVCodecPtrBestStream> findCudaCodec(
     for (int j = 0; (config = avcodec_get_hw_config(codec, j)) != nullptr;
          ++j) {
       if (config->device_type == AV_HWDEVICE_TYPE_CUDA) {
-        return makeAVCodecPtrBestStream(codec);
+        return codec;
       }
     }
   }

--- a/src/torchcodec/decoders/_core/CudaDevice.cpp
+++ b/src/torchcodec/decoders/_core/CudaDevice.cpp
@@ -259,7 +259,7 @@ void convertAVFrameToDecodedOutputOnCuda(
 // we have to do this because of an FFmpeg bug where hardware decoding is not
 // appropriately set, so we just go off and find the matching codec for the CUDA
 // device
-std::optional<const AVCodec*> findCudaCodec(
+std::optional<AVCodecPtrBestStream> findCudaCodec(
     const torch::Device& device,
     const AVCodecID& codecId) {
   throwErrorIfNonCudaDevice(device);
@@ -275,7 +275,7 @@ std::optional<const AVCodec*> findCudaCodec(
     for (int j = 0; (config = avcodec_get_hw_config(codec, j)) != nullptr;
          ++j) {
       if (config->device_type == AV_HWDEVICE_TYPE_CUDA) {
-        return codec;
+        return makeAVCodecPtrBestStream(codec);
       }
     }
   }

--- a/src/torchcodec/decoders/_core/DeviceInterface.h
+++ b/src/torchcodec/decoders/_core/DeviceInterface.h
@@ -40,7 +40,7 @@ void releaseContextOnCuda(
     const torch::Device& device,
     AVCodecContext* codecContext);
 
-std::optional<const AVCodec*> findCudaCodec(
+std::optional<AVCodecPtrBestStream> findCudaCodec(
     const torch::Device& device,
     const AVCodecID& codecId);
 

--- a/src/torchcodec/decoders/_core/DeviceInterface.h
+++ b/src/torchcodec/decoders/_core/DeviceInterface.h
@@ -40,7 +40,7 @@ void releaseContextOnCuda(
     const torch::Device& device,
     AVCodecContext* codecContext);
 
-std::optional<AVCodecPtrBestStream> findCudaCodec(
+std::optional<const AVCodec*> findCudaCodec(
     const torch::Device& device,
     const AVCodecID& codecId);
 

--- a/src/torchcodec/decoders/_core/DeviceInterface.h
+++ b/src/torchcodec/decoders/_core/DeviceInterface.h
@@ -40,7 +40,7 @@ void releaseContextOnCuda(
     const torch::Device& device,
     AVCodecContext* codecContext);
 
-std::optional<AVCodecPtr> findCudaCodec(
+std::optional<const AVCodec*> findCudaCodec(
     const torch::Device& device,
     const AVCodecID& codecId);
 

--- a/src/torchcodec/decoders/_core/FFMPEGCommon.cpp
+++ b/src/torchcodec/decoders/_core/FFMPEGCommon.cpp
@@ -10,6 +10,14 @@
 
 namespace facebook::torchcodec {
 
+AVCodecPtrBestStream makeAVCodecPtrBestStream(const AVCodec* codec) {
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(59, 18, 100)
+  return const_cast<AVCodec*>(codec);
+#else
+  return codec;
+#endif
+}
+
 std::string getFFMPEGErrorStringFromErrorCode(int errorCode) {
   char errorBuffer[AV_ERROR_MAX_STRING_SIZE] = {0};
   av_strerror(errorCode, errorBuffer, AV_ERROR_MAX_STRING_SIZE);

--- a/src/torchcodec/decoders/_core/FFMPEGCommon.cpp
+++ b/src/torchcodec/decoders/_core/FFMPEGCommon.cpp
@@ -10,7 +10,8 @@
 
 namespace facebook::torchcodec {
 
-AVCodecPtrBestStream makeAVCodecPtrBestStream(const AVCodec* codec) {
+AVCodecOnlyUseForCallingAVFindBestStream
+makeAVCodecOnlyUseForCallingAVFindBestStream(const AVCodec* codec) {
 #if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(59, 18, 100)
   return const_cast<AVCodec*>(codec);
 #else

--- a/src/torchcodec/decoders/_core/FFMPEGCommon.h
+++ b/src/torchcodec/decoders/_core/FFMPEGCommon.h
@@ -75,11 +75,15 @@ using UniqueSwsContext =
 // which was released in FFMPEG version=5.0.3
 // with libavcodec's version=59.18.100
 // (https://www.ffmpeg.org/olddownload.html).
+// Note that the alias is so-named so that it is only used when interacting with
+// av_find_best_stream(). It is not needed elsewhere.
 #if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(59, 18, 100)
-using AVCodecPtr = AVCodec*;
+using AVCodecPtrBestStream = AVCodec*;
 #else
-using AVCodecPtr = const AVCodec*;
+using AVCodecPtrBestStream = const AVCodec*;
 #endif
+
+AVCodecPtrBestStream makeAVCodecPtrBestStream(const AVCodec* codec);
 
 // Success code from FFMPEG is just a 0. We define it to make the code more
 // readable.

--- a/src/torchcodec/decoders/_core/FFMPEGCommon.h
+++ b/src/torchcodec/decoders/_core/FFMPEGCommon.h
@@ -78,12 +78,13 @@ using UniqueSwsContext =
 // Note that the alias is so-named so that it is only used when interacting with
 // av_find_best_stream(). It is not needed elsewhere.
 #if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(59, 18, 100)
-using AVCodecPtrBestStream = AVCodec*;
+using AVCodecOnlyUseForCallingAVFindBestStream = AVCodec*;
 #else
-using AVCodecPtrBestStream = const AVCodec*;
+using AVCodecOnlyUseForCallingAVFindBestStream = const AVCodec*;
 #endif
 
-AVCodecPtrBestStream makeAVCodecPtrBestStream(const AVCodec* codec);
+AVCodecOnlyUseForCallingAVFindBestStream
+makeAVCodecOnlyUseForCallingAVFindBestStream(const AVCodec* codec);
 
 // Success code from FFMPEG is just a 0. We define it to make the code more
 // readable.

--- a/src/torchcodec/decoders/_core/VideoDecoder.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoder.cpp
@@ -464,8 +464,9 @@ void VideoDecoder::addVideoStreamDecoder(
   }
 
   if (options.device.type() == torch::kCUDA) {
-    codec = findCudaCodec(options.device, streamInfo.stream->codecpar->codec_id)
-                .value_or(codec);
+    codec = makeAVCodecPtrBestStream(
+        findCudaCodec(options.device, streamInfo.stream->codecpar->codec_id)
+            .value_or(codec));
   }
 
   AVCodecContext* codecContext = avcodec_alloc_context3(codec);

--- a/src/torchcodec/decoders/_core/VideoDecoder.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoder.cpp
@@ -426,7 +426,7 @@ void VideoDecoder::createFilterGraph(
 }
 
 int VideoDecoder::getBestStreamIndex(AVMediaType mediaType) {
-  AVCodecPtrBestStream codec = nullptr;
+  AVCodecOnlyUseForCallingAVFindBestStream codec = nullptr;
   int streamNumber =
       av_find_best_stream(formatContext_.get(), mediaType, -1, -1, &codec, 0);
   return streamNumber;
@@ -441,7 +441,7 @@ void VideoDecoder::addVideoStreamDecoder(
         " is already active.");
   }
   TORCH_CHECK(formatContext_.get() != nullptr);
-  AVCodecPtrBestStream codec = nullptr;
+  AVCodecOnlyUseForCallingAVFindBestStream codec = nullptr;
   int streamNumber = av_find_best_stream(
       formatContext_.get(),
       AVMEDIA_TYPE_VIDEO,
@@ -464,7 +464,7 @@ void VideoDecoder::addVideoStreamDecoder(
   }
 
   if (options.device.type() == torch::kCUDA) {
-    codec = makeAVCodecPtrBestStream(
+    codec = makeAVCodecOnlyUseForCallingAVFindBestStream(
         findCudaCodec(options.device, streamInfo.stream->codecpar->codec_id)
             .value_or(codec));
   }

--- a/src/torchcodec/decoders/_core/VideoDecoder.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoder.cpp
@@ -426,7 +426,7 @@ void VideoDecoder::createFilterGraph(
 }
 
 int VideoDecoder::getBestStreamIndex(AVMediaType mediaType) {
-  AVCodecPtr codec = nullptr;
+  AVCodecPtrBestStream codec = nullptr;
   int streamNumber =
       av_find_best_stream(formatContext_.get(), mediaType, -1, -1, &codec, 0);
   return streamNumber;
@@ -441,7 +441,7 @@ void VideoDecoder::addVideoStreamDecoder(
         " is already active.");
   }
   TORCH_CHECK(formatContext_.get() != nullptr);
-  AVCodecPtr codec = nullptr;
+  AVCodecPtrBestStream codec = nullptr;
   int streamNumber = av_find_best_stream(
       formatContext_.get(),
       AVMEDIA_TYPE_VIDEO,


### PR DESCRIPTION
This somehow slipped through the checking in #452.

What we used to call `AVCodecPtr` and I've now renamed to `AVCodecPtrBestStream` is an alias for `AVCodec*` or `const AVCodec*` depending on which FFmpeg version we're compiling for. The const-requirements for this pointer changed across versions in the call [`av_find_best_stream()`](https://www.ffmpeg.org/doxygen/2.5/group__lavf__decoding.html#gaa6fa468c922ff5c60a6021dcac09aff9). I've renamed the alias to make it obvious that we _only_ should use it for when we're calling `av_find_best_stream()`; it's not a general alias for all uses of `AVCodec*`.

Where this gets awkward is in `findCudaCodec()` where we call other functions that always expect a `const AVCodec*`. So I created a function to abstract whether or not we need to a const-cast. My principle here is all checking of FFmpeg versions should happen in `FFMpegCommon`.