### PR TITLE
Update docs to indicate we handle URLs.

### DIFF
--- a/src/torchcodec/decoders/_video_decoder.py
+++ b/src/torchcodec/decoders/_video_decoder.py
@@ -26,7 +26,8 @@ class VideoDecoder:
     Args:
         source (str, ``Pathlib.path``, ``torch.Tensor``, or bytes): The source of the video.
 
-            - If ``str`` or ``Pathlib.path``: a path to a local video file.
+            - If ``str``: a local path or a URL to a video file.
+            - If ``Pathlib.path``: a path to a local video file.
             - If ``bytes`` object or ``torch.Tensor``: the raw encoded video data.
         stream_index (int, optional): Specifies which stream in the video to decode frames from.
             Note that this index is absolute across all media types. If left unspecified, then


### PR DESCRIPTION
I confirmed this locally with https://download.pytorch.org/torchaudio/tutorial-assets/stream-api/NASAs_Most_Scientifically_Complex_Space_Observatory_Requires_Precision-MP4.mp4.

In principle, I want to test this functionality in our tests. But I'm not sure how to test it without actually going to the network. The actual handling of the URL is done in [`avformat_open_input()`](https://ffmpeg.org/doxygen/2.8/group__lavf__decoding.html#ga10a404346c646e4ab58f4ed798baca32), and I'm not aware of how to mock stuff at the Python level such that `avformat_open_input()` would work. And I don't want our unit tests going to the network, both for speed and reliability reasons.