### PR TITLE
Allow audio decoder to seek backwards

### DIFF
--- a/src/torchcodec/decoders/_core/VideoDecoder.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoder.cpp
@@ -877,10 +877,9 @@ torch::Tensor VideoDecoder::getFramesPlayedInRangeAudio(
   auto finished = false;
   while (!finished) {
     try {
-      AVFrameStream avFrameStream =
-          decodeAVFrame([this, startPts](AVFrame* avFrame) {
-            return startPts < avFrame->pts + getDuration(avFrame);
-          });
+      AVFrameStream avFrameStream = decodeAVFrame([startPts](AVFrame* avFrame) {
+        return startPts < avFrame->pts + getDuration(avFrame);
+      });
       auto frameOutput = convertAVFrameToFrameOutput(avFrameStream);
       tensors.push_back(frameOutput.data);
     } catch (const EndOfFileException& e) {

--- a/test/decoders/test_ops.py
+++ b/test/decoders/test_ops.py
@@ -793,21 +793,29 @@ class TestAudioOps:
         )
 
         # starting immediately on the same frame is OK
+        start_seconds, stop_seconds = stop_seconds, 6
         frames = get_frames_by_pts_in_range_audio(
-            decoder, start_seconds=stop_seconds, stop_seconds=6
+            decoder, start_seconds=start_seconds, stop_seconds=stop_seconds
         )
-        torch.testing.assert_close(frames, get_reference_frames(stop_seconds, 6))
+        torch.testing.assert_close(
+            frames, get_reference_frames(start_seconds, stop_seconds)
+        )
 
         get_frames_by_pts_in_range_audio(
-            decoder, start_seconds=stop_seconds + 1e-4, stop_seconds=6
+            decoder, start_seconds=start_seconds + 1e-4, stop_seconds=stop_seconds
         )
-        torch.testing.assert_close(frames, get_reference_frames(stop_seconds, 6))
+        torch.testing.assert_close(
+            frames, get_reference_frames(start_seconds, stop_seconds)
+        )
 
         # seeking backwards
+        start_seconds, stop_seconds = 0, 2
         frames = get_frames_by_pts_in_range_audio(
-            decoder, start_seconds=0, stop_seconds=2
+            decoder, start_seconds=start_seconds, stop_seconds=stop_seconds
         )
-        torch.testing.assert_close(frames, get_reference_frames(0, 2))
+        torch.testing.assert_close(
+            frames, get_reference_frames(start_seconds, stop_seconds)
+        )
 
 
 if __name__ == "__main__":

--- a/test/decoders/test_ops.py
+++ b/test/decoders/test_ops.py
@@ -742,16 +742,17 @@ class TestAudioOps:
     @pytest.mark.parametrize("asset", (NASA_AUDIO, NASA_AUDIO_MP3))
     def test_multiple_calls(self, asset):
         # Ensure that multiple calls to get_frames_by_pts_in_range_audio on the
-        # same decoder are supported, whether it involves forward seeks or
-        # backwards seeks.
+        # same decoder are supported and correct, whether it involves forward
+        # seeks or backwards seeks.
 
         def get_reference_frames(start_seconds, stop_seconds):
-            # This stateless helper exists for convenience, to avoid
-            # complicating this test with pts-to-index conversions. Eventually
-            # we should remove it and just rely on the asset's methods.
-            # Using this helper is OK for now: we're comparing a decoder which
-            # seeks multiple times with a decoder which seeks only once (the one
-            # here, treated as the reference)
+            # Usually we get the reference frames from the asset's methods, but
+            # for this specific test, this helper is more convenient, because
+            # relying on the asset would force us to convert all timestamps into
+            # indices.
+            # Ultimately, this test compares a "stateful decoder" which calls
+            # `get_frames_by_pts_in_range_audio()`` multiple times with a
+            # "stateless decoder" (the one here, treated as the reference)
             decoder = create_from_file(str(asset.path), seek_mode="approximate")
             add_audio_stream(decoder)
 


### PR DESCRIPTION
Towards https://github.com/pytorch/torchcodec/issues/549.


Changes are quite subtle, but I'm fairly confident they work as expected, since they pass our robust tests. I'll make sure to write some solid documentation around the mechanisms involved eventually.

Benchmarks results show no perf hit


```
Duration: 13s
torchcodec: med = 8.05ms +- 1.13
torchaudio: med = 12.27ms +- 0.51

Duration: 13s
torchcodec: med = 4.20ms +- 0.91
torchaudio: med = 7.21ms +- 0.58

Duration: 2m11s
torchcodec: med = 28.26ms +- 0.95
torchaudio: med = 45.72ms +- 0.89

Duration: 1h27m
torchcodec: med = 1046.49ms +- 66.00
torchaudio: med = 1746.49ms +- 22.55
```

Benchmark code is the same as in https://github.com/pytorch/torchcodec/pull/538, I'm not benchmarking the "backwards seeking" logic.