### PR TITLE
Audio: allow next(), disallow seek()

### DIFF
--- a/src/torchcodec/decoders/_core/VideoDecoder.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoder.cpp
@@ -916,8 +916,8 @@ VideoDecoder::AudioFramesOutput VideoDecoder::getFramesPlayedInRangeAudio(
 // --------------------------------------------------------------------------
 
 void VideoDecoder::setCursorPtsInSeconds(double seconds) {
-    validateActiveStream(AVMEDIA_TYPE_VIDEO);
-    setCursorPtsInSecondsInternal(seconds);
+  validateActiveStream(AVMEDIA_TYPE_VIDEO);
+  setCursorPtsInSecondsInternal(seconds);
 }
 
 void VideoDecoder::setCursorPtsInSecondsInternal(double seconds) {

--- a/src/torchcodec/decoders/_core/VideoDecoder.h
+++ b/src/torchcodec/decoders/_core/VideoDecoder.h
@@ -370,6 +370,7 @@ class VideoDecoder {
   // DECODING APIS AND RELATED UTILS
   // --------------------------------------------------------------------------
 
+  void setCursorPtsInSecondsInternal(double seconds);
   bool canWeAvoidSeeking() const;
 
   void maybeSeekToBeforeDesiredPts();

--- a/test/decoders/test_ops.py
+++ b/test/decoders/test_ops.py
@@ -626,7 +626,7 @@ class TestAudioOps:
             partial(get_frames_in_range, start=4, stop=5),
             partial(get_frame_at_pts, seconds=2),
             partial(get_frames_by_pts, timestamps=[0, 1.5]),
-            partial(get_next_frame),
+            partial(seek_to_pts, seconds=5),
         ),
     )
     def test_audio_bad_method(self, method):
@@ -641,6 +641,20 @@ class TestAudioOps:
             RuntimeError, match="seek_mode must be 'approximate' for audio"
         ):
             add_audio_stream(decoder)
+
+    @pytest.mark.parametrize("asset", (NASA_AUDIO, NASA_AUDIO_MP3))
+    def test_next(self, asset):
+        decoder = create_from_file(str(asset.path), seek_mode="approximate")
+        add_audio_stream(decoder)
+
+        frame_index = 0
+        while True:
+            try:
+                frame, *_ = get_next_frame(decoder)
+            except IndexError:
+                break
+            torch.testing.assert_close(frame, asset.get_frame_data_by_index(frame_index))
+            frame_index += 1
 
     @pytest.mark.parametrize(
         "range",

--- a/test/decoders/test_ops.py
+++ b/test/decoders/test_ops.py
@@ -653,7 +653,9 @@ class TestAudioOps:
                 frame, *_ = get_next_frame(decoder)
             except IndexError:
                 break
-            torch.testing.assert_close(frame, asset.get_frame_data_by_index(frame_index))
+            torch.testing.assert_close(
+                frame, asset.get_frame_data_by_index(frame_index)
+            )
             frame_index += 1
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
This PR makes some minor changes to the core audio APIs:

- `get_next_frame()` is now allowed. It is needed to create our audio reference files (more on that in another PR)
- `seek_to_pts()` is disallowed. The only pts that we should allow to seek to is IN64_MIN. It's simpler to just disallow seeking entirely.