### PR TITLE
Remove outdated comment

### DIFF
--- a/src/torchcodec/decoders/_core/VideoDecoder.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoder.cpp
@@ -655,8 +655,6 @@ I    P     P    P    I    P    P    P    I    P    P    I    P    P    I    P
                           x              j         y
 
 (2) is more efficient than (1) if there is an I frame between x and y.
-
-We use av_index_search_timestamp to see if there is an I frame between x and y.
 */
 bool VideoDecoder::canWeAvoidSeekingForStream(
     const StreamInfo& streamInfo,


### PR DESCRIPTION
Remove the following comment:

> We use av_index_search_timestamp to see if there is an I frame between x and y.

This isn't strictly true: we first try our own index if it exists, and if not, fallback to `av_index_search_timestamp()`. This is fairly obvious from the code so I suggest to delete the comment rather than to edit it.