### PR TITLE
Add TORCHCODEC_DISABLE_COMPILE_WARNING_AS_ERROR environment variable to disable -Werror compilation option

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -112,6 +112,7 @@ class CMakeBuild(build_ext):
         torch_dir = Path(torch.utils.cmake_prefix_path) / "Torch"
         cmake_build_type = os.environ.get("CMAKE_BUILD_TYPE", "Release")
         enable_cuda = os.environ.get("ENABLE_CUDA", "")
+        torchcodec_disable_compile_warning_as_error = os.environ.get("TORCHCODEC_DISABLE_COMPILE_WARNING_AS_ERROR", "OFF")
         python_version = sys.version_info
         cmake_args = [
             f"-DCMAKE_INSTALL_PREFIX={self._install_prefix}",
@@ -120,6 +121,7 @@ class CMakeBuild(build_ext):
             f"-DCMAKE_BUILD_TYPE={cmake_build_type}",
             f"-DPYTHON_VERSION={python_version.major}.{python_version.minor}",
             f"-DENABLE_CUDA={enable_cuda}",
+            f"-DTORCHCODEC_DISABLE_COMPILE_WARNING_AS_ERROR={torchcodec_disable_compile_warning_as_error}"
         ]
 
         Path(self.build_temp).mkdir(parents=True, exist_ok=True)

--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,9 @@ class CMakeBuild(build_ext):
         torch_dir = Path(torch.utils.cmake_prefix_path) / "Torch"
         cmake_build_type = os.environ.get("CMAKE_BUILD_TYPE", "Release")
         enable_cuda = os.environ.get("ENABLE_CUDA", "")
-        torchcodec_disable_compile_warning_as_error = os.environ.get("TORCHCODEC_DISABLE_COMPILE_WARNING_AS_ERROR", "OFF")
+        torchcodec_disable_compile_warning_as_error = os.environ.get(
+            "TORCHCODEC_DISABLE_COMPILE_WARNING_AS_ERROR", "OFF"
+        )
         python_version = sys.version_info
         cmake_args = [
             f"-DCMAKE_INSTALL_PREFIX={self._install_prefix}",
@@ -121,7 +123,7 @@ class CMakeBuild(build_ext):
             f"-DCMAKE_BUILD_TYPE={cmake_build_type}",
             f"-DPYTHON_VERSION={python_version.major}.{python_version.minor}",
             f"-DENABLE_CUDA={enable_cuda}",
-            f"-DTORCHCODEC_DISABLE_COMPILE_WARNING_AS_ERROR={torchcodec_disable_compile_warning_as_error}"
+            f"-DTORCHCODEC_DISABLE_COMPILE_WARNING_AS_ERROR={torchcodec_disable_compile_warning_as_error}",
         ]
 
         Path(self.build_temp).mkdir(parents=True, exist_ok=True)

--- a/src/torchcodec/_core/CMakeLists.txt
+++ b/src/torchcodec/_core/CMakeLists.txt
@@ -8,7 +8,13 @@ find_package(pybind11 REQUIRED)
 find_package(Torch REQUIRED)
 find_package(Python3 ${PYTHON_VERSION} EXACT COMPONENTS Development)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic -Werror ${TORCH_CXX_FLAGS}")
