### PR TITLE
Simplify more APIs

### DIFF
--- a/src/torchcodec/decoders/_core/VideoDecoder.h
+++ b/src/torchcodec/decoders/_core/VideoDecoder.h
@@ -416,15 +416,9 @@ class VideoDecoder {
 
   int64_t secondsToIndexLowerBound(double seconds);
 
-  int64_t secondsToIndexUpperBound(
-      double seconds,
-      const StreamInfo& streamInfo,
-      const StreamMetadata& streamMetadata);
+  int64_t secondsToIndexUpperBound(double seconds);
 
-  int64_t getPts(
-      const StreamInfo& streamInfo,
-      const StreamMetadata& streamMetadata,
-      int64_t frameIndex);
+  int64_t getPts(int64_t frameIndex);
 
   // --------------------------------------------------------------------------
   // STREAM AND METADATA APIS


### PR DESCRIPTION
We were passing `streamInfo` and `streamMetadata` to `secondsToIndexLowerBound`, `secondsToIndexUpperBound` and `getPts`, but there's no need: we only ever call those on the active stream.