### PR TITLE
Remove `VideoStreamOptions` string constructor

### DIFF
--- a/src/torchcodec/decoders/_core/VideoDecoder.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoder.cpp
@@ -43,23 +43,6 @@ int64_t secondsToClosestPts(double seconds, const AVRational& timeBase) {
   return static_cast<int64_t>(std::round(seconds * timeBase.den));
 }
 
-std::vector<std::string> splitStringWithDelimiters(
-    const std::string& str,
-    const std::string& delims) {
-  std::vector<std::string> result;
-  if (str.empty()) {
-    return result;
-  }
-
-  std::string::size_type start = 0, end = 0;
-  while ((end = str.find_first_of(delims, start)) != std::string::npos) {
-    result.push_back(str.substr(start, end - start));
-    start = end + 1;
-  }
-  result.push_back(str.substr(start));
-  return result;
-}
-
 } // namespace
 
 // --------------------------------------------------------------------------
@@ -394,57 +377,6 @@ torch::Tensor VideoDecoder::getKeyFrameIndices() {
 // --------------------------------------------------------------------------
 // ADDING STREAMS API
 // --------------------------------------------------------------------------
-
-VideoDecoder::VideoStreamOptions::VideoStreamOptions(
-    const std::string& optionsString) {
-  std::vector<std::string> tokens =
-      splitStringWithDelimiters(optionsString, ",");
-  for (auto token : tokens) {
-    std::vector<std::string> pairs = splitStringWithDelimiters(token, "=");
-    if (pairs.size() != 2) {
-      throw std::runtime_error(
-          "Invalid option: " + token +
-          ". Options must be in the form 'option=value'.");
-    }
-    std::string key = pairs[0];
-    std::string value = pairs[1];
-    if (key == "ffmpeg_thread_count") {
-      ffmpegThreadCount = std::stoi(value);
-      if (ffmpegThreadCount < 0) {
-        throw std::runtime_error(
-            "Invalid ffmpeg_thread_count=" + value +
-            ". ffmpeg_thread_count must be >= 0.");
-      }
-    } else if (key == "dimension_order") {
-      if (value != "NHWC" && value != "NCHW") {
-        throw std::runtime_error(
-            "Invalid dimension_order=" + value +
-            ". dimensionOrder must be either NHWC or NCHW.");
-      }
-      dimensionOrder = value;
-    } else if (key == "width") {
-      width = std::stoi(value);
-    } else if (key == "height") {
-      height = std::stoi(value);
-    } else if (key == "color_conversion_library") {
-      if (value == "filtergraph") {
-        colorConversionLibrary = ColorConversionLibrary::FILTERGRAPH;
-      } else if (value == "swscale") {
-        colorConversionLibrary = ColorConversionLibrary::SWSCALE;
-      } else {
-        throw std::runtime_error(
-            "Invalid color_conversion_library=" + value +
-            ". color_conversion_library must be either "
-            "filtergraph or swscale.");
-      }
-    } else {
-      throw std::runtime_error(
-          "Invalid option: " + key +
-          ". Valid options are: "
-          "ffmpeg_thread_count=<int>,dimension_order=<string>");
-    }
-  }
-}
 
 void VideoDecoder::addStream(
     int streamIndex,

--- a/src/torchcodec/decoders/_core/VideoDecoder.h
+++ b/src/torchcodec/decoders/_core/VideoDecoder.h
@@ -121,7 +121,6 @@ class VideoDecoder {
   struct VideoStreamOptions {
     VideoStreamOptions() {}
 
-    explicit VideoStreamOptions(const std::string& optionsString);
     // Number of threads we pass to FFMPEG for decoding.
     // 0 means FFMPEG will choose the number of threads automatically to fully
     // utilize all cores. If not set, it will be the default FFMPEG behavior for

--- a/test/decoders/VideoDecoderTest.cpp
+++ b/test/decoders/VideoDecoderTest.cpp
@@ -227,9 +227,9 @@ TEST_P(VideoDecoderTest, DecodesFramesInABatchInNHWC) {
   ourDecoder->scanFileAndUpdateMetadataAndIndex();
   int bestVideoStreamIndex =
       *ourDecoder->getContainerMetadata().bestVideoStreamIndex;
-  ourDecoder->addVideoStream(
-      bestVideoStreamIndex,
-      VideoDecoder::VideoStreamOptions("dimension_order=NHWC"));
+  VideoDecoder::VideoStreamOptions videoStreamOptions;
+  videoStreamOptions.dimensionOrder = "NHWC";
+  ourDecoder->addVideoStream(bestVideoStreamIndex, videoStreamOptions);
   // Frame with index 180 corresponds to timestamp 6.006.
   auto output = ourDecoder->getFramesAtIndices({0, 180});
   auto tensor = output.data;
@@ -392,9 +392,10 @@ TEST_P(VideoDecoderTest, PreAllocatedTensorFilterGraph) {
   ourDecoder->scanFileAndUpdateMetadataAndIndex();
   int bestVideoStreamIndex =
       *ourDecoder->getContainerMetadata().bestVideoStreamIndex;
-  ourDecoder->addVideoStream(
-      bestVideoStreamIndex,
-      VideoDecoder::VideoStreamOptions("color_conversion_library=filtergraph"));
+  VideoDecoder::VideoStreamOptions videoStreamOptions;
+  videoStreamOptions.colorConversionLibrary =
+      VideoDecoder::ColorConversionLibrary::FILTERGRAPH;
+  ourDecoder->addVideoStream(bestVideoStreamIndex, videoStreamOptions);
   auto output =
       ourDecoder->getFrameAtIndexInternal(0, preAllocatedOutputTensor);
   EXPECT_EQ(output.data.data_ptr(), preAllocatedOutputTensor.data_ptr());
@@ -409,9 +410,10 @@ TEST_P(VideoDecoderTest, PreAllocatedTensorSwscale) {
   ourDecoder->scanFileAndUpdateMetadataAndIndex();
   int bestVideoStreamIndex =
       *ourDecoder->getContainerMetadata().bestVideoStreamIndex;
-  ourDecoder->addVideoStream(
-      bestVideoStreamIndex,
-      VideoDecoder::VideoStreamOptions("color_conversion_library=swscale"));
+  VideoDecoder::VideoStreamOptions videoStreamOptions;
+  videoStreamOptions.colorConversionLibrary =
+      VideoDecoder::ColorConversionLibrary::SWSCALE;
+  ourDecoder->addVideoStream(bestVideoStreamIndex, videoStreamOptions);
   auto output =
       ourDecoder->getFrameAtIndexInternal(0, preAllocatedOutputTensor);
   EXPECT_EQ(output.data.data_ptr(), preAllocatedOutputTensor.data_ptr());


### PR DESCRIPTION
The string constructor was only used in C++ tests. It's a lot of code for little benefit.

The ops were [already relying](https://github.com/pytorch/torchcodec/blob/ae19a7882752823e5cd9a8c580f01150dbc6e3ec/src/torchcodec/decoders/_core/VideoDecoderOps.cpp#L180-L218) on the (arguably cleaner) default constructor.

I checked and couldn't find any internal use of the string constructor either.