### PR TITLE
Encoder: properly validate sample rate parameter

### DIFF
--- a/src/torchcodec/_core/Encoder.cpp
+++ b/src/torchcodec/_core/Encoder.cpp
@@ -1,3 +1,5 @@
+#include <sstream>
+
 #include "src/torchcodec/_core/Encoder.h"
 #include "torch/types.h"
 
@@ -15,12 +17,12 @@ void validateSampleRate(const AVCodec& avCodec, int sampleRate) {
       return;
     }
   }
-  std::string supportedRates;
+  std::stringstream supportedRates;
   for (auto i = 0; avCodec.supported_samplerates[i] != 0; ++i) {
     if (i > 0) {
-      supportedRates += ", ";
+      supportedRates << ", ";
     }
-    supportedRates += std::to_string(avCodec.supported_samplerates[i]);
+    supportedRates << avCodec.supported_samplerates[i];
   }
 
   TORCH_CHECK(
@@ -28,7 +30,7 @@ void validateSampleRate(const AVCodec& avCodec, int sampleRate) {
       "invalid sample rate=",
       sampleRate,
       ". Supported sample rate values are: ",
-      supportedRates);
+      supportedRates.str());
 }
 
 } // namespace

--- a/src/torchcodec/_core/Encoder.cpp
+++ b/src/torchcodec/_core/Encoder.cpp
@@ -40,7 +40,7 @@ AudioEncoder::~AudioEncoder() {}
 AudioEncoder::AudioEncoder(
     const torch::Tensor wf,
     int sampleRate,
-    std::string_view fileName,
+    std::string_view fileName)
     : wf_(wf) {
   TORCH_CHECK(
       wf_.dtype() == torch::kFloat32,

--- a/src/torchcodec/_core/Encoder.h
+++ b/src/torchcodec/_core/Encoder.h
@@ -9,6 +9,10 @@ class AudioEncoder {
 
   AudioEncoder(
       const torch::Tensor wf,
+      // The *output* sample rate. We can't really decide for the user what it
+      // should be. Particularly, the sample rate of the input waveform should
+      // match this, and that's up to the user. If sample rates don't match,
+      // encoding will still work but audio will be distorted.
       int sampleRate,
       std::string_view fileName);
   void encode();
@@ -24,13 +28,5 @@ class AudioEncoder {
   int streamIndex_;
 
   const torch::Tensor wf_;
-  // The *output* sample rate. We can't really decide for the user what it
-  // should be. Particularly, the sample rate of the input waveform should match
-  // this, and that's up to the user. If sample rates don't match, encoding will
-  // still work but audio will be distorted.
-  // We technically could let the user also specify the input sample rate, and
-  // resample the waveform internally to match them, but that's not in scope for
-  // an initial version (if at all).
-  int sampleRate_;
 };
 } // namespace facebook::torchcodec

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1107,9 +1107,7 @@ class TestAudioEncoderOps:
                 wf=torch.rand(10, 10), sample_rate=10, filename="./file.bad_extension"
             )
 
-        # TODO-ENCODING: raise more informative error message when sample rate
-        # isn't supported
-        with pytest.raises(RuntimeError, match="Invalid argument"):
+        with pytest.raises(RuntimeError, match="invalid sample rate=10"):
             create_audio_encoder(
                 wf=self.decode(NASA_AUDIO_MP3),
                 sample_rate=10,


### PR DESCRIPTION
Also remove the `sampleRate_` field which we're not using