### PR TITLE
Enable public decoder creation with file like object

### DIFF
--- a/src/torchcodec/_core/ops.py
+++ b/src/torchcodec/_core/ops.py
@@ -141,7 +141,7 @@ def create_from_bytes(
 
 
 def create_from_file_like(
-    file_like: Union[io.RawIOBase, io.BytesIO], seek_mode: Optional[str] = None
+    file_like: Union[io.RawIOBase, io.BufferedReader], seek_mode: Optional[str] = None
 ) -> torch.Tensor:
     assert _pybind_ops is not None
     return _convert_to_tensor(_pybind_ops.create_from_file_like(file_like, seek_mode))

--- a/src/torchcodec/decoders/_audio_decoder.py
+++ b/src/torchcodec/decoders/_audio_decoder.py
@@ -26,14 +26,14 @@ class AudioDecoder:
     Returned samples are float samples normalized in [-1, 1]
 
     Args:
-        source (str, ``Pathlib.path``,
-                ``io.RawIOBase``, ``io.BufferedReader``,
-                bytes, or ``torch.Tensor``): The source of the audio:
+        source (str, ``Pathlib.path``, bytes, ``torch.Tensor`` or file-like object): The source of the video:
 
             - If ``str``: a local path or a URL to a video or audio file.
             - If ``Pathlib.path``: a path to a local video or audio file.
-            - If ``io.RawIOBase`` or ``io.BufferedReader``: a file-like object that refers to a audio file.
             - If ``bytes`` object or ``torch.Tensor``: the raw encoded audio data.
+            - If file-like object: we read video data from the object on demand. The object must
+              expose the methods ``read(self, size: int) -> bytes`` and
+              ``seek(self, offset: int, whence: int) -> bytes``. Read more in TODO_FILE_LIKE_TUTORIAL.
         stream_index (int, optional): Specifies which stream in the file to decode samples from.
             Note that this index is absolute across all media types. If left unspecified, then
             the :term:`best stream` is used.

--- a/src/torchcodec/decoders/_audio_decoder.py
+++ b/src/torchcodec/decoders/_audio_decoder.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import io
 from pathlib import Path
 from typing import Optional, Union
 
@@ -25,10 +26,13 @@ class AudioDecoder:
     Returned samples are float samples normalized in [-1, 1]
 
     Args:
-        source (str, ``Pathlib.path``, ``torch.Tensor``, or bytes): The source of the audio:
+        source (str, ``Pathlib.path``,
+                ``io.RawIOBase``, ``io.BufferedReader``,
+                bytes, or ``torch.Tensor``): The source of the audio:
 
             - If ``str``: a local path or a URL to a video or audio file.
             - If ``Pathlib.path``: a path to a local video or audio file.
+            - If ``io.RawIOBase`` or ``io.BufferedReader``: a file-like object that refers to a audio file.
             - If ``bytes`` object or ``torch.Tensor``: the raw encoded audio data.
         stream_index (int, optional): Specifies which stream in the file to decode samples from.
             Note that this index is absolute across all media types. If left unspecified, then
@@ -45,7 +49,7 @@ class AudioDecoder:
 
     def __init__(
         self,
-        source: Union[str, Path, bytes, Tensor],
+        source: Union[str, Path, io.RawIOBase, io.BufferedReader, bytes, Tensor],
         *,
         stream_index: Optional[int] = None,
         sample_rate: Optional[int] = None,

--- a/src/torchcodec/decoders/_decoder_utils.py
+++ b/src/torchcodec/decoders/_decoder_utils.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import io
 from pathlib import Path
 
 from typing import Union
@@ -18,18 +19,32 @@ https://github.com/pytorch/torchcodec/issues/new?assignees=&labels=&projects=&te
 
 
 def create_decoder(
-    *, source: Union[str, Path, bytes, Tensor], seek_mode: str
+    *,
+    source: Union[str, Path, io.RawIOBase, io.BufferedReader, bytes, Tensor],
+    seek_mode: str,
 ) -> Tensor:
     if isinstance(source, str):
         return core.create_from_file(source, seek_mode)
     elif isinstance(source, Path):
         return core.create_from_file(str(source), seek_mode)
+    elif isinstance(source, io.RawIOBase) or isinstance(source, io.BufferedReader):
+        return core.create_from_file_like(source, seek_mode)
     elif isinstance(source, bytes):
         return core.create_from_bytes(source, seek_mode)
     elif isinstance(source, Tensor):
         return core.create_from_tensor(source, seek_mode)
+    elif isinstance(source, io.TextIOBase):
+        raise TypeError(
+            "source is of type io.TextIOBase; did you forget to specify binary reading?"
+        )
+    elif hasattr(source, "read") and hasattr(source, "seek"):
+        # This check must be after checking for text-based reading. Also placing
+        # it last in general to be defensive: hasattr is a blunt instrument. We
+        # could use the inspect module to check for methods with the right
+        # signature.
+        return core.create_from_file_like(source, seek_mode)
 
     raise TypeError(
         f"Unknown source type: {type(source)}. "
-        "Supported types are str, Path, bytes and Tensor."
+        "Supported types are str, Path, io.RawIOBase, io.BufferedReader, bytes and Tensor."
     )

--- a/src/torchcodec/decoders/_decoder_utils.py
+++ b/src/torchcodec/decoders/_decoder_utils.py
@@ -35,7 +35,7 @@ def create_decoder(
         return core.create_from_tensor(source, seek_mode)
     elif isinstance(source, io.TextIOBase):
         raise TypeError(
-            "source is of type io.TextIOBase; did you forget to specify binary reading?"
+            "source is for reading text, likely from open(..., 'r'). Try with 'rb' for binary reading?"
         )
     elif hasattr(source, "read") and hasattr(source, "seek"):
         # This check must be after checking for text-based reading. Also placing
@@ -46,5 +46,7 @@ def create_decoder(
 
     raise TypeError(
         f"Unknown source type: {type(source)}. "
-        "Supported types are str, Path, io.RawIOBase, io.BufferedReader, bytes and Tensor."
+        "Supported types are str, Path, bytes, Tensor and file-like objects with "
+        "read(self, size: int) -> bytes and "
+        "seek(self, offset: int, whence: int) -> bytes methods."
     )

--- a/src/torchcodec/decoders/_video_decoder.py
+++ b/src/torchcodec/decoders/_video_decoder.py
@@ -22,14 +22,14 @@ class VideoDecoder:
     """A single-stream video decoder.
 
     Args:
-        source (str, ``Pathlib.path``,
-                ``io.RawIOBase``, ``io.BufferedReader``,
-                bytes, or ``torch.Tensor``): The source of the video:
+        source (str, ``Pathlib.path``, bytes, ``torch.Tensor`` or file-like object): The source of the video:
 
             - If ``str``: a local path or a URL to a video file.
             - If ``Pathlib.path``: a path to a local video file.
-            - If ``io.RawIOBase`` or ``io.BufferedReader``: a file-like object that refers to a video file.
             - If ``bytes`` object or ``torch.Tensor``: the raw encoded video data.
+            - If file-like object: we read video data from the object on demand. The object must
+              expose the methods ``read(self, size: int) -> bytes`` and
+              ``seek(self, offset: int, whence: int) -> bytes``. Read more in TODO_FILE_LIKE_TUTORIAL.
         stream_index (int, optional): Specifies which stream in the video to decode frames from.
             Note that this index is absolute across all media types. If left unspecified, then
             the :term:`best stream` is used.

--- a/src/torchcodec/decoders/_video_decoder.py
+++ b/src/torchcodec/decoders/_video_decoder.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import io
 import numbers
 from pathlib import Path
 from typing import Literal, Optional, Tuple, Union
@@ -21,10 +22,13 @@ class VideoDecoder:
     """A single-stream video decoder.
 
     Args:
-        source (str, ``Pathlib.path``, ``torch.Tensor``, or bytes): The source of the video.
+        source (str, ``Pathlib.path``,
+                ``io.RawIOBase``, ``io.BufferedReader``,
+                bytes, or ``torch.Tensor``): The source of the video:
 
             - If ``str``: a local path or a URL to a video file.
             - If ``Pathlib.path``: a path to a local video file.
+            - If ``io.RawIOBase`` or ``io.BufferedReader``: a file-like object that refers to a video file.
             - If ``bytes`` object or ``torch.Tensor``: the raw encoded video data.
         stream_index (int, optional): Specifies which stream in the video to decode frames from.
             Note that this index is absolute across all media types. If left unspecified, then
@@ -66,7 +70,7 @@ class VideoDecoder:
 
     def __init__(
         self,
-        source: Union[str, Path, bytes, Tensor],
+        source: Union[str, Path, io.RawIOBase, io.BufferedReader, bytes, Tensor],
         *,
         stream_index: Optional[int] = None,
         dimension_order: Literal["NCHW", "NHWC"] = "NCHW",


### PR DESCRIPTION
Exposes the ability for users to pass a file-like object to our public `VideoDecoder` and `AudioEncoder` objects. More testing to make sure we're getting the correct results to follow.

I wanted to put up this PR to discuss how to approach objects that have a `read` and `seek` attribute, but do not actually have the correct signature. Currently, if users provide that, they'll see the kinds of exceptions that we test for in `test_ops.py`. Are we okay with that? Is that enough? If no, then we could do what I allude to in the comment, and use the [inspect](https://docs.python.org/3/library/inspect.html) module to verify that the methods will actually work.

I also want to call out something that pleased me _immensely_: this feature and audio decoding have been in development in parallel, and they work together seamlessly! To the point that I was actually testing for audio without realizing it, as I just modified the test for decoder creation and only after it all worked did I realize I was testing for video and audio.