### PR TITLE
Avoid unnecessary calls to `avcodec_receive_frame` in decoding loop

### DIFF
--- a/src/torchcodec/decoders/_core/VideoDecoder.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoder.cpp
@@ -951,9 +951,6 @@ VideoDecoder::AVFrameStream VideoDecoder::decodeAVFrame(
   outerLoopStart:
     ffmpegStatus =
         avcodec_receive_frame(streamInfo.codecContext.get(), avFrame.get());
-    if (ffmpegStatus == AVERROR(EAGAIN)) {
-      printf("Yes\n");
-    }
 
     if (ffmpegStatus != AVSUCCESS && ffmpegStatus != AVERROR(EAGAIN)) {
       // Non-retriable error


### PR DESCRIPTION
This PR improves our main decoding loop which, in `main`, is calling `avcodec_receive_frame` tons and tons of time when it doesn't need to.

This PR saves `643` calls on the short `nasa_13013.mp4` (1034 in main, 391 now).


See comments below it's easier to explain with the code.