### PR TITLE
Rename `maybeDesiredPts_` into `desiredPts_`

### DIFF
--- a/src/torchcodec/decoders/_core/VideoDecoder.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoder.cpp
@@ -746,7 +746,7 @@ void VideoDecoder::maybeSeekToBeforeDesiredPts() {
   for (int streamIndex : activeStreamIndices_) {
     StreamInfo& streamInfo = streamInfos_[streamIndex];
     // clang-format off: clang format clashes
-    streamInfo.discardFramesBeforePts = secondsToClosestPts(*maybeDesiredPts_, streamInfo.timeBase);
+    streamInfo.discardFramesBeforePts = secondsToClosestPts(*desiredPts_, streamInfo.timeBase);
     // clang-format on
   }
 
@@ -756,7 +756,7 @@ void VideoDecoder::maybeSeekToBeforeDesiredPts() {
   bool mustSeek = false;
   for (int streamIndex : activeStreamIndices_) {
     StreamInfo& streamInfo = streamInfos_[streamIndex];
-    int64_t desiredPtsForStream = *maybeDesiredPts_ * streamInfo.timeBase.den;
+    int64_t desiredPtsForStream = *desiredPts_ * streamInfo.timeBase.den;
     if (!canWeAvoidSeekingForStream(
             streamInfo, streamInfo.currentPts, desiredPtsForStream)) {
       mustSeek = true;
@@ -770,7 +770,7 @@ void VideoDecoder::maybeSeekToBeforeDesiredPts() {
   int firstActiveStreamIndex = *activeStreamIndices_.begin();
   const auto& firstStreamInfo = streamInfos_[firstActiveStreamIndex];
   int64_t desiredPts =
-      secondsToClosestPts(*maybeDesiredPts_, firstStreamInfo.timeBase);
+      secondsToClosestPts(*desiredPts_, firstStreamInfo.timeBase);
 
   // For some encodings like H265, FFMPEG sometimes seeks past the point we
   // set as the max_ts. So we use our own index to give it the exact pts of
@@ -809,9 +809,9 @@ VideoDecoder::RawDecodedOutput VideoDecoder::getDecodedOutputWithFilter(
     throw std::runtime_error("No active streams configured.");
   }
   resetDecodeStats();
-  if (maybeDesiredPts_.has_value()) {
+  if (desiredPts_.has_value()) {
     maybeSeekToBeforeDesiredPts();
-    maybeDesiredPts_ = std::nullopt;
+    desiredPts_ = std::nullopt;
   }
   // Need to get the next frame or error from PopFrame.
   UniqueAVFrame avFrame(av_frame_alloc());
@@ -1487,7 +1487,7 @@ VideoDecoder::DecodedOutput VideoDecoder::getNextFrameNoDemuxInternal(
 }
 
 void VideoDecoder::setCursorPtsInSeconds(double seconds) {
-  maybeDesiredPts_ = seconds;
+  desiredPts_ = seconds;
 }
 
 VideoDecoder::DecodeStats VideoDecoder::getDecodeStats() const {

--- a/src/torchcodec/decoders/_core/VideoDecoder.h
+++ b/src/torchcodec/decoders/_core/VideoDecoder.h
@@ -420,7 +420,7 @@ class VideoDecoder {
   std::set<int> activeStreamIndices_;
   // Set when the user wants to seek and stores the desired pts that the user
   // wants to seek to.
-  std::optional<double> maybeDesiredPts_;
+  std::optional<double> desiredPts_;
 
   // Stores various internal decoding stats.
   DecodeStats decodeStats_;


### PR DESCRIPTION
I might be missing something, but I'm not sure why there is a `maybe` prefix. This field **is** the desired Pts we want to seek to. It's not conditional on anything.

The `maybe` prefix seems to be related to the logic of `maybeSeekToBeforeDesiredPts()`: it makes sense there, since we have a heuristic to decide whether or not we'll call `avformat_seek_file()`. We may or may not seek, hence the `maybe`.

But, regardless of whether a seek was done, we *will* end up at `maybeDesiredPts`. So, to me, this should simply be `desiredPts_`.