### PR TITLE
Move packet allocation out of decoding loop

### DIFF
--- a/src/torchcodec/decoders/_core/FFMPEGCommon.cpp
+++ b/src/torchcodec/decoders/_core/FFMPEGCommon.cpp
@@ -10,6 +10,25 @@
 
 namespace facebook::torchcodec {
 
+AVPacketHandler::AVPacketHandler() : avPacket_(av_packet_alloc()) {
+  TORCH_CHECK(avPacket_ != nullptr, "Couldn't allocate avPacket.");
+}
+AVPacketHandler::~AVPacketHandler() {
+  av_packet_free(&avPacket_);
+}
+
+ReferencedAVPacket::ReferencedAVPacket(AVPacketHandler& shared)
+    : avPacket_(shared.avPacket_) {}
+ReferencedAVPacket::~ReferencedAVPacket() {
+  av_packet_unref(avPacket_);
+}
+AVPacket* ReferencedAVPacket::get() {
+  return avPacket_;
+}
+AVPacket* ReferencedAVPacket::operator->() {
+  return avPacket_;
+}
+
 AVCodecOnlyUseForCallingAVFindBestStream
 makeAVCodecOnlyUseForCallingAVFindBestStream(const AVCodec* codec) {
 #if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(59, 18, 100)

--- a/src/torchcodec/decoders/_core/FFMPEGCommon.cpp
+++ b/src/torchcodec/decoders/_core/FFMPEGCommon.cpp
@@ -10,22 +10,22 @@
 
 namespace facebook::torchcodec {
 
-AVPacketHandler::AVPacketHandler() : avPacket_(av_packet_alloc()) {
+AutoFreedAVPacket::AutoFreedAVPacket() : avPacket_(av_packet_alloc()) {
   TORCH_CHECK(avPacket_ != nullptr, "Couldn't allocate avPacket.");
 }
-AVPacketHandler::~AVPacketHandler() {
+AutoFreedAVPacket::~AutoFreedAVPacket() {
   av_packet_free(&avPacket_);
 }
 
-ReferencedAVPacket::ReferencedAVPacket(AVPacketHandler& shared)
+AutoUnrefedAVPacket::AutoUnrefedAVPacket(AutoFreedAVPacket& shared)
     : avPacket_(shared.avPacket_) {}
-ReferencedAVPacket::~ReferencedAVPacket() {
+AutoUnrefedAVPacket::~AutoUnrefedAVPacket() {
   av_packet_unref(avPacket_);
 }
-AVPacket* ReferencedAVPacket::get() {
+AVPacket* AutoUnrefedAVPacket::get() {
   return avPacket_;
 }
-AVPacket* ReferencedAVPacket::operator->() {
+AVPacket* AutoUnrefedAVPacket::operator->() {
   return avPacket_;
 }
 

--- a/src/torchcodec/decoders/_core/FFMPEGCommon.cpp
+++ b/src/torchcodec/decoders/_core/FFMPEGCommon.cpp
@@ -10,22 +10,22 @@
 
 namespace facebook::torchcodec {
 
-AutoFreedAVPacket::AutoFreedAVPacket() : avPacket_(av_packet_alloc()) {
+AutoAVPacket::AutoAVPacket() : avPacket_(av_packet_alloc()) {
   TORCH_CHECK(avPacket_ != nullptr, "Couldn't allocate avPacket.");
 }
-AutoFreedAVPacket::~AutoFreedAVPacket() {
+AutoAVPacket::~AutoAVPacket() {
   av_packet_free(&avPacket_);
 }
 
-AutoUnrefedAVPacket::AutoUnrefedAVPacket(AutoFreedAVPacket& shared)
+ReferenceAVPacket::ReferenceAVPacket(AutoAVPacket& shared)
     : avPacket_(shared.avPacket_) {}
-AutoUnrefedAVPacket::~AutoUnrefedAVPacket() {
+ReferenceAVPacket::~ReferenceAVPacket() {
   av_packet_unref(avPacket_);
 }
-AVPacket* AutoUnrefedAVPacket::get() {
+AVPacket* ReferenceAVPacket::get() {
   return avPacket_;
 }
-AVPacket* AutoUnrefedAVPacket::operator->() {
+AVPacket* ReferenceAVPacket::operator->() {
   return avPacket_;
 }
 

--- a/src/torchcodec/decoders/_core/FFMPEGCommon.h
+++ b/src/torchcodec/decoders/_core/FFMPEGCommon.h
@@ -71,37 +71,37 @@ using UniqueSwsContext =
 // These 2 classes share the same underlying AVPacket object. They are meant to
 // be used in tandem, like so:
 //
-// AutoFreedAVPacket autoFreedAVPacket; // <-- malloc for AVPacket happens here
+// AutoAVPacket autoAVPacket; // <-- malloc for AVPacket happens here
 // while(...){
-//   AutoUnrefedAVPacket packet(autoFreedAVPacket);
+//   ReferenceAVPacket packet(autoAVPacket);
 //   av_read_frame(..., packet.get());  <-- av_packet_ref() called by FFmpeg
 // } <-- av_packet_unref() called here
 //
 // This achieves a few desirable things:
 // - Memory allocation of the underlying AVPacket happens only once, when
-//   autoFreedAVPacket is created.
-// - av_packet_free() is called when autoFreedAVPacket gets out of scope
+//   autoAVPacket is created.
+// - av_packet_free() is called when autoAVPacket gets out of scope
 // - av_packet_unref() is automatically called when needed, i.e. at the end of
 //   each loop iteration (or when hitting break / continue). This prevents the
 //   risk of us forgetting to call it.
-class AutoFreedAVPacket {
-  friend class AutoUnrefedAVPacket;
+class AutoAVPacket {
+  friend class ReferenceAVPacket;
 
  private:
   AVPacket* avPacket_;
 
  public:
-  AutoFreedAVPacket();
-  ~AutoFreedAVPacket();
+  AutoAVPacket();
+  ~AutoAVPacket();
 };
 
-class AutoUnrefedAVPacket {
+class ReferenceAVPacket {
  private:
   AVPacket* avPacket_;
 
  public:
-  AutoUnrefedAVPacket(AutoFreedAVPacket& shared);
-  ~AutoUnrefedAVPacket();
+  ReferenceAVPacket(AutoAVPacket& shared);
+  ~ReferenceAVPacket();
   AVPacket* get();
   AVPacket* operator->();
 };

--- a/src/torchcodec/decoders/_core/VideoDecoder.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoder.cpp
@@ -573,9 +573,9 @@ void VideoDecoder::scanFileAndUpdateMetadataAndIndex() {
     return;
   }
 
-  AutoFreedAVPacket autoFreedAVPacket;
+  AutoAVPacket autoAVPacket;
   while (true) {
-    AutoUnrefedAVPacket packet(autoFreedAVPacket);
+    ReferenceAVPacket packet(autoAVPacket);
 
     // av_read_frame is a misleading name: it gets the next **packet**.
     int ffmpegStatus = av_read_frame(formatContext_.get(), packet.get());
@@ -806,7 +806,7 @@ VideoDecoder::RawDecodedOutput VideoDecoder::getDecodedOutputWithFilter(
   }
   // Need to get the next frame or error from PopFrame.
   UniqueAVFrame frame(av_frame_alloc());
-  AutoFreedAVPacket autoFreedAVPacket;
+  AutoAVPacket autoAVPacket;
   int ffmpegStatus = AVSUCCESS;
   bool reachedEOF = false;
   int frameStreamIndex = -1;
@@ -846,7 +846,7 @@ VideoDecoder::RawDecodedOutput VideoDecoder::getDecodedOutputWithFilter(
       // pulling frames from its internal buffers.
       continue;
     }
-    AutoUnrefedAVPacket packet(autoFreedAVPacket);
+    ReferenceAVPacket packet(autoAVPacket);
     ffmpegStatus = av_read_frame(formatContext_.get(), packet.get());
     decodeStats_.numPacketsRead++;
     if (ffmpegStatus == AVERROR_EOF) {

--- a/src/torchcodec/decoders/_core/VideoDecoder.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoder.cpp
@@ -546,8 +546,9 @@ void VideoDecoder::scanFileAndUpdateMetadataAndIndex() {
   if (scanned_all_streams_) {
     return;
   }
+
+  UniqueAVPacket packet(av_packet_alloc());
   while (true) {
-    UniqueAVPacket packet(av_packet_alloc());
     int ffmpegStatus = av_read_frame(formatContext_.get(), packet.get());
     if (ffmpegStatus == AVERROR_EOF) {
       break;
@@ -560,6 +561,7 @@ void VideoDecoder::scanFileAndUpdateMetadataAndIndex() {
     int streamIndex = packet->stream_index;
 
     if (packet->flags & AV_PKT_FLAG_DISCARD) {
+      av_packet_unref(packet.get());
       continue;
     }
     auto& streamMetadata = containerMetadata_.streams[streamIndex];
@@ -578,6 +580,7 @@ void VideoDecoder::scanFileAndUpdateMetadataAndIndex() {
       streams_[streamIndex].keyFrames.push_back(frameInfo);
     }
     streams_[streamIndex].allFrames.push_back(frameInfo);
+    av_packet_unref(packet.get());
   }
   for (size_t streamIndex = 0; streamIndex < containerMetadata_.streams.size();
        ++streamIndex) {

--- a/src/torchcodec/decoders/_core/VideoDecoder.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoder.cpp
@@ -573,9 +573,9 @@ void VideoDecoder::scanFileAndUpdateMetadataAndIndex() {
     return;
   }
 
-  AVPacketHandler avPacketHandler;
+  AutoFreedAVPacket autoFreedAVPacket;
   while (true) {
-    ReferencedAVPacket packet(avPacketHandler);
+    AutoUnrefedAVPacket packet(autoFreedAVPacket);
 
     // av_read_frame is a misleading name: it gets the next **packet**.
     int ffmpegStatus = av_read_frame(formatContext_.get(), packet.get());
@@ -806,7 +806,7 @@ VideoDecoder::RawDecodedOutput VideoDecoder::getDecodedOutputWithFilter(
   }
   // Need to get the next frame or error from PopFrame.
   UniqueAVFrame frame(av_frame_alloc());
-  AVPacketHandler avPacketHandler;
+  AutoFreedAVPacket autoFreedAVPacket;
   int ffmpegStatus = AVSUCCESS;
   bool reachedEOF = false;
   int frameStreamIndex = -1;
@@ -846,7 +846,7 @@ VideoDecoder::RawDecodedOutput VideoDecoder::getDecodedOutputWithFilter(
       // pulling frames from its internal buffers.
       continue;
     }
-    ReferencedAVPacket packet(avPacketHandler);
+    AutoUnrefedAVPacket packet(autoFreedAVPacket);
     ffmpegStatus = av_read_frame(formatContext_.get(), packet.get());
     decodeStats_.numPacketsRead++;
     if (ffmpegStatus == AVERROR_EOF) {


### PR DESCRIPTION
### What's in main


We allocate AVPacket objects in 2 places. In `scanFileAndUpdateMetadataAndIndex`:https://github.com/pytorch/torchcodec/blob/b1719e77a8b20022fd92bf24ac58b4dfac6d4e69/src/torchcodec/decoders/_core/VideoDecoder.cpp#L550

and in `getDecodedOutputWithFilter()`, the main decoding loop:

https://github.com/pytorch/torchcodec/blob/b1719e77a8b20022fd92bf24ac58b4dfac6d4e69/src/torchcodec/decoders/_core/VideoDecoder.cpp#L802

The `UniqueAVPacket` calls `av_packet_free` when it goes out of scope:

https://github.com/pytorch/torchcodec/blob/b1719e77a8b20022fd92bf24ac58b4dfac6d4e69/src/torchcodec/decoders/_core/FFMPEGCommon.h#L60-L61


In both cases, we allocate these objects *within* the decoding loop. That means that for each packet, we allocate a new `AVPacket` object.

### What's in other FFmpeg examples

 Now, [some resources](https://github.com/leandromoreira/ffmpeg-libav-tutorial/blob/master/0_hello_world.c#L166) I've seen, including [FFmpeg's tutorials](https://ffmpeg.org/doxygen/7.0/demux_decode_8c-example.html), don't do that. They allocate one **single** `AVPacket` object outside of the loop, and call [`av_packet_unref()`](https://ffmpeg.org/doxygen/7.0/group__lavc__packet.html#ga63d5a489b419bd5d45cfd09091cbcbc2) manually. (Note that `av_packet_free`, which is what we call in `main`, [also calls](https://ffmpeg.org/doxygen/6.0/avpacket_8c_source.html#l00073) `av_packet_unref()`)


### What this PR does


This PR does what the other examples do: move the `AVPacket` allocation outside of the loop, and manually call `av_packet_unref()` when needed.

### Do we want this?

I don't know how I feel about this. Sure, this can save a fair amount `malloc` calls, but whether this is noticeable is to be benchmarked. Importantly, we now run the risk of forgetting to call `av_packet_unref()` when needed, and leaking memory.
Perhaps there's a smart C++ construct we can use to make sure `av_packet_unref()` is called when needed, while still calling `av_packet_alloc()` only once?