### PR TITLE
Reorganize private APIs in videoDecoder.h

### DIFF
--- a/src/torchcodec/decoders/_core/VideoDecoder.h
+++ b/src/torchcodec/decoders/_core/VideoDecoder.h
@@ -289,7 +289,7 @@ class VideoDecoder {
     int64_t nextPts = INT64_MAX;
   };
 
-  struct FilterState {
+  struct FilterGraphContext {
     UniqueAVFilterGraph filterGraph;
     AVFilterContext* sourceContext = nullptr;
     AVFilterContext* sinkContext = nullptr;
@@ -321,7 +321,7 @@ class VideoDecoder {
     VideoStreamOptions videoStreamOptions;
     // The filter state associated with this stream (for video streams). The
     // actual graph will be nullptr for inactive streams.
-    FilterState filterState;
+    FilterGraphContext filterGraphContext;
     ColorConversionLibrary colorConversionLibrary = FILTERGRAPH;
     std::vector<FrameInfo> keyFrames;
     std::vector<FrameInfo> allFrames;


### PR DESCRIPTION
Needs https://github.com/pytorch/torchcodec/pull/478 first.

Same intent as https://github.com/pytorch/torchcodec/pull/477, but for private parts this time.