### PR TITLE
Remove streamIndex  parameter and multi-stream related logic

### DIFF
--- a/src/torchcodec/decoders/_core/VideoDecoder.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoder.cpp
@@ -845,9 +845,8 @@ I    P     P    P    I    P    P    P    I    P    P    I    P    P    I    P
 
 (2) is more efficient than (1) if there is an I frame between x and y.
 */
-bool VideoDecoder::canWeAvoidSeekingForStream(
-    int64_t currentPts,
-    int64_t targetPts) {
+bool VideoDecoder::canWeAvoidSeeking(int64_t currentPts, int64_t targetPts)
+    const {
   if (targetPts < currentPts) {
     // We can never skip a seek if we are seeking backwards.
     return false;
@@ -880,7 +879,7 @@ void VideoDecoder::maybeSeekToBeforeDesiredPts() {
   decodeStats_.numSeeksAttempted++;
 
   int64_t desiredPtsForStream = *desiredPtsSeconds_ * streamInfo.timeBase.den;
-  if (canWeAvoidSeekingForStream(streamInfo.currentPts, desiredPtsForStream)) {
+  if (canWeAvoidSeeking(streamInfo.currentPts, desiredPtsForStream)) {
     decodeStats_.numSeeksSkipped++;
     return;
   }
@@ -1472,8 +1471,8 @@ void VideoDecoder::createSwsContext(
 // PTS <-> INDEX CONVERSIONS
 // --------------------------------------------------------------------------
 
-int VideoDecoder::getKeyFrameIndexForPts(int64_t pts) {
-  const StreamInfo& streamInfo = streamInfos_[activeStreamIndex_];
+int VideoDecoder::getKeyFrameIndexForPts(int64_t pts) const {
+  const StreamInfo& streamInfo = streamInfos_.at(activeStreamIndex_);
   if (streamInfo.keyFrames.empty()) {
     return av_index_search_timestamp(
         streamInfo.stream, pts, AVSEEK_FLAG_BACKWARD);
@@ -1484,7 +1483,7 @@ int VideoDecoder::getKeyFrameIndexForPts(int64_t pts) {
 
 int VideoDecoder::getKeyFrameIndexForPtsUsingScannedIndex(
     const std::vector<VideoDecoder::FrameInfo>& keyFrames,
-    int64_t pts) {
+    int64_t pts) const {
   auto upperBound = std::upper_bound(
       keyFrames.begin(),
       keyFrames.end(),

--- a/src/torchcodec/decoders/_core/VideoDecoder.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoder.cpp
@@ -658,20 +658,16 @@ VideoDecoder::getFramesInRange(int64_t start, int64_t stop, int64_t step) {
   return frameBatchOutput;
 }
 
-VideoDecoder::FrameOutput VideoDecoder::getFramePlayedAt(
-    double seconds) {
-  for (auto& [streamIndex, streamInfo] : streamInfos_) {
-    double frameStartTime =
-        ptsToSeconds(streamInfo.currentPts, streamInfo.timeBase);
-    double frameEndTime = ptsToSeconds(
-        streamInfo.currentPts + streamInfo.currentDuration,
-        streamInfo.timeBase);
-    if (seconds >= frameStartTime && seconds < frameEndTime) {
-      // We are in the same frame as the one we just returned. However, since we
-      // don't cache it locally, we have to rewind back.
-      seconds = frameStartTime;
-      break;
-    }
+VideoDecoder::FrameOutput VideoDecoder::getFramePlayedAt(double seconds) {
+  StreamInfo& streamInfo = streamInfos_[activeStreamIndex_];
+  double frameStartTime =
+      ptsToSeconds(streamInfo.currentPts, streamInfo.timeBase);
+  double frameEndTime = ptsToSeconds(
+      streamInfo.currentPts + streamInfo.currentDuration, streamInfo.timeBase);
+  if (seconds >= frameStartTime && seconds < frameEndTime) {
+    // We are in the same frame as the one we just returned. However, since we
+    // don't cache it locally, we have to rewind back.
+    seconds = frameStartTime;
   }
 
   setCursorPtsInSeconds(seconds);

--- a/src/torchcodec/decoders/_core/VideoDecoder.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoder.cpp
@@ -531,13 +531,13 @@ void VideoDecoder::addVideoStreamDecoder(
 // HIGH-LEVEL DECODING ENTRY-POINTS
 // --------------------------------------------------------------------------
 
-VideoDecoder::FrameOutput VideoDecoder::getNextFrameNoDemux() {
-  auto output = getNextFrameNoDemuxInternal();
+VideoDecoder::FrameOutput VideoDecoder::getNextFrame() {
+  auto output = getNextFrameInternal();
   output.data = maybePermuteHWC2CHW(output.data);
   return output;
 }
 
-VideoDecoder::FrameOutput VideoDecoder::getNextFrameNoDemuxInternal(
+VideoDecoder::FrameOutput VideoDecoder::getNextFrameInternal(
     std::optional<torch::Tensor> preAllocatedOutputTensor) {
   AVFrameStream avFrameStream = decodeAVFrame([this](AVFrame* avFrame) {
     StreamInfo& activeStreamInfo = streamInfos_[activeStreamIndex_];
@@ -564,7 +564,7 @@ VideoDecoder::FrameOutput VideoDecoder::getFrameAtIndexInternal(
 
   int64_t pts = getPts(streamInfo, streamMetadata, frameIndex);
   setCursorPtsInSeconds(ptsToSeconds(pts, streamInfo.timeBase));
-  return getNextFrameNoDemuxInternal(preAllocatedOutputTensor);
+  return getNextFrameInternal(preAllocatedOutputTensor);
 }
 
 VideoDecoder::FrameBatchOutput VideoDecoder::getFramesAtIndices(
@@ -658,7 +658,7 @@ VideoDecoder::getFramesInRange(int64_t start, int64_t stop, int64_t step) {
   return frameBatchOutput;
 }
 
-VideoDecoder::FrameOutput VideoDecoder::getFramePlayedAtNoDemux(
+VideoDecoder::FrameOutput VideoDecoder::getFramePlayedAt(
     double seconds) {
   for (auto& [streamIndex, streamInfo] : streamInfos_) {
     double frameStartTime =

--- a/src/torchcodec/decoders/_core/VideoDecoder.h
+++ b/src/torchcodec/decoders/_core/VideoDecoder.h
@@ -171,13 +171,13 @@ class VideoDecoder {
   };
 
   // Places the cursor at the first frame on or after the position in seconds.
-  // Calling getNextFrameNoDemux() will return the first frame at
+  // Calling getNextFrame() will return the first frame at
   // or after this position.
   void setCursorPtsInSeconds(double seconds);
 
   // Decodes the frame where the current cursor position is. It also advances
   // the cursor to the next frame.
-  FrameOutput getNextFrameNoDemux();
+  FrameOutput getNextFrame();
 
   FrameOutput getFrameAtIndex(int64_t frameIndex);
 
@@ -196,7 +196,7 @@ class VideoDecoder {
   // duration of 1.0s, it will be visible in the timestamp range [5.0, 6.0).
   // i.e. it will be returned when this function is called with seconds=5.0 or
   // seconds=5.999, etc.
-  FrameOutput getFramePlayedAtNoDemux(double seconds);
+  FrameOutput getFramePlayedAt(double seconds);
 
   FrameBatchOutput getFramesPlayedAt(const std::vector<double>& timestamps);
 
@@ -367,7 +367,7 @@ class VideoDecoder {
 
   AVFrameStream decodeAVFrame(std::function<bool(AVFrame*)> filterFunction);
 
-  FrameOutput getNextFrameNoDemuxInternal(
+  FrameOutput getNextFrameInternal(
       std::optional<torch::Tensor> preAllocatedOutputTensor = std::nullopt);
 
   torch::Tensor maybePermuteHWC2CHW(torch::Tensor& hwcTensor);

--- a/src/torchcodec/decoders/_core/VideoDecoder.h
+++ b/src/torchcodec/decoders/_core/VideoDecoder.h
@@ -357,10 +357,6 @@ class VideoDecoder {
   // --------------------------------------------------------------------------
 
   void initializeDecoder();
-  void updateMetadataWithCodecContext(
-      int streamIndex,
-      AVCodecContext* codecContext);
-
   // --------------------------------------------------------------------------
   // DECODING APIS AND RELATED UTILS
   // --------------------------------------------------------------------------

--- a/src/torchcodec/decoders/_core/VideoDecoder.h
+++ b/src/torchcodec/decoders/_core/VideoDecoder.h
@@ -467,7 +467,7 @@ class VideoDecoder {
   // VALIDATION UTILS
   // --------------------------------------------------------------------------
 
-  void validateUserProvidedStreamIndex(int streamIndex);
+  void validateActiveStream();
   void validateScannedAllStreams(const std::string& msg);
   void validateFrameIndex(
       const StreamMetadata& streamMetadata,

--- a/src/torchcodec/decoders/_core/VideoDecoder.h
+++ b/src/torchcodec/decoders/_core/VideoDecoder.h
@@ -361,7 +361,7 @@ class VideoDecoder {
   // DECODING APIS AND RELATED UTILS
   // --------------------------------------------------------------------------
 
-  bool canWeAvoidSeekingForStream(int64_t currentPts, int64_t targetPts);
+  bool canWeAvoidSeeking(int64_t currentPts, int64_t targetPts) const;
 
   void maybeSeekToBeforeDesiredPts();
 
@@ -405,14 +405,14 @@ class VideoDecoder {
   // PTS <-> INDEX CONVERSIONS
   // --------------------------------------------------------------------------
 
-  int getKeyFrameIndexForPts(int64_t pts);
+  int getKeyFrameIndexForPts(int64_t pts) const;
 
   // Returns the key frame index of the presentation timestamp using our index.
   // We build this index by scanning the file in
   // scanFileAndUpdateMetadataAndIndex
   int getKeyFrameIndexForPtsUsingScannedIndex(
       const std::vector<VideoDecoder::FrameInfo>& keyFrames,
-      int64_t pts);
+      int64_t pts) const;
 
   int64_t secondsToIndexLowerBound(
       double seconds,

--- a/src/torchcodec/decoders/_core/VideoDecoderOps.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoderOps.cpp
@@ -253,54 +253,53 @@ OpsFrameOutput get_frame_at_pts(at::Tensor& decoder, double seconds) {
 
 OpsFrameOutput get_frame_at_index(
     at::Tensor& decoder,
-    int64_t stream_index,
+    [[maybe_unused]] int64_t stream_index,
     int64_t frame_index) {
   auto videoDecoder = unwrapTensorToGetDecoder(decoder);
-  auto result = videoDecoder->getFrameAtIndex(stream_index, frame_index);
+  auto result = videoDecoder->getFrameAtIndex(frame_index);
   return makeOpsFrameOutput(result);
 }
 
 OpsFrameBatchOutput get_frames_at_indices(
     at::Tensor& decoder,
-    int64_t stream_index,
+    [[maybe_unused]] int64_t stream_index,
     at::IntArrayRef frame_indices) {
   auto videoDecoder = unwrapTensorToGetDecoder(decoder);
   std::vector<int64_t> frameIndicesVec(
       frame_indices.begin(), frame_indices.end());
-  auto result = videoDecoder->getFramesAtIndices(stream_index, frameIndicesVec);
+  auto result = videoDecoder->getFramesAtIndices(frameIndicesVec);
   return makeOpsFrameBatchOutput(result);
 }
 
 OpsFrameBatchOutput get_frames_in_range(
     at::Tensor& decoder,
-    int64_t stream_index,
+    [[maybe_unused]] int64_t stream_index,
     int64_t start,
     int64_t stop,
     std::optional<int64_t> step) {
   auto videoDecoder = unwrapTensorToGetDecoder(decoder);
-  auto result = videoDecoder->getFramesInRange(
-      stream_index, start, stop, step.value_or(1));
+  auto result = videoDecoder->getFramesInRange(start, stop, step.value_or(1));
   return makeOpsFrameBatchOutput(result);
 }
 
 OpsFrameBatchOutput get_frames_by_pts(
     at::Tensor& decoder,
-    int64_t stream_index,
+    [[maybe_unused]] int64_t stream_index,
     at::ArrayRef<double> timestamps) {
   auto videoDecoder = unwrapTensorToGetDecoder(decoder);
   std::vector<double> timestampsVec(timestamps.begin(), timestamps.end());
-  auto result = videoDecoder->getFramesPlayedAt(stream_index, timestampsVec);
+  auto result = videoDecoder->getFramesPlayedAt(timestampsVec);
   return makeOpsFrameBatchOutput(result);
 }
 
 OpsFrameBatchOutput get_frames_by_pts_in_range(
     at::Tensor& decoder,
-    int64_t stream_index,
+    [[maybe_unused]] int64_t stream_index,
     double start_seconds,
     double stop_seconds) {
   auto videoDecoder = unwrapTensorToGetDecoder(decoder);
-  auto result = videoDecoder->getFramesPlayedInRange(
-      stream_index, start_seconds, stop_seconds);
+  auto result =
+      videoDecoder->getFramesPlayedInRange(start_seconds, stop_seconds);
   return makeOpsFrameBatchOutput(result);
 }
 
@@ -328,19 +327,19 @@ std::string mapToJson(const std::map<std::string, std::string>& metadataMap) {
 
 bool _test_frame_pts_equality(
     at::Tensor& decoder,
-    int64_t stream_index,
+    [[maybe_unused]] int64_t stream_index,
     int64_t frame_index,
     double pts_seconds_to_test) {
   auto videoDecoder = unwrapTensorToGetDecoder(decoder);
   return pts_seconds_to_test ==
-      videoDecoder->getPtsSecondsForFrame(stream_index, frame_index);
+      videoDecoder->getPtsSecondsForFrame(frame_index);
 }
 
 torch::Tensor _get_key_frame_indices(
     at::Tensor& decoder,
-    int64_t stream_index) {
+    [[maybe_unused]] int64_t stream_index) {
   auto videoDecoder = unwrapTensorToGetDecoder(decoder);
-  return videoDecoder->getKeyFrameIndices(stream_index);
+  return videoDecoder->getKeyFrameIndices();
 }
 
 std::string get_json_metadata(at::Tensor& decoder) {

--- a/src/torchcodec/decoders/_core/VideoDecoderOps.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoderOps.cpp
@@ -233,7 +233,7 @@ OpsFrameOutput get_next_frame(at::Tensor& decoder) {
   auto videoDecoder = unwrapTensorToGetDecoder(decoder);
   VideoDecoder::FrameOutput result;
   try {
-    result = videoDecoder->getNextFrameNoDemux();
+    result = videoDecoder->getNextFrame();
   } catch (const VideoDecoder::EndOfFileException& e) {
     C10_THROW_ERROR(IndexError, e.what());
   }
@@ -247,7 +247,7 @@ OpsFrameOutput get_next_frame(at::Tensor& decoder) {
 
 OpsFrameOutput get_frame_at_pts(at::Tensor& decoder, double seconds) {
   auto videoDecoder = unwrapTensorToGetDecoder(decoder);
-  auto result = videoDecoder->getFramePlayedAtNoDemux(seconds);
+  auto result = videoDecoder->getFramePlayedAt(seconds);
   return makeOpsFrameOutput(result);
 }
 

--- a/test/decoders/VideoDecoderTest.cpp
+++ b/test/decoders/VideoDecoderTest.cpp
@@ -285,8 +285,7 @@ TEST_P(VideoDecoderTest, GetsFramePlayedAtTimestamp) {
       kPtsOfLastFrameInVideoStream + kDurationOfLastFrameInVideoStream;
   // Sanity check: make sure duration is strictly positive.
   EXPECT_GT(kPtsPlusDurationOfLastFrame, kPtsOfLastFrameInVideoStream);
-  output =
-      ourDecoder->getFramePlayedAt(kPtsPlusDurationOfLastFrame - 1e-6);
+  output = ourDecoder->getFramePlayedAt(kPtsPlusDurationOfLastFrame - 1e-6);
   EXPECT_EQ(output.ptsSeconds, kPtsOfLastFrameInVideoStream);
 }
 

--- a/test/decoders/VideoDecoderTest.cpp
+++ b/test/decoders/VideoDecoderTest.cpp
@@ -208,7 +208,7 @@ TEST_P(VideoDecoderTest, DecodesFramesInABatchInNCHW) {
       *ourDecoder->getContainerMetadata().bestVideoStreamIndex;
   ourDecoder->addVideoStreamDecoder(bestVideoStreamIndex);
   // Frame with index 180 corresponds to timestamp 6.006.
-  auto output = ourDecoder->getFramesAtIndices(bestVideoStreamIndex, {0, 180});
+  auto output = ourDecoder->getFramesAtIndices({0, 180});
   auto tensor = output.data;
   EXPECT_EQ(tensor.sizes(), std::vector<long>({2, 3, 270, 480}));
 
@@ -232,7 +232,7 @@ TEST_P(VideoDecoderTest, DecodesFramesInABatchInNHWC) {
       bestVideoStreamIndex,
       VideoDecoder::VideoStreamOptions("dimension_order=NHWC"));
   // Frame with index 180 corresponds to timestamp 6.006.
-  auto output = ourDecoder->getFramesAtIndices(bestVideoStreamIndex, {0, 180});
+  auto output = ourDecoder->getFramesAtIndices({0, 180});
   auto tensor = output.data;
   EXPECT_EQ(tensor.sizes(), std::vector<long>({2, 270, 480, 3}));
 
@@ -397,8 +397,8 @@ TEST_P(VideoDecoderTest, PreAllocatedTensorFilterGraph) {
   ourDecoder->addVideoStreamDecoder(
       bestVideoStreamIndex,
       VideoDecoder::VideoStreamOptions("color_conversion_library=filtergraph"));
-  auto output = ourDecoder->getFrameAtIndexInternal(
-      bestVideoStreamIndex, 0, preAllocatedOutputTensor);
+  auto output =
+      ourDecoder->getFrameAtIndexInternal(0, preAllocatedOutputTensor);
   EXPECT_EQ(output.data.data_ptr(), preAllocatedOutputTensor.data_ptr());
 }
 
@@ -414,8 +414,8 @@ TEST_P(VideoDecoderTest, PreAllocatedTensorSwscale) {
   ourDecoder->addVideoStreamDecoder(
       bestVideoStreamIndex,
       VideoDecoder::VideoStreamOptions("color_conversion_library=swscale"));
-  auto output = ourDecoder->getFrameAtIndexInternal(
-      bestVideoStreamIndex, 0, preAllocatedOutputTensor);
+  auto output =
+      ourDecoder->getFrameAtIndexInternal(0, preAllocatedOutputTensor);
   EXPECT_EQ(output.data.data_ptr(), preAllocatedOutputTensor.data_ptr());
 }
 


### PR DESCRIPTION
Towards https://github.com/pytorch/torchcodec/issues/476. Our VideoDecoder is inherently single-stream and almost all `streamIndex` parameters aren't used, so this PR removes them. This also removes most but not all multi-stream related logic (there is some left in the scan for example).

I haven't updates the custom ops APIs nor the core APIs because this may create conflicts internally and I want to deal with that separately as a follow-up PR.

Other clean-ups we could do afterwards:

- Update Python core APIs and ops APIs to remove the stream_index parameter.
- Remove the AVFrameStream struct and just use AVFrame. We know the stream, we don't need to keep track of it.
- Remove the `StreamInfos_` vec and only keep a single `StreamInfo` for the active stream.
- Simplify the scan to ignore inactive streams (at the very least we don't need to set the StreamInfo_ for inactive streams).