### PR TITLE
Do nullptr check on result from av_get_sample_fmt_name()

### DIFF
--- a/src/torchcodec/decoders/_core/VideoDecoder.cpp
+++ b/src/torchcodec/decoders/_core/VideoDecoder.cpp
@@ -161,7 +161,15 @@ void VideoDecoder::initializeDecoder() {
     } else if (avStream->codecpar->codec_type == AVMEDIA_TYPE_AUDIO) {
       AVSampleFormat format =
           static_cast<AVSampleFormat>(avStream->codecpar->format);
-      streamMetadata.sampleFormat = av_get_sample_fmt_name(format);
+
+      // If the AVSampleFormat is not recognized, we get back nullptr. We have
+      // to make sure we don't initialize a std::string with nullptr. There's
+      // nothing to do on the else branch because we're already using an
+      // optional; it'll just remain empty.
+      const char* rawSampleFormat = av_get_sample_fmt_name(format);
+      if (rawSampleFormat != nullptr) {
+        streamMetadata.sampleFormat = std::string(rawSampleFormat);
+      }
       containerMetadata_.numAudioStreams++;
     }
 


### PR DESCRIPTION
We need to check the result of [`av_get_sample_fmt_name()`](https://ffmpeg.org/doxygen/6.1/group__lavu__sampfmts.html#ga31b9d149b2de9821a65f4f5612970838) because it can return `nullptr`.