### PR TITLE
Reorganize public APIs in `videoDecoder.h`

### DIFF
--- a/src/torchcodec/decoders/_core/VideoDecoder.h
+++ b/src/torchcodec/decoders/_core/VideoDecoder.h
@@ -29,6 +29,9 @@ class VideoDecoder {
 
   enum class SeekMode { exact, approximate };
 
+  explicit VideoDecoder(const std::string& videoFilePath, SeekMode seekMode);
+  explicit VideoDecoder(const void* buffer, size_t length, SeekMode seekMode);
+
   // Creates a VideoDecoder from the video at videoFilePath.
   static std::unique_ptr<VideoDecoder> createFromFilePath(
       const std::string& videoFilePath,
@@ -278,8 +281,6 @@ class VideoDecoder {
   void resetDecodeStats();
 
  private:
-  explicit VideoDecoder(const std::string& videoFilePath, SeekMode seekMode);
-  explicit VideoDecoder(const void* buffer, size_t length, SeekMode seekMode);
   torch::Tensor maybePermuteHWC2CHW(int streamIndex, torch::Tensor& hwcTensor);
 
   struct FrameInfo {


### PR DESCRIPTION
This PR re-organizes the public-facing part of  `videoDecoder.h`. Some APIs were grouped together when it didn't really make sense anymore. I also deleted outdated comments (or at risk of being outdated), and expanded on some.

Notably, this PR makes the constructor private. I think it makes sense since the decoder cannot be used without calling `initializeDecoder()`, which is already private.