### PR TITLE
Align high-level decoding entry points names with Python

### DIFF
--- a/src/torchcodec/decoders/_core/VideoDecoder.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoder.cpp
@@ -1064,7 +1064,7 @@ void VideoDecoder::convertAVFrameToDecodedOutputOnCPU(
   }
 }
 
-VideoDecoder::DecodedOutput VideoDecoder::getFramePlayedAtTimestampNoDemux(
+VideoDecoder::DecodedOutput VideoDecoder::getFramePlayedAtNoDemux(
     double seconds) {
   for (auto& [streamIndex, streamInfo] : streamInfos_) {
     double frameStartTime =
@@ -1314,7 +1314,7 @@ VideoDecoder::BatchDecodedOutput VideoDecoder::getFramesAtIndices(
   return output;
 }
 
-VideoDecoder::BatchDecodedOutput VideoDecoder::getFramesPlayedByTimestamps(
+VideoDecoder::BatchDecodedOutput VideoDecoder::getFramesPlayedAt(
     int streamIndex,
     const std::vector<double>& timestamps) {
   validateUserProvidedStreamIndex(streamIndex);
@@ -1382,8 +1382,7 @@ VideoDecoder::BatchDecodedOutput VideoDecoder::getFramesInRange(
   return output;
 }
 
-VideoDecoder::BatchDecodedOutput
-VideoDecoder::getFramesPlayedByTimestampInRange(
+VideoDecoder::BatchDecodedOutput VideoDecoder::getFramesPlayedInRange(
     int streamIndex,
     double startSeconds,
     double stopSeconds) {

--- a/src/torchcodec/decoders/_core/VideoDecoder.h
+++ b/src/torchcodec/decoders/_core/VideoDecoder.h
@@ -208,7 +208,7 @@ class VideoDecoder {
   // duration of 1.0s, it will be visible in the timestamp range [5.0, 6.0).
   // i.e. it will be returned when this function is called with seconds=5.0 or
   // seconds=5.999, etc.
-  DecodedOutput getFramePlayedAtTimestampNoDemux(double seconds);
+  DecodedOutput getFramePlayedAtNoDemux(double seconds);
 
   DecodedOutput getFrameAtIndex(int streamIndex, int64_t frameIndex);
   // This is morally private but needs to be exposed for C++ tests. Once
@@ -236,7 +236,7 @@ class VideoDecoder {
       int streamIndex,
       const std::vector<int64_t>& frameIndices);
 
-  BatchDecodedOutput getFramesPlayedByTimestamps(
+  BatchDecodedOutput getFramesPlayedAt(
       int streamIndex,
       const std::vector<double>& timestamps);
 
@@ -265,7 +265,7 @@ class VideoDecoder {
   // Valid values for startSeconds and stopSeconds are:
   //
   //   [minPtsSecondsFromScan, maxPtsSecondsFromScan)
-  BatchDecodedOutput getFramesPlayedByTimestampInRange(
+  BatchDecodedOutput getFramesPlayedInRange(
       int streamIndex,
       double startSeconds,
       double stopSeconds);

--- a/src/torchcodec/decoders/_core/VideoDecoderOps.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoderOps.cpp
@@ -245,7 +245,7 @@ OpsDecodedOutput get_next_frame(at::Tensor& decoder) {
 
 OpsDecodedOutput get_frame_at_pts(at::Tensor& decoder, double seconds) {
   auto videoDecoder = unwrapTensorToGetDecoder(decoder);
-  auto result = videoDecoder->getFramePlayedAtTimestampNoDemux(seconds);
+  auto result = videoDecoder->getFramePlayedAtNoDemux(seconds);
   return makeOpsDecodedOutput(result);
 }
 
@@ -287,8 +287,7 @@ OpsBatchDecodedOutput get_frames_by_pts(
     at::ArrayRef<double> timestamps) {
   auto videoDecoder = unwrapTensorToGetDecoder(decoder);
   std::vector<double> timestampsVec(timestamps.begin(), timestamps.end());
-  auto result =
-      videoDecoder->getFramesPlayedByTimestamps(stream_index, timestampsVec);
+  auto result = videoDecoder->getFramesPlayedAt(stream_index, timestampsVec);
   return makeOpsBatchDecodedOutput(result);
 }
 
@@ -298,7 +297,7 @@ OpsBatchDecodedOutput get_frames_by_pts_in_range(
     double start_seconds,
     double stop_seconds) {
   auto videoDecoder = unwrapTensorToGetDecoder(decoder);
-  auto result = videoDecoder->getFramesPlayedByTimestampInRange(
+  auto result = videoDecoder->getFramesPlayedInRange(
       stream_index, start_seconds, stop_seconds);
   return makeOpsBatchDecodedOutput(result);
 }

--- a/test/decoders/VideoDecoderTest.cpp
+++ b/test/decoders/VideoDecoderTest.cpp
@@ -267,18 +267,18 @@ TEST_P(VideoDecoderTest, GetsFramePlayedAtTimestamp) {
   std::unique_ptr<VideoDecoder> ourDecoder =
       createDecoderFromPath(path, GetParam());
   ourDecoder->addVideoStreamDecoder(-1);
-  auto output = ourDecoder->getFramePlayedAtTimestampNoDemux(6.006);
+  auto output = ourDecoder->getFramePlayedAtNoDemux(6.006);
   EXPECT_EQ(output.ptsSeconds, 6.006);
   // The frame's duration is 0.033367 according to ffprobe,
   // so the next frame is played at timestamp=6.039367.
   const double kNextFramePts = 6.039366666666667;
   // The frame that is played a microsecond before the next frame is still
   // the previous frame.
-  output = ourDecoder->getFramePlayedAtTimestampNoDemux(kNextFramePts - 1e-6);
+  output = ourDecoder->getFramePlayedAtNoDemux(kNextFramePts - 1e-6);
   EXPECT_EQ(output.ptsSeconds, 6.006);
   // The frame that is played at the exact pts of the frame is the next
   // frame.
-  output = ourDecoder->getFramePlayedAtTimestampNoDemux(kNextFramePts);
+  output = ourDecoder->getFramePlayedAtNoDemux(kNextFramePts);
   EXPECT_EQ(output.ptsSeconds, kNextFramePts);
 
   // This is the timestamp of the last frame in this video.
@@ -288,8 +288,8 @@ TEST_P(VideoDecoderTest, GetsFramePlayedAtTimestamp) {
       kPtsOfLastFrameInVideoStream + kDurationOfLastFrameInVideoStream;
   // Sanity check: make sure duration is strictly positive.
   EXPECT_GT(kPtsPlusDurationOfLastFrame, kPtsOfLastFrameInVideoStream);
-  output = ourDecoder->getFramePlayedAtTimestampNoDemux(
-      kPtsPlusDurationOfLastFrame - 1e-6);
+  output =
+      ourDecoder->getFramePlayedAtNoDemux(kPtsPlusDurationOfLastFrame - 1e-6);
   EXPECT_EQ(output.ptsSeconds, kPtsOfLastFrameInVideoStream);
 }
 


### PR DESCRIPTION
This PR aligns the C++ names of the high-level decoding entrypoints with those of the Python API.