### PR TITLE
Move "scanned" metadata as video-only and add `begin_stream_from_header`

### DIFF
--- a/src/torchcodec/decoders/_audio_decoder.py
+++ b/src/torchcodec/decoders/_audio_decoder.py
@@ -11,7 +11,10 @@ from torch import Tensor
 
 from torchcodec import AudioSamples
 from torchcodec.decoders import _core as core
-from torchcodec.decoders._decoder_utils import create_decoder
+from torchcodec.decoders._decoder_utils import (
+    create_decoder,
+    ERROR_REPORTING_INSTRUCTIONS,
+)
 
 
 class AudioDecoder:

--- a/src/torchcodec/decoders/_audio_decoder.py
+++ b/src/torchcodec/decoders/_audio_decoder.py
@@ -11,10 +11,7 @@ from torch import Tensor
 
 from torchcodec import AudioSamples
 from torchcodec.decoders import _core as core
-from torchcodec.decoders._decoder_utils import (
-    create_decoder,
-    get_and_validate_stream_metadata,
-)
+from torchcodec.decoders._decoder_utils import create_decoder
 
 
 class AudioDecoder:
@@ -57,15 +54,20 @@ class AudioDecoder:
             self._decoder, stream_index=stream_index, sample_rate=sample_rate
         )
 
