### PR TITLE
Properly launder EOF exception

### DIFF
--- a/src/torchcodec/decoders/_core/VideoDecoderOps.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoderOps.cpp
@@ -240,7 +240,12 @@ OpsFrameOutput get_next_frame(at::Tensor& decoder) {
 
 OpsFrameOutput get_frame_at_pts(at::Tensor& decoder, double seconds) {
   auto videoDecoder = unwrapTensorToGetDecoder(decoder);
-  auto result = videoDecoder->getFramePlayedAt(seconds);
+  VideoDecoder::FrameOutput result;
+  try {
+    result = videoDecoder->getFramePlayedAt(seconds);
+  } catch (const VideoDecoder::EndOfFileException& e) {
+    C10_THROW_ERROR(IndexError, e.what());
+  }
   return makeOpsFrameOutput(result);
 }
 

--- a/test/decoders/test_video_decoder.py
+++ b/test/decoders/test_video_decoder.py
@@ -351,6 +351,14 @@ class TestVideoDecoder:
         assert_frames_equal(ref_frame9, frame9.data)
 
     @pytest.mark.parametrize("device", cpu_and_cuda())
+    @pytest.mark.parametrize("seek_mode", ("exact", "approximate"))
+    def test_get_frame_at_fails(self, device, seek_mode):
+        decoder = VideoDecoder(NASA_VIDEO.path, device=device, seek_mode=seek_mode)
+
+        with pytest.raises(IndexError, match="out of bounds"):
+            decoder.get_frame_at(1000)  # noqa
+
+    @pytest.mark.parametrize("device", cpu_and_cuda())
     def test_get_frame_at_tuple_unpacking(self, device):
         decoder = VideoDecoder(NASA_VIDEO.path, device=device)
 

--- a/test/decoders/test_video_decoder.py
+++ b/test/decoders/test_video_decoder.py
@@ -351,14 +351,6 @@ class TestVideoDecoder:
         assert_frames_equal(ref_frame9, frame9.data)
 
     @pytest.mark.parametrize("device", cpu_and_cuda())
-    @pytest.mark.parametrize("seek_mode", ("exact", "approximate"))
-    def test_get_frame_at_fails(self, device, seek_mode):
-        decoder = VideoDecoder(NASA_VIDEO.path, device=device, seek_mode=seek_mode)
-
-        with pytest.raises(IndexError, match="out of bounds"):
-            decoder.get_frame_at(1000)  # noqa
-
-    @pytest.mark.parametrize("device", cpu_and_cuda())
     def test_get_frame_at_tuple_unpacking(self, device):
         decoder = VideoDecoder(NASA_VIDEO.path, device=device)
 

--- a/test/decoders/test_video_decoder_ops.py
+++ b/test/decoders/test_video_decoder_ops.py
@@ -309,7 +309,6 @@ class TestOps:
         decoder = create_from_file(str(NASA_VIDEO.path))
         add_video_stream(decoder, device=device)
 
-
         seek_to_pts(decoder, 12.979633)
         last_frame, _, _ = get_next_frame(decoder)
         reference_last_frame = NASA_VIDEO.get_frame_data_by_index(289)

--- a/test/decoders/test_video_decoder_ops.py
+++ b/test/decoders/test_video_decoder_ops.py
@@ -308,12 +308,17 @@ class TestOps:
     def test_throws_exception_at_eof(self, device):
         decoder = create_from_file(str(NASA_VIDEO.path))
         add_video_stream(decoder, device=device)
+
+
         seek_to_pts(decoder, 12.979633)
         last_frame, _, _ = get_next_frame(decoder)
         reference_last_frame = NASA_VIDEO.get_frame_data_by_index(289)
         assert_frames_equal(last_frame, reference_last_frame.to(device))
         with pytest.raises(IndexError, match="no more frames"):
             get_next_frame(decoder)
+
+        with pytest.raises(IndexError, match="no more frames"):
+            get_frame_at_pts(decoder, seconds=1000.0)
 
     @pytest.mark.parametrize("device", cpu_and_cuda())
     def test_throws_exception_if_seek_too_far(self, device):


### PR DESCRIPTION
In the C++ `VideoDecoder`, we throw a `EndOfFileException` if we hit the end of a stream while decoding. We need to launder that into a Python exception in the implementation of some of our core ops. We were already doing this for `core.get_next_frame()`, but not for `core.get_frame_at_pts()`.

Note that I don't think we need to do this for any of our other APIs because we end up checking the indices (even when we're passed a pts), and those become Python `RuntimeError` exceptions. That is, for all of the other core ops, I believe we should never hit the EOF exception because we're already preventing that from our other checks. There is a case to be made that we should just be super paranoid and do it anyway, which I'm open to doing.