### PR TITLE
Remove our own manywheel fixup

### DIFF
--- a/packaging/post_build_script.sh
+++ b/packaging/post_build_script.sh
@@ -37,22 +37,5 @@ assert_not_in_wheel $wheel_path "^doc"
 assert_not_in_wheel $wheel_path "^benchmarks"
 assert_not_in_wheel $wheel_path "^packaging"
 
-if [[ "$unamestr" == 'Linux' ]]; then
-    # TODO: Put this back with higher upper bound of version symbol.
-    # # See invoked python script below for details about this check.
-    # extracted_wheel_dir=$(mktemp -d)
-    # unzip -q $wheel_path -d $extracted_wheel_dir
-    # symbols_matches=$(find $extracted_wheel_dir | grep ".so$" | xargs objdump --syms | grep GLIBCXX_3.4.)
-    # python packaging/check_glibcxx.py "$symbols_matches"
-
-    echo "ls dist"
-    ls dist
-
-    old="linux_x86_64"
-    new="manylinux_2_17_x86_64.manylinux2014_x86_64"
-    echo "Replacing ${old} with ${new} in wheel name"
-    mv dist/*${old}*.whl $(echo dist/*${old}*.whl | sed "s/${old}/${new}/")
-fi
-
 echo "ls dist"
 ls dist

--- a/packaging/post_build_script.sh
+++ b/packaging/post_build_script.sh
@@ -37,14 +37,14 @@ assert_not_in_wheel $wheel_path "^doc"
 assert_not_in_wheel $wheel_path "^benchmarks"
 assert_not_in_wheel $wheel_path "^packaging"
 
-if [[ "$unamestr" == 'Linux' ]]; then
-    # TODO: Put this back with higher upper bound of version symbol.
-    # # See invoked python script below for details about this check.
-    # extracted_wheel_dir=$(mktemp -d)
-    # unzip -q $wheel_path -d $extracted_wheel_dir
-    # symbols_matches=$(find $extracted_wheel_dir | grep ".so$" | xargs objdump --syms | grep GLIBCXX_3.4.)
-    # python packaging/check_glibcxx.py "$symbols_matches"
-fi
+# TODO: Put this back with higher upper bound of version symbol.
+#if [[ "$unamestr" == 'Linux' ]]; then
+#    # See invoked python script below for details about this check.
+#    extracted_wheel_dir=$(mktemp -d)
+#    unzip -q $wheel_path -d $extracted_wheel_dir
+#    symbols_matches=$(find $extracted_wheel_dir | grep ".so$" | xargs objdump --syms | grep GLIBCXX_3.4.)
+#    python packaging/check_glibcxx.py "$symbols_matches"
+#fi
 
 echo "ls dist"
 ls dist

--- a/packaging/post_build_script.sh
+++ b/packaging/post_build_script.sh
@@ -37,5 +37,14 @@ assert_not_in_wheel $wheel_path "^doc"
 assert_not_in_wheel $wheel_path "^benchmarks"
 assert_not_in_wheel $wheel_path "^packaging"
 
+if [[ "$unamestr" == 'Linux' ]]; then
+    # TODO: Put this back with higher upper bound of version symbol.
+    # # See invoked python script below for details about this check.
+    # extracted_wheel_dir=$(mktemp -d)
+    # unzip -q $wheel_path -d $extracted_wheel_dir
+    # symbols_matches=$(find $extracted_wheel_dir | grep ".so$" | xargs objdump --syms | grep GLIBCXX_3.4.)
+    # python packaging/check_glibcxx.py "$symbols_matches"
+fi
+
 echo "ls dist"
 ls dist


### PR DESCRIPTION
We had our own fixup for manywheel compliance on Linux. The test-infra repo just merged their own: https://github.com/pytorch/test-infra/pull/6538

Ours was failing because it was already done. For example, see: https://github.com/pytorch/torchcodec/actions/runs/14576597340/job/40883950594?pr=638. This PR just removes our fixup code as we can rely on theirs.