+if(DEFINED TORCHCODEC_DISABLE_COMPILE_WARNING_AS_ERROR AND TORCHCODEC_DISABLE_COMPILE_WARNING_AS_ERROR)
+    set(TORCHCODEC_WERROR_OPTION "")
+else()
+    set(TORCHCODEC_WERROR_OPTION "-Werror")
+endif()
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic ${TORCHCODEC_WERROR_OPTION} ${TORCH_CXX_FLAGS}")
 
 function(make_torchcodec_sublibrary
     library_name


### PR DESCRIPTION
The `-Werror` option is typically enabled automatically by library authors, so they ensure that all contributors to the library early fail if new code they write contain a warning, ensuring as soon as possible that no new warnings are added to the library. This is the reason (I guess) why `-Werror` was added in ttps://github.com/pytorch/torchcodec/pull/452 . On the other hand, people that package libraries for distributions prefer to disable the `-Werror` option, as they may want to compile a given library with a new compilers or new ffmpeg versions (that may not have even existed when a given release of a library was tagged), that introduce new warnings, without having a failure. For a detailed discussion of this from the point of view of people packaging libraries, see https://youtu.be/_5weX5mx8hc?si=ZtiWaK7KPTfQ01_g&t=322 .

For example, `torchcodec` 0.3.0 currently fails with error:

~~~
 │ │   [ 38%] Building CXX object src/torchcodec/_core/CMakeFiles/libtorchcodec_decoder7.dir/Encoder.cpp.o
 │ │   cd $SRC_DIR/build/temp.linux-x86_64-cpython-310/src/torchcodec/_core && $BUILD_PREFIX/bin/x86_64-conda-linux-gnu-
 │ │ c++ -DPROTOBUF_USE_DLLS -DUSE_C10D_GLOO -DUSE_C10D_NCCL -DUSE_DISTRIBUTED -DUSE_RPC -DUSE_TENSORPIPE -Dlibtorchcode
 │ │ c_decoder7_EXPORTS -I$SRC_DIR/src/torchcodec/_core/./../../.. -I$PREFIX/include/python3.10 -isystem $PREFIX/lib/pyt
 │ │ hon3.10/site-packages/torch/include -isystem $PREFIX/lib/python3.10/site-packages/torch/include/torch/csrc/api/incl
 │ │ ude -fvisibility-inlines-hidden -fmessage-length=0 -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-prot
 │ │ ector-strong -fno-plt -O2 -ffunction-sections -pipe -isystem $PREFIX/include -fdebug-prefix-map=$SRC_DIR=/usr/local
 │ │ /src/conda/torchcodec-0.3.0 -fdebug-prefix-map=$PREFIX=/usr/local/src/conda-prefix  -I$PREFIX/targets/x86_64-linux/
 │ │ include -I$BUILD_PREFIX/targets/x86_64-linux/include -Wall -Wextra -pedantic -Werror -D_GLIBCXX_USE_CXX11_ABI=1 -O3
 │ │  -DNDEBUG -std=gnu++17 -fPIC -fdiagnostics-color=always -D_GLIBCXX_USE_CXX11_ABI=1 -MD -MT src/torchcodec/_core/CMa
 │ │ keFiles/libtorchcodec_decoder7.dir/Encoder.cpp.o -MF CMakeFiles/libtorchcodec_decoder7.dir/Encoder.cpp.o.d -o CMake
 │ │ Files/libtorchcodec_decoder7.dir/Encoder.cpp.o -c $SRC_DIR/src/torchcodec/_core/Encoder.cpp
 │ │   $SRC_DIR/src/torchcodec/_core/Encoder.cpp: In function 'void facebook::torchcodec::{anonymous}::validateSampleRat
 │ │ e(const AVCodec&, int)':
 │ │   $SRC_DIR/src/torchcodec/_core/Encoder.cpp:11:15: error: 'AVCodec::supported_samplerates' is deprecated [-Werror=d
 │ │ eprecated-declarations]
 │ │      11 |   if (avCodec.supported_samplerates == nullptr) {
 │ │         |               ^~~~~~~~~~~~~~~~~~~~~
 │ │   In file included from $PREFIX/include/libavcodec/avcodec.h:41,
 │ │                    from $SRC_DIR/src/torchcodec/_core/./../../../src/torchcodec/_core/FFMPEGCommon.h:14,
 │ │                    from $SRC_DIR/src/torchcodec/_core/./../../../src/torchcodec/_core/Encoder.h:3,
 │ │                    from $SRC_DIR/src/torchcodec/_core/Encoder.cpp:3:
 │ │   $PREFIX/include/libavcodec/codec.h:217:16: note: declared here
 │ │     217 |     const int *supported_samplerates;       ///< @deprecated use avcodec_get_supported_config()
 │ │         |                ^~~~~~~~~~~~~~~~~~~~~
 │ │   $SRC_DIR/src/torchcodec/_core/Encoder.cpp:11:15: error: 'AVCodec::supported_samplerates' is deprecated [-Werror=d
 │ │ eprecated-declarations]
 │ │      11 |   if (avCodec.supported_samplerates == nullptr) {
 │ │         |               ^~~~~~~~~~~~~~~~~~~~~
 │ │   $PREFIX/include/libavcodec/codec.h:217:16: note: declared here
 │ │     217 |     const int *supported_samplerates;       ///< @deprecated use avcodec_get_supported_config()
 │ │         |                ^~~~~~~~~~~~~~~~~~~~~
 │ │   $SRC_DIR/src/torchcodec/_core/Encoder.cpp:11:15: error: 'AVCodec::supported_samplerates' is deprecated [-Werror=d
 │ │ eprecated-declarations]
 │ │      11 |   if (avCodec.supported_samplerates == nullptr) {
 │ │         |               ^~~~~~~~~~~~~~~~~~~~~
 │ │   $PREFIX/include/libavcodec/codec.h:217:16: note: declared here
 │ │     217 |     const int *supported_samplerates;       ///< @deprecated use avcodec_get_supported_config()
 │ │         |                ^~~~~~~~~~~~~~~~~~~~~
 │ │   $SRC_DIR/src/torchcodec/_core/Encoder.cpp:15:28: error: 'AVCodec::supported_samplerates' is deprecated [-Werror=d
 │ │ eprecated-declarations]
 │ │      15 |   for (auto i = 0; avCodec.supported_samplerates[i] != 0; ++i) {
 │ │         |                            ^~~~~~~~~~~~~~~~~~~~~
~~~

when compiled against ffmpeg >=7.1.0, as the `supported_samplerates` deprecation was added in 7.1.0 .

This PR leaves the default behavior as it is, but adds a `TORCHCODEC_DISABLE_COMPILE_WARNING_AS_ERROR` environment variable (and corresponding CMake variable) to permit to disable the `-Werror` option. 

CMake provides the built-in CMake variable [`CMAKE_COMPILE_WARNING_AS_ERROR`](https://cmake.org/cmake/help/latest/prop_tgt/COMPILE_WARNING_AS_ERROR.html) since CMake 3.24, but as the CMake minimum required version is 3.18, using a custom CMake option seems the solution with minimal complexity.

Similar to https://github.com/PickNikRobotics/RSL/pull/117 and https://github.com/ros-misc-utilities/ffmpeg_encoder_decoder/pull/2 .