### PR TITLE
Fix doc rendering of child dataclasses

### DIFF
--- a/docs/source/_templates/dataclass.rst
+++ b/docs/source/_templates/dataclass.rst
@@ -8,3 +8,4 @@
 .. autoclass:: {{ name }}
     :members:
     :undoc-members: __init__
+    :inherited-members:

--- a/examples/audio_decoding.py
+++ b/examples/audio_decoding.py
@@ -76,7 +76,6 @@ play_audio(samples)
 # all streams start exactly at 0! This is not a bug in TorchCodec, this is a
 # property of the file that was defined when it was encoded.
 #
-# %%
 # Specifying a range
 # ------------------
 #

--- a/src/torchcodec/decoders/_core/_metadata.py
+++ b/src/torchcodec/decoders/_core/_metadata.py
@@ -22,11 +22,6 @@ from torchcodec.decoders._core.ops import (
 SPACES = "  "
 
 
-# TODO-AUDIO: docs below are mostly for video streams, we should edit them and /
-# or make sure they're OK for audio streams as well. Not sure how to best handle
-# docs for such class hierarchy.
-# TODO very related, none of these common fields in this base class show up in
-# the docs right now.
 @dataclass
 class StreamMetadata:
     duration_seconds_from_header: Optional[float]
@@ -40,7 +35,7 @@ class StreamMetadata:
     codec: Optional[str]
     """Codec (str or None)."""
     stream_index: int
-    """Index of the stream within the video (int)."""
+    """Index of the stream that this metadata refers to (int)."""
 
     def __repr__(self):
         s = self.__class__.__name__ + ":\n"


### PR DESCRIPTION
The inherited fields of the metadata metaclasses weren't properly shown on the docs.