### PR TITLE
Fix VideoDecoder device argument to accept torch.device

### DIFF
--- a/src/torchcodec/decoders/_video_decoder.py
+++ b/src/torchcodec/decoders/_video_decoder.py
@@ -8,7 +8,7 @@ import numbers
 from pathlib import Path
 from typing import Literal, Optional, Tuple, Union
 
-from torch import device, Tensor
+from torch import device as torch_device, Tensor
 
 from torchcodec import Frame, FrameBatch
 from torchcodec.decoders import _core as core
@@ -72,7 +72,7 @@ class VideoDecoder:
         stream_index: Optional[int] = None,
         dimension_order: Literal["NCHW", "NHWC"] = "NCHW",
         num_ffmpeg_threads: int = 1,
-        device: Optional[Union[str, device]] = "cpu",
+        device: Optional[Union[str, torch_device]] = "cpu",
         seek_mode: Literal["exact", "approximate"] = "exact",
     ):
         allowed_seek_modes = ("exact", "approximate")
@@ -93,6 +93,9 @@ class VideoDecoder:
 
         if num_ffmpeg_threads is None:
             raise ValueError(f"{num_ffmpeg_threads = } should be an int.")
+
+        if isinstance(device, torch_device):
+            device = str(device)
 
         core.add_video_stream(
             self._decoder,

--- a/test/decoders/test_decoders.py
+++ b/test/decoders/test_decoders.py
@@ -285,6 +285,11 @@ class TestVideoDecoder:
                 # See https://github.com/pytorch/torchcodec/issues/428
                 assert_frames_equal(sliced, ref)
 
+    def test_device_instance(self):
+        # Non-regression test for https://github.com/pytorch/torchcodec/issues/602
+        decoder = VideoDecoder(NASA_VIDEO.path, device=torch.device("cpu"))
+        assert isinstance(decoder.metadata, VideoStreamMetadata)
+
     @pytest.mark.parametrize("device", cpu_and_cuda())
     @pytest.mark.parametrize("seek_mode", ("exact", "approximate"))
     def test_getitem_fails(self, device, seek_mode):


### PR DESCRIPTION
### Summary

This PR fixes an issue where passing a `torch.device` to the `VideoDecoder` constructor causes a type error when passed to the underlying C++ `add_video_stream` function, which expects a `str`.

### Changes

- Convert `torch.device` to `str` inside `__init__` if necessary.

### Why

Fixes bug #602: `torch.device` instances were not compatible with the expected C++ type (`Optional[str]`), causing decoding to fail.

Closes #602.