### PR TITLE
Disable FFmpeg5 for CUDA tests

### DIFF
--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -67,7 +67,8 @@ jobs:
           # include more python versions.
         python-version: ['3.9']
         cuda-version: ['11.8', '12.4', '12.6']
-        ffmpeg-version-for-tests: ['5', '6', '7']
+        # TODO: put back ffmpeg 5 https://github.com/pytorch/torchcodec/issues/325
+        ffmpeg-version-for-tests: ['6', '7']
     container:
       image: "pytorch/manylinux2_28-builder:cuda${{ matrix.cuda-version }}"
       options: "--gpus all -e NVIDIA_DRIVER_CAPABILITIES=video,compute,utility"


### PR DESCRIPTION
CI has been red for ~3 months due to our CUDA jobs failing with a weird dependency issue with FFmpeg 5, as tracked in https://github.com/pytorch/torchcodec/issues/325.

We haven't fixed it yet, and we even pushed some releases since then, so it's probably time to admit defeat and disable the job.