### PR TITLE
Remove `getKeyFrameIndexForPtsUsingEncoderIndex`

### DIFF
--- a/src/torchcodec/decoders/_core/VideoDecoder.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoder.cpp
@@ -553,14 +553,6 @@ VideoDecoder::ContainerMetadata VideoDecoder::getContainerMetadata() const {
   return containerMetadata_;
 }
 
-int VideoDecoder::getKeyFrameIndexForPtsUsingEncoderIndex(
-    AVStream* stream,
-    int64_t pts) const {
-  int currentKeyFrameIndex =
-      av_index_search_timestamp(stream, pts, AVSEEK_FLAG_BACKWARD);
-  return currentKeyFrameIndex;
-}
-
 int VideoDecoder::getKeyFrameIndexForPtsUsingScannedIndex(
     const std::vector<VideoDecoder::FrameInfo>& keyFrames,
     int64_t pts) const {
@@ -683,9 +675,11 @@ int VideoDecoder::getKeyFrameIndexForPts(
     const StreamInfo& streamInfo,
     int64_t pts) const {
   if (streamInfo.keyFrames.empty()) {
-    return getKeyFrameIndexForPtsUsingEncoderIndex(streamInfo.stream, pts);
+    return av_index_search_timestamp(
+        streamInfo.stream, pts, AVSEEK_FLAG_BACKWARD);
+  } else {
+    return getKeyFrameIndexForPtsUsingScannedIndex(streamInfo.keyFrames, pts);
   }
-  return getKeyFrameIndexForPtsUsingScannedIndex(streamInfo.keyFrames, pts);
 }
 
 /*

--- a/src/torchcodec/decoders/_core/VideoDecoder.h
+++ b/src/torchcodec/decoders/_core/VideoDecoder.h
@@ -416,9 +416,6 @@ class VideoDecoder {
   int getKeyFrameIndexForPtsUsingScannedIndex(
       const std::vector<VideoDecoder::FrameInfo>& keyFrames,
       int64_t pts) const;
-  // Return key frame index, from FFmpeg. Potentially less accurate
-  int getKeyFrameIndexForPtsUsingEncoderIndex(AVStream* stream, int64_t pts)
-      const;
 
   int64_t secondsToIndexLowerBound(
       double seconds,


### PR DESCRIPTION
Originally I meant to make `getKeyFrameIndexForPtsUsingEncoderIndex()` a function instead of a method, because it's not relying on any attribute of the decoder class. But since it's only used in one single place anyway, I decided to inline it and remove it completely.