-        (
-            self.metadata,
-            self.stream_index,
-            self._begin_stream_seconds,
-            self._end_stream_seconds,
-        ) = get_and_validate_stream_metadata(
-            decoder=self._decoder, stream_index=stream_index, media_type="audio"
+        container_metadata = core.get_container_metadata(self._decoder)
+        self.stream_index = (
+            container_metadata.best_audio_stream_index
+            if stream_index is None
+            else stream_index
         )
+        if self.stream_index is None:
+            raise ValueError(
+                "The best audio stream is unknown and there is no specified stream. "
+                + ERROR_REPORTING_INSTRUCTIONS
+            )
+        self.metadata = container_metadata.streams[self.stream_index]
         assert isinstance(self.metadata, core.AudioStreamMetadata)  # mypy
+
         self._desired_sample_rate = (
             sample_rate if sample_rate is not None else self.metadata.sample_rate
         )
@@ -89,12 +91,6 @@ class AudioDecoder:
         if stop_seconds is not None and not start_seconds <= stop_seconds:
             raise ValueError(
                 f"Invalid start seconds: {start_seconds}. It must be less than or equal to stop seconds ({stop_seconds})."
-            )
-        if not self._begin_stream_seconds <= start_seconds < self._end_stream_seconds:
-            raise ValueError(
-                f"Invalid start seconds: {start_seconds}. "
-                f"It must be greater than or equal to {self._begin_stream_seconds} "
-                f"and less than or equal to {self._end_stream_seconds}."
             )
         frames, first_pts = core.get_frames_by_pts_in_range_audio(
             self._decoder,

--- a/src/torchcodec/decoders/_core/VideoDecoder.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoder.cpp
@@ -948,8 +948,9 @@ VideoDecoder::AudioFramesOutput VideoDecoder::getFramesPlayedInRangeAudio(
   TORCH_CHECK(
       frames.size() > 0 && firstFramePtsSeconds.has_value(),
       "No audio frames were decoded. ",
-      "This should probably not happen. ",
-      "Please report an issue on the TorchCodec repo.");
+      "This is probably because start_seconds is too high? ",
+      "Current value is ",
+      startSeconds);
 
   return AudioFramesOutput{torch::cat(frames, 1), *firstFramePtsSeconds};
 }

--- a/src/torchcodec/decoders/_core/VideoDecoder.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoder.cpp
@@ -147,6 +147,10 @@ void VideoDecoder::initializeDecoder() {
       streamMetadata.durationSeconds =
           av_q2d(avStream->time_base) * avStream->duration;
     }
+    if (avStream->start_time != AV_NOPTS_VALUE) {
+      streamMetadata.beginStreamFromHeader =
+          av_q2d(avStream->time_base) * avStream->start_time;
+    }
 
     if (avStream->codecpar->codec_type == AVMEDIA_TYPE_VIDEO) {
       double fps = av_q2d(avStream->r_frame_rate);

--- a/src/torchcodec/decoders/_core/VideoDecoder.h
+++ b/src/torchcodec/decoders/_core/VideoDecoder.h
@@ -59,6 +59,7 @@ class VideoDecoder {
     std::optional<AVCodecID> codecId;
     std::optional<std::string> codecName;
     std::optional<double> durationSeconds;
+    std::optional<double> beginStreamFromHeader;
     std::optional<int64_t> numFrames;
     std::optional<int64_t> numKeyFrames;
     std::optional<double> averageFps;

--- a/src/torchcodec/decoders/_core/VideoDecoderOps.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoderOps.cpp
@@ -473,6 +473,10 @@ std::string get_stream_json_metadata(
   if (streamMetadata.numFrames.has_value()) {
     map["numFrames"] = std::to_string(*streamMetadata.numFrames);
   }
+  if (streamMetadata.beginStreamFromHeader.has_value()) {
+    map["beginStreamFromHeader"] =
+        std::to_string(*streamMetadata.beginStreamFromHeader);
+  }
   if (streamMetadata.minPtsSecondsFromScan.has_value()) {
     map["minPtsSecondsFromScan"] =
         std::to_string(*streamMetadata.minPtsSecondsFromScan);

--- a/src/torchcodec/decoders/_core/_metadata.py
+++ b/src/torchcodec/decoders/_core/_metadata.py
@@ -32,20 +32,18 @@ class StreamMetadata:
     duration_seconds_from_header: Optional[float]
     """Duration of the stream, in seconds, obtained from the header (float or
     None). This could be inaccurate."""
-    bit_rate: Optional[float]
-    """Bit rate of the stream, in seconds (float or None)."""
     begin_stream_seconds_from_header: Optional[float]
     """Beginning of the stream, in seconds, obtained from the header (float or
     None). Usually, this is equal to 0."""
+    bit_rate: Optional[float]
+    """Bit rate of the stream, in seconds (float or None)."""
     codec: Optional[str]
     """Codec (str or None)."""
     stream_index: int
     """Index of the stream within the video (int)."""
 
     def __repr__(self):
-        # Overridden because properites are not printed by default.
         s = self.__class__.__name__ + ":\n"
-        s += f"{SPACES}duration_seconds: {self.duration_seconds}\n"
         for field in dataclasses.fields(self):
             s += f"{SPACES}{field.name}: {getattr(self, field.name)}\n"
         return s
@@ -158,6 +156,9 @@ class VideoStreamMetadata(StreamMetadata):
 
     def __repr__(self):
         s = super().__repr__()
+        s += f"{SPACES}duration_seconds: {self.duration_seconds}\n"
+        s += f"{SPACES}begin_stream_seconds: {self.begin_stream_seconds}\n"
+        s += f"{SPACES}end_stream_seconds: {self.end_stream_seconds}\n"
         s += f"{SPACES}num_frames: {self.num_frames}\n"
         s += f"{SPACES}average_fps: {self.average_fps}\n"
         return s

--- a/src/torchcodec/decoders/_core/_metadata.py
+++ b/src/torchcodec/decoders/_core/_metadata.py
@@ -34,20 +34,24 @@ class StreamMetadata:
     None). This could be inaccurate."""
     bit_rate: Optional[float]
     """Bit rate of the stream, in seconds (float or None)."""
+    begin_stream_seconds_from_header: Optional[float]
+    """Beginning of the stream, in seconds, obtained from the header (float or
+    None). Usually, this is equal to 0."""
     begin_stream_seconds_from_content: Optional[float]
     """Beginning of the stream, in seconds (float or None).
-    Conceptually, this corresponds to the first frame's :term:`pts`. It is
-    computed as min(frame.pts) across all frames in the stream. Usually, this is
-    equal to 0."""
+    Conceptually, this corresponds to the first frame's :term:`pts`. It is only
+    computed when a :term:`scan` is done as min(frame.pts) across all frames in
+    the stream. Usually, this is equal to 0."""
     end_stream_seconds_from_content: Optional[float]
     """End of the stream, in seconds (float or None).
     Conceptually, this corresponds to last_frame.pts + last_frame.duration. It
-    is computed as max(frame.pts + frame.duration) across all frames in the
-    stream. Note that no frame is played at this time value, so calling
-    :meth:`~torchcodec.decoders.VideoDecoder.get_frame_played_at` with
-    this value would result in an error. Retrieving the last frame is best done
-    by simply indexing the :class:`~torchcodec.decoders.VideoDecoder`
-    object with ``[-1]``.
+    is only computed when a :term:`scan` is done as max(frame.pts +
+    frame.duration) across all frames in the stream. Note that no frame is
+    played at this time value, so calling
+    :meth:`~torchcodec.decoders.VideoDecoder.get_frame_played_at` with this
+    value would result in an error. Retrieving the last frame is best done by
+    simply indexing the :class:`~torchcodec.decoders.VideoDecoder` object with
+    ``[-1]``.
     """
     codec: Optional[str]
     """Codec (str or None)."""
@@ -224,6 +228,7 @@ def get_container_metadata(decoder: torch.Tensor) -> ContainerMetadata:
         common_meta = dict(
             duration_seconds_from_header=stream_dict.get("durationSeconds"),
             bit_rate=stream_dict.get("bitRate"),
+            begin_stream_seconds_from_header=stream_dict.get("beginStreamFromHeader"),
             begin_stream_seconds_from_content=stream_dict.get("minPtsSecondsFromScan"),
             end_stream_seconds_from_content=stream_dict.get("maxPtsSecondsFromScan"),
             codec=stream_dict.get("codec"),

--- a/src/torchcodec/decoders/_decoder_utils.py
+++ b/src/torchcodec/decoders/_decoder_utils.py
@@ -6,7 +6,7 @@
 
 from pathlib import Path
 
-from typing import Optional, Tuple, Union
+from typing import Union
 
 from torch import Tensor
 from torchcodec.decoders import _core as core
@@ -32,56 +32,4 @@ def create_decoder(
     raise TypeError(
         f"Unknown source type: {type(source)}. "
         "Supported types are str, Path, bytes and Tensor."
-    )
-
-
-def get_and_validate_stream_metadata(
-    *,
-    decoder: Tensor,
-    stream_index: Optional[int] = None,
-    media_type: str,
-) -> Tuple[core._metadata.StreamMetadata, int, float, float]:
-
-    if media_type not in ("video", "audio"):
-        raise ValueError(f"Bad {media_type = }, should be audio or video")
-
-    container_metadata = core.get_container_metadata(decoder)
-
-    if stream_index is None:
-        best_stream_index = (
-            container_metadata.best_video_stream_index
-            if media_type == "video"
-            else container_metadata.best_audio_stream_index
-        )
-        if best_stream_index is None:
-            raise ValueError(
-                f"The best {media_type} stream is unknown and there is no specified stream. "
-                + ERROR_REPORTING_INSTRUCTIONS
-            )
-        stream_index = best_stream_index
-
-    # This should be logically true because of the above conditions, but type checker
-    # is not clever enough.
-    assert stream_index is not None
-
-    metadata = container_metadata.streams[stream_index]
-
-    if metadata.begin_stream_seconds is None:
-        raise ValueError(
-            "The minimum pts value in seconds is unknown. "
-            + ERROR_REPORTING_INSTRUCTIONS
-        )
-    begin_stream_seconds = metadata.begin_stream_seconds
-
-    if metadata.end_stream_seconds is None:
-        raise ValueError(
-            "The maximum pts value in seconds is unknown. "
-            + ERROR_REPORTING_INSTRUCTIONS
-        )
-    end_stream_seconds = metadata.end_stream_seconds
-    return (
-        metadata,
-        stream_index,
-        begin_stream_seconds,
-        end_stream_seconds,
     )

--- a/src/torchcodec/decoders/_video_decoder.py
+++ b/src/torchcodec/decoders/_video_decoder.py
@@ -348,6 +348,7 @@ def _get_and_validate_stream_metadata(
             )
 
     metadata = container_metadata.streams[stream_index]
+    assert isinstance(metadata, core._metadata.VideoStreamMetadata)  # mypy
 
     if metadata.begin_stream_seconds is None:
         raise ValueError(

--- a/test/decoders/test_decoders.py
+++ b/test/decoders/test_decoders.py
@@ -955,7 +955,7 @@ class TestAudioDecoder:
             == decoder.metadata.stream_index
             == asset.default_stream_index
         )
-        assert decoder.metadata.duration_seconds == pytest.approx(
+        assert decoder.metadata.duration_seconds_from_header == pytest.approx(
             asset.duration_seconds
         )
         assert decoder.metadata.sample_rate == asset.sample_rate
@@ -967,13 +967,18 @@ class TestAudioDecoder:
         decoder = AudioDecoder(asset.path)
 
         with pytest.raises(ValueError, match="Invalid start seconds"):
-            decoder.get_samples_played_in_range(start_seconds=-1300)
+            decoder.get_samples_played_in_range(start_seconds=3, stop_seconds=2)
 
-        with pytest.raises(ValueError, match="Invalid start seconds"):
+        with pytest.raises(RuntimeError, match="No audio frames were decoded"):
             decoder.get_samples_played_in_range(start_seconds=9999)
 
-        with pytest.raises(ValueError, match="Invalid start seconds"):
-            decoder.get_samples_played_in_range(start_seconds=3, stop_seconds=2)
+    @pytest.mark.parametrize("asset", (NASA_AUDIO, NASA_AUDIO_MP3))
+    def test_negative_start(self, asset):
+        decoder = AudioDecoder(asset.path)
+        samples = decoder.get_samples_played_in_range(start_seconds=-1300)
+        reference_samples = decoder.get_samples_played_in_range()
+        torch.testing.assert_close(samples.data, reference_samples.data)
+        assert samples.pts_seconds == reference_samples.pts_seconds
 
     @pytest.mark.parametrize("asset", (NASA_AUDIO, NASA_AUDIO_MP3))
     @pytest.mark.parametrize("stop_seconds", (None, "duration", 99999999))

--- a/test/decoders/test_metadata.py
+++ b/test/decoders/test_metadata.py
@@ -90,9 +90,7 @@ def test_get_metadata(metadata_getter):
     best_audio_stream_metadata = metadata.streams[metadata.best_audio_stream_index]
     assert isinstance(best_audio_stream_metadata, AudioStreamMetadata)
     assert best_audio_stream_metadata is metadata.best_audio_stream
-    assert best_audio_stream_metadata.duration_seconds == pytest.approx(
-        13.056, abs=0.001
-    )
+    assert best_audio_stream_metadata.duration_seconds_from_header == 13.056
     assert best_audio_stream_metadata.begin_stream_seconds_from_header == 0
     assert best_audio_stream_metadata.bit_rate == 128837
     assert best_audio_stream_metadata.codec == "aac"
@@ -111,9 +109,7 @@ def test_get_metadata_audio_file(metadata_getter):
     best_audio_stream_metadata = metadata.streams[metadata.best_audio_stream_index]
     assert isinstance(best_audio_stream_metadata, AudioStreamMetadata)
     assert best_audio_stream_metadata is metadata.best_audio_stream
-    assert best_audio_stream_metadata.duration_seconds == pytest.approx(
-        13.248, abs=0.001
-    )
+    assert best_audio_stream_metadata.duration_seconds_from_header == 13.248
     assert best_audio_stream_metadata.begin_stream_seconds_from_header == 0.138125
     assert best_audio_stream_metadata.bit_rate == 64000
     assert best_audio_stream_metadata.codec == "mp3"

--- a/test/decoders/test_metadata.py
+++ b/test/decoders/test_metadata.py
@@ -7,6 +7,7 @@
 import functools
 
 import pytest
+from torchcodec.decoders import AudioDecoder, VideoDecoder
 
 from torchcodec.decoders._core import (
     AudioStreamMetadata,
@@ -140,3 +141,44 @@ def test_num_frames_fallback(
     )
 
     assert metadata.num_frames == expected_num_frames
+
+
+def test_repr():
+    # Test for calls to print(), str(), etc. Useful to make sure we don't forget
+    # to add additional @properties to __repr__
+    assert (
+        str(VideoDecoder(NASA_VIDEO.path).metadata)
+        == """VideoStreamMetadata:
+  duration_seconds_from_header: 13.013
+  begin_stream_seconds_from_header: 0.0
+  bit_rate: 128783.0
+  codec: h264
+  stream_index: 3
+  begin_stream_seconds_from_content: 0.0
+  end_stream_seconds_from_content: 13.013
+  width: 480
+  height: 270
+  num_frames_from_header: 390
+  num_frames_from_content: 390
+  average_fps_from_header: 29.97003
+  duration_seconds: 13.013
+  begin_stream_seconds: 0.0
+  end_stream_seconds: 13.013
+  num_frames: 390
+  average_fps: 29.97002997002997
+"""
+    )
+
+    assert (
+        str(AudioDecoder(NASA_AUDIO_MP3.path).metadata)
+        == """AudioStreamMetadata:
+  duration_seconds_from_header: 13.248
+  begin_stream_seconds_from_header: 0.138125
+  bit_rate: 64000.0
+  codec: mp3
+  stream_index: 0
+  sample_rate: 8000
+  num_channels: 2
+  sample_format: fltp
+"""
+    )

--- a/test/decoders/test_metadata.py
+++ b/test/decoders/test_metadata.py
@@ -20,6 +20,10 @@ from torchcodec.decoders._core import (
 from ..utils import NASA_AUDIO_MP3, NASA_VIDEO
 
 
+# TODO: Expected values in these tests should be based on the assets's
+# attributes rather than on hard-coded values.
+
+
 def _get_container_metadata(path, seek_mode):
     decoder = create_from_file(str(path), seek_mode=seek_mode)
     return get_container_metadata(decoder)
@@ -73,6 +77,7 @@ def test_get_metadata(metadata_getter):
     assert best_video_stream_metadata.duration_seconds == pytest.approx(
         13.013, abs=0.001
     )
+    assert best_video_stream_metadata.begin_stream_seconds_from_header == 0
     assert best_video_stream_metadata.bit_rate == 128783
     assert best_video_stream_metadata.average_fps == pytest.approx(29.97, abs=0.001)
     assert best_video_stream_metadata.codec == "h264"
@@ -88,6 +93,7 @@ def test_get_metadata(metadata_getter):
     assert best_audio_stream_metadata.duration_seconds == pytest.approx(
         13.056, abs=0.001
     )
+    assert best_audio_stream_metadata.begin_stream_seconds_from_header == 0
     assert best_audio_stream_metadata.bit_rate == 128837
     assert best_audio_stream_metadata.codec == "aac"
     assert best_audio_stream_metadata.sample_format == "fltp"
@@ -108,6 +114,7 @@ def test_get_metadata_audio_file(metadata_getter):
     assert best_audio_stream_metadata.duration_seconds == pytest.approx(
         13.248, abs=0.001
     )
+    assert best_audio_stream_metadata.begin_stream_seconds_from_header == 0.138125
     assert best_audio_stream_metadata.bit_rate == 64000
     assert best_audio_stream_metadata.codec == "mp3"
     assert best_audio_stream_metadata.sample_format == "fltp"
@@ -126,6 +133,7 @@ def test_num_frames_fallback(
         bit_rate=123,
         num_frames_from_header=num_frames_from_header,
         num_frames_from_content=num_frames_from_content,
+        begin_stream_seconds_from_header=0,
         begin_stream_seconds_from_content=0,
         end_stream_seconds_from_content=4,
         codec="whatever",


### PR DESCRIPTION
This PR does a bunch of related things:

- We add a new `begin_stream_seconds_from_header` field to audio and video metadata. It is derived from the AVStream's `start_time` field. This field is useful e.g. in our tutorial example because it is now clear that the stream doesn't exactly starts at 0.
- We move the `begin_stream_seconds_from_content` and `end_stream_seconds_from_content` fields as video-only: these fields are derived from a scan, so there's no point having them for audio.
- As a consequence of that, we move the `duration_seconds` metadata as video-only, because it is derived from `begin_stream_seconds_from_content` and `end_stream_seconds_from_content`. This means that audio metadata now only contains `duration_seconds_from_header`.
- We now allow negative `start_seconds` in the call to `get_samples_played_in_range`: the input check was based on `begin_stream_seconds_from_content` so that didn't make much sense. We still have tests that make sure we provide good error messages in the incorrect cases.