### PR TITLE
Prevent Google from indexing old versions

### DIFF
--- a/0.0.1/api_ref_decoders.html
+++ b/0.0.1/api_ref_decoders.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/0.0.1/generated/torchcodec.decoders.Frame.html
+++ b/0.0.1/generated/torchcodec.decoders.Frame.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/0.0.1/generated/torchcodec.decoders.FrameBatch.html
+++ b/0.0.1/generated/torchcodec.decoders.FrameBatch.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/0.0.1/generated/torchcodec.decoders.SimpleVideoDecoder.html
+++ b/0.0.1/generated/torchcodec.decoders.SimpleVideoDecoder.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/0.0.1/generated/torchcodec.decoders.VideoStreamMetadata.html
+++ b/0.0.1/generated/torchcodec.decoders.VideoStreamMetadata.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/0.0.1/generated_examples/basic_example.html
+++ b/0.0.1/generated_examples/basic_example.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/0.0.1/generated_examples/index.html
+++ b/0.0.1/generated_examples/index.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/0.0.1/generated_examples/sg_execution_times.html
+++ b/0.0.1/generated_examples/sg_execution_times.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/0.0.1/genindex.html
+++ b/0.0.1/genindex.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/0.0.1/glossary.html
+++ b/0.0.1/glossary.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/0.0.1/index.html
+++ b/0.0.1/index.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/0.0.1/install_instructions.html
+++ b/0.0.1/install_instructions.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/0.0.1/search.html
+++ b/0.0.1/search.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/0.0.1/sg_execution_times.html
+++ b/0.0.1/sg_execution_times.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/0.0.2/api_ref_decoders.html
+++ b/0.0.2/api_ref_decoders.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/0.0.2/generated/torchcodec.decoders.Frame.html
+++ b/0.0.2/generated/torchcodec.decoders.Frame.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/0.0.2/generated/torchcodec.decoders.FrameBatch.html
+++ b/0.0.2/generated/torchcodec.decoders.FrameBatch.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/0.0.2/generated/torchcodec.decoders.SimpleVideoDecoder.html
+++ b/0.0.2/generated/torchcodec.decoders.SimpleVideoDecoder.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/0.0.2/generated/torchcodec.decoders.VideoStreamMetadata.html
+++ b/0.0.2/generated/torchcodec.decoders.VideoStreamMetadata.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/0.0.2/generated_examples/basic_example.html
+++ b/0.0.2/generated_examples/basic_example.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/0.0.2/generated_examples/index.html
+++ b/0.0.2/generated_examples/index.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/0.0.2/generated_examples/sg_execution_times.html
+++ b/0.0.2/generated_examples/sg_execution_times.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/0.0.2/genindex.html
+++ b/0.0.2/genindex.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/0.0.2/glossary.html
+++ b/0.0.2/glossary.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/0.0.2/index.html
+++ b/0.0.2/index.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/0.0.2/install_instructions.html
+++ b/0.0.2/install_instructions.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/0.0.2/search.html
+++ b/0.0.2/search.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/0.0.2/sg_execution_times.html
+++ b/0.0.2/sg_execution_times.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/0.0.3/api_ref_decoders.html
+++ b/0.0.3/api_ref_decoders.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/0.0.3/generated/torchcodec.decoders.Frame.html
+++ b/0.0.3/generated/torchcodec.decoders.Frame.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/0.0.3/generated/torchcodec.decoders.FrameBatch.html
+++ b/0.0.3/generated/torchcodec.decoders.FrameBatch.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/0.0.3/generated/torchcodec.decoders.SimpleVideoDecoder.html
+++ b/0.0.3/generated/torchcodec.decoders.SimpleVideoDecoder.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/0.0.3/generated/torchcodec.decoders.VideoStreamMetadata.html
+++ b/0.0.3/generated/torchcodec.decoders.VideoStreamMetadata.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/0.0.3/generated_examples/basic_example.html
+++ b/0.0.3/generated_examples/basic_example.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/0.0.3/generated_examples/index.html
+++ b/0.0.3/generated_examples/index.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/0.0.3/generated_examples/sg_execution_times.html
+++ b/0.0.3/generated_examples/sg_execution_times.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/0.0.3/genindex.html
+++ b/0.0.3/genindex.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/0.0.3/glossary.html
+++ b/0.0.3/glossary.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/0.0.3/index.html
+++ b/0.0.3/index.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/0.0.3/install_instructions.html
+++ b/0.0.3/install_instructions.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/0.0.3/search.html
+++ b/0.0.3/search.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/0.0.3/sg_execution_times.html
+++ b/0.0.3/sg_execution_times.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/0.1/api_ref_decoders.html
+++ b/0.1/api_ref_decoders.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/0.1/api_ref_samplers.html
+++ b/0.1/api_ref_samplers.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/0.1/api_ref_torchcodec.html
+++ b/0.1/api_ref_torchcodec.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/0.1/generated/torchcodec.Frame.html
+++ b/0.1/generated/torchcodec.Frame.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/0.1/generated/torchcodec.FrameBatch.html
+++ b/0.1/generated/torchcodec.FrameBatch.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/0.1/generated/torchcodec.decoders.VideoDecoder.html
+++ b/0.1/generated/torchcodec.decoders.VideoDecoder.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/0.1/generated/torchcodec.decoders.VideoStreamMetadata.html
+++ b/0.1/generated/torchcodec.decoders.VideoStreamMetadata.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/0.1/generated/torchcodec.samplers.clips_at_random_indices.html
+++ b/0.1/generated/torchcodec.samplers.clips_at_random_indices.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/0.1/generated/torchcodec.samplers.clips_at_random_timestamps.html
+++ b/0.1/generated/torchcodec.samplers.clips_at_random_timestamps.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/0.1/generated/torchcodec.samplers.clips_at_regular_indices.html
+++ b/0.1/generated/torchcodec.samplers.clips_at_regular_indices.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/0.1/generated/torchcodec.samplers.clips_at_regular_timestamps.html
+++ b/0.1/generated/torchcodec.samplers.clips_at_regular_timestamps.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/0.1/generated_examples/basic_cuda_example.html
+++ b/0.1/generated_examples/basic_cuda_example.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/0.1/generated_examples/basic_example.html
+++ b/0.1/generated_examples/basic_example.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/0.1/generated_examples/index.html
+++ b/0.1/generated_examples/index.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/0.1/generated_examples/sampling.html
+++ b/0.1/generated_examples/sampling.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/0.1/generated_examples/sg_execution_times.html
+++ b/0.1/generated_examples/sg_execution_times.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/0.1/genindex.html
+++ b/0.1/genindex.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/0.1/glossary.html
+++ b/0.1/glossary.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/0.1/index.html
+++ b/0.1/index.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/0.1/search.html
+++ b/0.1/search.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/0.1/sg_execution_times.html
+++ b/0.1/sg_execution_times.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 


### PR DESCRIPTION
Google is still indexing old docs versions (0.1 instead of 0.2). Ran the following command:

```
for f in 0.0.1 0.0.2 0.0.3 0.1 ; do find $f -name "*.html" ! -path "*/_modules/*" -print0 | xargs -0 sed -i '/<head>/a \ \ <meta name="robots" content="noindex">' ; done
```

Which is from https://github.com/pytorch/docs/blob/site/add_noindex_tag.sh

For now, I think we'll have to add these tags manually when we push new doc versions.