### PR TITLE
Remove 'unstable API' notice from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,6 @@ We achieve these capabilities through:
 * Returning data as PyTorch tensors, ready to be fed into PyTorch transforms
   or used directly to train models.
 
-> [!NOTE]
-> ⚠️ TorchCodec is still in development stage and some APIs may be updated
-> in future versions, depending on user feedback.
-> If you have any suggestions or issues, please let us know by
-> [opening an issue](https://github.com/pytorch/torchcodec/issues/new/choose)!
-
 ## Using TorchCodec
 
 Here's a condensed summary of what you can do with TorchCodec. For more detailed

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -67,13 +67,6 @@ We achieve these capabilities through:
 
         How to sample regular and random clips from a video
 
-.. note::
-
-   TorchCodec is still in development stage and we are actively seeking
-   feedback. If you have any suggestions or issues, please let us know by
-   `opening an issue <https://github.com/pytorch/torchcodec/issues/new/choose>`_
-   on our `GitHub repository <https://github.com/pytorch/torchcodec/>`_.
-
 .. toctree::
    :maxdepth: 1
    :caption: TorchCodec documentation


### PR DESCRIPTION
The APIs we expose are stable by now, I feel like we can safely remove these notices?