### PR TITLE
Remove +cpu from version name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -188,12 +188,14 @@ def _write_version_files():
         # the content of `version.txt` plus some suffix like "+cpu" or "+cu112".
         # See
         # https://github.com/pytorch/test-infra/blob/61e6da7a6557152eb9879e461a26ad667c15f0fd/tools/pkg-helpers/pytorch_pkg_helpers/version.py#L113
+        version = version.replace("+cpu", "")
         with open(_ROOT_DIR / "version.txt", "w") as f:
             f.write(f"{version}")
     else:
         with open(_ROOT_DIR / "version.txt") as f:
             version = f.readline().strip()
         try:
+            version = version.replace("+cpu", "")
             sha = (
                 subprocess.check_output(
                     ["git", "rev-parse", "HEAD"], cwd=str(_ROOT_DIR)


### PR DESCRIPTION
I've had to add this to every release branch so far. I think it's OK to have on `main` too, CI seems OK with it.