### PR TITLE
Prevent calls to setCursor on floats

### DIFF
--- a/src/torchcodec/decoders/_core/VideoDecoder.h
+++ b/src/torchcodec/decoders/_core/VideoDecoder.h
@@ -368,6 +368,7 @@ class VideoDecoder {
   // --------------------------------------------------------------------------
 
   void setCursor(int64_t pts);
+  void setCursor(double) = delete; // prevent calls with doubles and floats
   bool canWeAvoidSeeking() const;
 
   void maybeSeekToBeforeDesiredPts();


### PR DESCRIPTION
This will prevent us from calling `setCursor()` with double and floats, which should avoid similar bugs to https://github.com/pytorch/torchcodec/pull/599.

Ideally we should find stricter compilation flags that enforce this, but this should at least address numerical types.