### PR TITLE
Use torchcodec lowercase for wheel names

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "TorchCodec"
+name = "torchcodec"
 description = "A video decoder for PyTorch"
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
This PR renames our wheel files from `TorchCodec` to `torchcodec`.

As I published 0.2.1 I received the following email from PyPI:


> This email is notifying you of an upcoming deprecation that we have determined may affect you as a result of your recent upload to 'TorchCodec'.
> In the future, PyPI will require all newly uploaded binary distribution filenames to comply with the [binary distribution format](https://packaging.python.org/en/latest/specifications/binary-distribution-format/). Any binary distributions already uploaded will remain in place as-is and do not need to be updated.
> Specifically, your recent upload of 'TorchCodec-0.2.1-cp39-cp39-macosx_11_0_arm64.whl' is incompatible with the distribution format specification because the filename does not contain the normalized project name 'torchcodec'.


