### PR TITLE
Rename FilterState into FilterGraphContext

### DIFF
--- a/src/torchcodec/decoders/_core/VideoDecoder.h
+++ b/src/torchcodec/decoders/_core/VideoDecoder.h
@@ -289,7 +289,7 @@ class VideoDecoder {
     int64_t nextPts = INT64_MAX;
   };
 
-  struct FilterState {
+  struct FilterGraphContext {
     UniqueAVFilterGraph filterGraph;
     AVFilterContext* sourceContext = nullptr;
     AVFilterContext* sinkContext = nullptr;
@@ -321,7 +321,7 @@ class VideoDecoder {
     VideoStreamOptions videoStreamOptions;
     // The filter state associated with this stream (for video streams). The
     // actual graph will be nullptr for inactive streams.
-    FilterState filterState;
+    FilterGraphContext filterGraphContext;
     ColorConversionLibrary colorConversionLibrary = FILTERGRAPH;
     std::vector<FrameInfo> keyFrames;
     std::vector<FrameInfo> allFrames;


### PR DESCRIPTION
Needs https://github.com/pytorch/torchcodec/pull/477 first.


This PR renames `FilterState` into `FilterGraphContext` so as to align it with swsContext and to avoid ambiguity with other functions that also take in a "filter", like  `getAVFrameUsingFilterFunction`