### PR TITLE
Remove createFrom functions in C++

### DIFF
--- a/src/torchcodec/decoders/_core/VideoDecoder.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoder.cpp
@@ -318,21 +318,6 @@ void VideoDecoder::initializeDecoder() {
   initialized_ = true;
 }
 
-std::unique_ptr<VideoDecoder> VideoDecoder::createFromFilePath(
-    const std::string& videoFilePath,
-    SeekMode seekMode) {
-  return std::unique_ptr<VideoDecoder>(
-      new VideoDecoder(videoFilePath, seekMode));
-}
-
-std::unique_ptr<VideoDecoder> VideoDecoder::createFromBuffer(
-    const void* buffer,
-    size_t length,
-    SeekMode seekMode) {
-  return std::unique_ptr<VideoDecoder>(
-      new VideoDecoder(buffer, length, seekMode));
-}
-
 void VideoDecoder::createFilterGraph(
     StreamInfo& streamInfo,
     int expectedOutputHeight,

--- a/src/torchcodec/decoders/_core/VideoDecoder.h
+++ b/src/torchcodec/decoders/_core/VideoDecoder.h
@@ -29,17 +29,14 @@ class VideoDecoder {
 
   enum class SeekMode { exact, approximate };
 
-  explicit VideoDecoder(const std::string& videoFilePath, SeekMode seekMode);
-  explicit VideoDecoder(const void* buffer, size_t length, SeekMode seekMode);
-
   // Creates a VideoDecoder from the video at videoFilePath.
-  static std::unique_ptr<VideoDecoder> createFromFilePath(
+  explicit VideoDecoder(
       const std::string& videoFilePath,
       SeekMode seekMode = SeekMode::exact);
 
   // Creates a VideoDecoder from a given buffer. Note that the buffer is not
   // owned by the VideoDecoder.
-  static std::unique_ptr<VideoDecoder> createFromBuffer(
+  explicit VideoDecoder(
       const void* buffer,
       size_t length,
       SeekMode seekMode = SeekMode::exact);

--- a/src/torchcodec/decoders/_core/VideoDecoderOps.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoderOps.cpp
@@ -117,7 +117,7 @@ at::Tensor create_from_file(
   }
 
   std::unique_ptr<VideoDecoder> uniqueDecoder =
-      VideoDecoder::createFromFilePath(filenameStr, realSeek);
+      std::make_unique<VideoDecoder>(filenameStr, realSeek);
 
   return wrapDecoderPointerToTensor(std::move(uniqueDecoder));
 }
@@ -134,9 +134,9 @@ at::Tensor create_from_tensor(
     realSeek = seekModeFromString(seek_mode.value());
   }
 
-  std::unique_ptr<VideoDecoder> videoDecoder =
-      VideoDecoder::createFromBuffer(buffer, length, realSeek);
-  return wrapDecoderPointerToTensor(std::move(videoDecoder));
+  std::unique_ptr<VideoDecoder> uniqueDecoder =
+      std::make_unique<VideoDecoder>(buffer, length, realSeek);
+  return wrapDecoderPointerToTensor(std::move(uniqueDecoder));
 }
 
 at::Tensor create_from_buffer(
@@ -149,7 +149,7 @@ at::Tensor create_from_buffer(
   }
 
   std::unique_ptr<VideoDecoder> uniqueDecoder =
-      VideoDecoder::createFromBuffer(buffer, length, realSeek);
+      std::make_unique<VideoDecoder>(buffer, length, realSeek);
   return wrapDecoderPointerToTensor(std::move(uniqueDecoder));
 }
 

--- a/test/decoders/VideoDecoderTest.cpp
+++ b/test/decoders/VideoDecoderTest.cpp
@@ -50,10 +50,10 @@ class VideoDecoderTest : public testing::TestWithParam<bool> {
       content_ = outputStringStream.str();
       void* buffer = content_.data();
       size_t length = outputStringStream.str().length();
-      return VideoDecoder::createFromBuffer(
+      return std::make_unique<VideoDecoder>(
           buffer, length, VideoDecoder::SeekMode::approximate);
     } else {
-      return VideoDecoder::createFromFilePath(
+      return std::make_unique<VideoDecoder>(
           filepath, VideoDecoder::SeekMode::approximate);
     }
   }
@@ -94,8 +94,7 @@ TEST_P(VideoDecoderTest, ReturnsFpsAndDurationForVideoInMetadata) {
 
 TEST(VideoDecoderTest, MissingVideoFileThrowsException) {
   EXPECT_THROW(
-      VideoDecoder::createFromFilePath("/this/file/does/not/exist"),
-      std::invalid_argument);
+      VideoDecoder("/this/file/does/not/exist"), std::invalid_argument);
 }
 
 void dumpTensorToDisk(
@@ -145,8 +144,7 @@ double computeAverageCosineSimilarity(
 
 TEST(VideoDecoderTest, RespectsWidthAndHeightFromOptions) {
   std::string path = getResourcePath("nasa_13013.mp4");
-  std::unique_ptr<VideoDecoder> decoder =
-      VideoDecoder::createFromFilePath(path);
+  std::unique_ptr<VideoDecoder> decoder = std::make_unique<VideoDecoder>(path);
   VideoDecoder::VideoStreamOptions videoStreamOptions;
   videoStreamOptions.width = 100;
   videoStreamOptions.height = 120;
@@ -157,8 +155,7 @@ TEST(VideoDecoderTest, RespectsWidthAndHeightFromOptions) {
 
 TEST(VideoDecoderTest, RespectsOutputTensorDimensionOrderFromOptions) {
   std::string path = getResourcePath("nasa_13013.mp4");
-  std::unique_ptr<VideoDecoder> decoder =
-      VideoDecoder::createFromFilePath(path);
+  std::unique_ptr<VideoDecoder> decoder = std::make_unique<VideoDecoder>(path);
   VideoDecoder::VideoStreamOptions videoStreamOptions;
   videoStreamOptions.dimensionOrder = "NHWC";
   decoder->addVideoStreamDecoder(-1, videoStreamOptions);


### PR DESCRIPTION
Completes the refactoring started in #434.

The `createFrom()` functions don't add any values, because the [`std::make_unique`](https://en.cppreference.com/w/cpp/memory/unique_ptr/make_unique) function already does a similar thing.