### PR TITLE
add opencv benchmark

### DIFF
--- a/benchmarks/decoders/benchmark_decoders.py
+++ b/benchmarks/decoders/benchmark_decoders.py
@@ -28,6 +28,7 @@ from benchmark_decoders_library import (
     TorchCodecPublic,
     TorchCodecPublicNonBatch,
     TorchVision,
+    OpenCVDecoder,
 )
 
 
@@ -61,6 +62,7 @@ decoder_registry = {
         {"backend": "video_reader"},
     ),
     "torchaudio": DecoderKind("TorchAudio", TorchAudioDecoder),
+    "opencv": DecoderKind("OpenCV", OpenCVDecoder),
 }
 
 


### PR DESCRIPTION
This PR added the benchmark for opencv. The benchmark shows that there is gap. Hope the torchcodec team can find out where the gap is from and improve the decoding performance. 

Local benchmark 

```
|  decode 10 uniform frames  |  decode 10 random frames  |  first 1 frames  |  first 10 frames  |  first 100 frames
1 threads: --------------------------------------------------------------------------------------------------------------------------------
      OpenCV            |            22.4            |            22.6           |       6.4        |        9.3        |        18.1
      TorchCodecPublic  |            39.4            |            28.1           |       9.5        |        9.8        |        26.0
```

Times are in milliseconds (ms).

![Image](https://github.com/user-attachments/assets/c06827ff-1b70-4144-b9ea-182403457881)