### PR TITLE
Fix FFmpeg build job

### DIFF
--- a/.github/workflows/build_ffmpeg.yaml
+++ b/.github/workflows/build_ffmpeg.yaml
@@ -34,7 +34,7 @@ jobs:
       contents: read
     with:
       job-name: Build
-      upload-artifact: ffmpeg-lgpl-linux-${{ strategy.job-index }}
+      upload-artifact: ffmpeg-lgpl-linux_x86_64-${{ matrix.ffmpeg-version }}
       repository: pytorch/torchcodec
       script: |
         export FFMPEG_VERSION="${{ matrix.ffmpeg-version }}"
@@ -56,7 +56,7 @@ jobs:
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
     with:
       job-name: Build
-      upload-artifact: ffmpeg-lgpl-macos-${{ strategy.job-index }}
+      upload-artifact: ffmpeg-lgpl-macos-${{ matrix.ffmpeg-version }}
       repository: pytorch/torchcodec
       runner: macos-14-xlarge
       script: |

--- a/.github/workflows/build_ffmpeg.yaml
+++ b/.github/workflows/build_ffmpeg.yaml
@@ -34,7 +34,7 @@ jobs:
       contents: read
     with:
       job-name: Build
-      upload-artifact: ffmpeg-lgpl
+      upload-artifact: ffmpeg-lgpl-linux-${{ strategy.job-index }}
       repository: pytorch/torchcodec
       script: |
         export FFMPEG_VERSION="${{ matrix.ffmpeg-version }}"
@@ -56,7 +56,7 @@ jobs:
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
     with:
       job-name: Build
-      upload-artifact: ffmpeg-lgpl
+      upload-artifact: ffmpeg-lgpl-macos-${{ strategy.job-index }}
       repository: pytorch/torchcodec
       runner: macos-14-xlarge
       script: |


### PR DESCRIPTION
Our FFmpeg build jobg have been failing for a few months: https://github.com/pytorch/torchcodec/actions/workflows/build_ffmpeg.yaml

with something like 

```
Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
```

It seems to be related to the update from v3 to `actions/download-artifact@v4` (https://github.com/actions/upload-artifact/issues/480#issuecomment-1937762859).

This PR gives each artifact a unique name, which fixes the upload.