### PR TITLE
Remove redundant includes

### DIFF
--- a/src/torchcodec/_core/SingleStreamDecoder.cpp
+++ b/src/torchcodec/_core/SingleStreamDecoder.cpp
@@ -17,15 +17,10 @@
 #include "torch/types.h"
 
 extern "C" {
-#include <libavcodec/avcodec.h>
 #include <libavfilter/buffersink.h>
 #include <libavfilter/buffersrc.h>
-#include <libavformat/avformat.h>
 #include <libavutil/imgutils.h>
 #include <libavutil/log.h>
-#include <libavutil/pixdesc.h>
-#include <libswresample/swresample.h>
-#include <libswscale/swscale.h>
 }
 
 namespace facebook::torchcodec {


### PR DESCRIPTION
These are already included in `FFMPEGCommon.h`; I think it's reasonable that we assume all .cpp files that need to do FFmpeg stuff have included `FFMPEGCommon.h` either directly or indirectly. Better for clarity and build times.