### PR TITLE
Minor cleanup for firstFramePtsSeconds

### DIFF
--- a/src/torchcodec/decoders/_core/VideoDecoder.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoder.cpp
@@ -957,6 +957,12 @@ VideoDecoder::AudioFramesOutput VideoDecoder::getFramesPlayedInRangeAudio(
     frames.push_back(*lastSamples);
   }
 
+  TORCH_CHECK(
+      frames.size() > 0 && firstFramePtsSeconds.has_value(),
+      "No audio frames were decoded. ",
+      "This should probably not happen. ",
+      "Please report an issue on the TorchCodec repo.");
+
   return AudioFramesOutput{torch::cat(frames, 1), *firstFramePtsSeconds};
 }
 


### PR DESCRIPTION
Using an `std::optional` instead of a `min()` logic. Should be the same end result but potentially more correct, in case the frames's pts aren't ordered (which would be WEIRD).