### PR TITLE
Disable C++ tests on FFmpeg 6.1.1

### DIFF
--- a/.github/workflows/cpp_tests.yaml
+++ b/.github/workflows/cpp_tests.yaml
@@ -19,7 +19,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ffmpeg-version-for-tests: ['4.4.2', '5.1.2', '6.1.1', '7.0.1']
+        # TODO put back 6.1.1. See
+        # https://github.com/pytorch/torchcodec/issues/518
+        ffmpeg-version-for-tests: ['4.4.2', '5.1.2', '7.0.1']
     steps:
       - name: Check out repo
         uses: actions/checkout@v3


### PR DESCRIPTION
Opened https://github.com/pytorch/torchcodec/issues/518 to keep track of this, but these tests have been failing for a few weeks now with an infra-related problem.
Until we dedicate some time to fixing it, we should deactivate it to keep the CI green.