### PR TITLE
Fix sample rate conversion bug with multi-channel data

### DIFF
--- a/src/torchcodec/decoders/_core/VideoDecoder.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoder.cpp
@@ -1522,17 +1522,22 @@ std::optional<torch::Tensor> VideoDecoder::maybeFlushSwrBuffers() {
     return std::nullopt;
   }
 
-  torch::Tensor lastSamples = torch::empty(
-      {getNumChannels(streamInfo.codecContext), numRemainingSamples},
-      torch::kFloat32);
-  uint8_t* lastSamplesData = static_cast<uint8_t*>(lastSamples.data_ptr());
+  auto numChannels = getNumChannels(streamInfo.codecContext);
+  torch::Tensor lastSamples =
+      torch::empty({numChannels, numRemainingSamples}, torch::kFloat32);
+
+  std::vector<uint8_t*> outputBuffers(numChannels);
+  for (auto i = 0; i < numChannels; i++) {
+    outputBuffers[i] = static_cast<uint8_t*>(lastSamples[i].data_ptr());
+  }
 
   auto actualNumRemainingSamples = swr_convert(
       streamInfo.swrContext.get(),
-      &lastSamplesData,
+      outputBuffers.data(),
       numRemainingSamples,
       nullptr,
       0);
+
   return lastSamples.narrow(
       /*dim=*/1, /*start=*/0, /*length=*/actualNumRemainingSamples);
 }

--- a/test/decoders/test_decoders.py
+++ b/test/decoders/test_decoders.py
@@ -1157,10 +1157,12 @@ class TestAudioDecoder:
             rtol=rtol,
         )
 
-    def test_upsample(self):
+    def test_sample_rate_conversion_stereo(self):
+        # Non-regression test for https://github.com/pytorch/torchcodec/pull/584
         asset = NASA_AUDIO_MP3
         assert asset.sample_rate == 8000
-        decoder = AudioDecoder(asset.path, sample_rate=44100)
+        assert asset.num_channels == 2
+        decoder = AudioDecoder(asset.path, sample_rate=44_100)
         decoder.get_samples_played_in_range(start_seconds=0)
 
     def test_s16_ffmpeg4_bug(self):

--- a/test/decoders/test_decoders.py
+++ b/test/decoders/test_decoders.py
@@ -1157,6 +1157,12 @@ class TestAudioDecoder:
             rtol=rtol,
         )
 
+    def test_upsample(self):
+        asset = NASA_AUDIO_MP3
+        assert asset.sample_rate == 8000
+        decoder = AudioDecoder(asset.path, sample_rate=44100)
+        decoder.get_samples_played_in_range(start_seconds=0)
+
     def test_s16_ffmpeg4_bug(self):
         # s16 fails on FFmpeg4 but can be decoded on other versions.
         # Debugging logs show that we're hitting:


### PR DESCRIPTION
We were only testing sample rate conversion on mono data, and I didn't realize that the flushing part was segfaulting when `num_channels > 1`. I wasn't setting the output buffer parameter of `swr_convert()` correctly.
