### PR TITLE
Explicitly disallow copying packet management objects

### DIFF
--- a/src/torchcodec/decoders/_core/FFMPEGCommon.h
+++ b/src/torchcodec/decoders/_core/FFMPEGCommon.h
@@ -92,6 +92,8 @@ class AutoAVPacket {
 
  public:
   AutoAVPacket();
+  AutoAVPacket(const AutoAVPacket& other) = delete;
+  AutoAVPacket& operator=(const AutoAVPacket& other) = delete;
   ~AutoAVPacket();
 };
 
@@ -100,7 +102,9 @@ class ReferenceAVPacket {
   AVPacket* avPacket_;
 
  public:
-  ReferenceAVPacket(AutoAVPacket& shared);
+  explicit ReferenceAVPacket(AutoAVPacket& shared);
+  ReferenceAVPacket(const ReferenceAVPacket& other) = delete;
+  ReferenceAVPacket& operator=(const ReferenceAVPacket& other) = delete;
   ~ReferenceAVPacket();
   AVPacket* get();
   AVPacket* operator->();


### PR DESCRIPTION
Clang tidy caught this internally:

1. Single-argument constructors should be tagged with [`explicit`](https://en.cppreference.com/w/cpp/language/explicit) unless we want them to be a part of auto-conversions. We rarely do.
2. We should follow [the rule of three](https://en.cppreference.com/w/cpp/language/rule_of_three): classes that define a destructor should also define a copy constructor and copy assignment operator. In our case, we actually want to disallow copying these objects. We could actually allow them to be moved, but I don't think we'll need that. If it ever comes up, we'll know because the compiler will complain.

As an aside, I couldn't find a well-supported way to run clang-tidy with pre-commit. :/