### PR TITLE
Audio encoding: support custom `num_channels`

### DIFF
--- a/src/torchcodec/_core/Encoder.cpp
+++ b/src/torchcodec/_core/Encoder.cpp
@@ -179,6 +179,8 @@ void AudioEncoder::initializeEncoder(
 
   desiredNumChannels_ = static_cast<int>(numChannels.value_or(wf_.sizes()[0]));
   validateNumChannels(*avCodec, desiredNumChannels_);
+  // The avCodecContext layout defines the layout of the encoded output, it's
+  // not related to the input sampes.
   setDefaultChannelLayout(avCodecContext_, desiredNumChannels_);
 
   validateSampleRate(*avCodec, sampleRate);
@@ -233,6 +235,8 @@ void AudioEncoder::encode() {
   avFrame->format = AV_SAMPLE_FMT_FLTP;
   avFrame->sample_rate = avCodecContext_->sample_rate;
   avFrame->pts = 0;
+  // We set the channel layout of the frame to the default layout corresponding
+  // to the input samples' number of channels
   setDefaultChannelLayout(avFrame, static_cast<int>(wf_.sizes()[0]));
 
   auto status = av_frame_get_buffer(avFrame.get(), 0);

--- a/src/torchcodec/_core/Encoder.cpp
+++ b/src/torchcodec/_core/Encoder.cpp
@@ -179,7 +179,6 @@ void AudioEncoder::initializeEncoder(
 
   desiredNumChannels_ = static_cast<int>(numChannels.value_or(wf_.sizes()[0]));
   validateNumChannels(*avCodec, desiredNumChannels_);
-
   setDefaultChannelLayout(avCodecContext_, desiredNumChannels_);
 
   validateSampleRate(*avCodec, sampleRate);

--- a/src/torchcodec/_core/Encoder.h
+++ b/src/torchcodec/_core/Encoder.h
@@ -13,6 +13,9 @@ class AudioEncoder {
   // like passing 0, which results in choosing the minimum supported bit rate.
   // Passing 44_100 could result in output being 44000 if only 44000 is
   // supported.
+  //
+  // TODO-ENCODING: bundle the optional params like bitRate, numChannels, etc.
+  // into an AudioStreamOptions struct, or similar.
   AudioEncoder(
       const torch::Tensor wf,
       // The *output* sample rate. We can't really decide for the user what it
@@ -21,20 +24,23 @@ class AudioEncoder {
       // encoding will still work but audio will be distorted.
       int sampleRate,
       std::string_view fileName,
-      std::optional<int64_t> bitRate = std::nullopt);
+      std::optional<int64_t> bitRate = std::nullopt,
+      std::optional<int64_t> numChannels = std::nullopt);
   AudioEncoder(
       const torch::Tensor wf,
       int sampleRate,
       std::string_view formatName,
       std::unique_ptr<AVIOToTensorContext> avioContextHolder,
-      std::optional<int64_t> bitRate = std::nullopt);
+      std::optional<int64_t> bitRate = std::nullopt,
+      std::optional<int64_t> numChannels = std::nullopt);
   void encode();
   torch::Tensor encodeToTensor();
 
  private:
   void initializeEncoder(
       int sampleRate,
-      std::optional<int64_t> bitRate = std::nullopt);
+      std::optional<int64_t> bitRate = std::nullopt,
+      std::optional<int64_t> numChannels = std::nullopt);
   void encodeInnerLoop(
       AutoAVPacket& autoAVPacket,
       const UniqueAVFrame& srcAVFrame);
@@ -44,6 +50,9 @@ class AudioEncoder {
   UniqueAVCodecContext avCodecContext_;
   int streamIndex_;
   UniqueSwrContext swrContext_;
+  // TODO-ENCODING: desiredNumChannels should just be part of an options struct,
+  // see other TODO above.
+  int desiredNumChannels_ = -1;
 
   const torch::Tensor wf_;
 

--- a/src/torchcodec/_core/FFMPEGCommon.cpp
+++ b/src/torchcodec/_core/FFMPEGCommon.cpp
@@ -101,7 +101,7 @@ void setDefaultChannelLayout(UniqueAVFrame& avFrame, int numChannels) {
 }
 
 void validateNumChannels(const AVCodec& avCodec, int numChannels) {
-#if LIBAVFILTER_VERSION_MAJOR > 8 // FFmpeg > 5
+#if LIBAVFILTER_VERSION_MAJOR > 7 // FFmpeg > 4
   if (avCodec.ch_layouts == nullptr) {
     // If we can't validate, we must assume it'll be fine. If not, FFmpeg will
     // eventually raise.

--- a/src/torchcodec/_core/FFMPEGCommon.cpp
+++ b/src/torchcodec/_core/FFMPEGCommon.cpp
@@ -113,6 +113,8 @@ void validateNumChannels(const AVCodec& avCodec, int numChannels) {
       return;
     }
   }
+  // At this point it seems that the encoder doesn't support the requested
+  // number of channels, so we error out.
   std::stringstream supportedNumChannels;
   for (auto i = 0; avCodec.ch_layouts[i].order != AV_CHANNEL_ORDER_UNSPEC;
        ++i) {
@@ -126,6 +128,8 @@ void validateNumChannels(const AVCodec& avCodec, int numChannels) {
     // can't validate, same as above.
     return;
   }
+  // At this point it seems that the encoder doesn't support the requested
+  // number of channels, so we error out.
   for (auto i = 0; avCodec.channel_layouts[i] != 0; ++i) {
     if (numChannels ==
         av_get_channel_layout_nb_channels(avCodec.channel_layouts[i])) {

--- a/src/torchcodec/_core/FFMPEGCommon.cpp
+++ b/src/torchcodec/_core/FFMPEGCommon.cpp
@@ -88,22 +88,34 @@ void setDefaultChannelLayout(
 #endif
 }
 
-void setChannelLayout(
-    UniqueAVFrame& dstAVFrame,
-    const UniqueAVCodecContext& avCodecContext) {
+void setDefaultChannelLayout(UniqueAVFrame& avFrame, int numChannels) {
 #if LIBAVFILTER_VERSION_MAJOR > 7 // FFmpeg > 4
-  auto status = av_channel_layout_copy(
-      &dstAVFrame->ch_layout, &avCodecContext->ch_layout);
-  TORCH_CHECK(
-      status == AVSUCCESS,
-      "Couldn't copy channel layout to avFrame: ",
-      getFFMPEGErrorStringFromErrorCode(status));
+  AVChannelLayout channel_layout;
+  av_channel_layout_default(&channel_layout, numChannels);
+  avFrame->ch_layout = channel_layout;
 #else
-  dstAVFrame->channel_layout = avCodecContext->channel_layout;
-  dstAVFrame->channels = avCodecContext->channels;
-
+  uint64_t channel_layout = av_get_default_channel_layout(numChannels);
+  avFrame->channel_layout = channel_layout;
+  avFrame->channels = numChannels;
 #endif
 }
+
+// void setChannelLayout(
+//     UniqueAVFrame& dstAVFrame,
+//     const UniqueAVCodecContext& avCodecContext) {
+// #if LIBAVFILTER_VERSION_MAJOR > 7 // FFmpeg > 4
+//   auto status = av_channel_layout_copy(
+//       &dstAVFrame->ch_layout, &avCodecContext->ch_layout);
+//   TORCH_CHECK(
+//       status == AVSUCCESS,
+//       "Couldn't copy channel layout to avFrame: ",
+//       getFFMPEGErrorStringFromErrorCode(status));
+// #else
+//   dstAVFrame->channel_layout = avCodecContext->channel_layout;
+//   dstAVFrame->channels = avCodecContext->channels;
+
+// #endif
+// }
 
 namespace {
 #if LIBAVFILTER_VERSION_MAJOR > 7 // FFmpeg > 4

--- a/src/torchcodec/_core/FFMPEGCommon.cpp
+++ b/src/torchcodec/_core/FFMPEGCommon.cpp
@@ -107,8 +107,9 @@ void validateNumChannels(const AVCodec& avCodec, int numChannels) {
     // eventually raise.
     return;
   }
-  for (auto i = 0; avCodec.ch_layouts[i].order != AV_CHANNEL_ORDER_UNSPEC;
-       ++i) {
+  // FFmpeg doc indicate that the ch_layouts array is terminated by a zeroed
+  // layout, so checking for nb_channels == 0 should indicate its end.
+  for (auto i = 0; avCodec.ch_layouts[i].nb_channels != 0; ++i) {
     if (numChannels == avCodec.ch_layouts[i].nb_channels) {
       return;
     }
@@ -116,8 +117,7 @@ void validateNumChannels(const AVCodec& avCodec, int numChannels) {
   // At this point it seems that the encoder doesn't support the requested
   // number of channels, so we error out.
   std::stringstream supportedNumChannels;
-  for (auto i = 0; avCodec.ch_layouts[i].order != AV_CHANNEL_ORDER_UNSPEC;
-       ++i) {
+  for (auto i = 0; avCodec.ch_layouts[i].nb_channels != 0; ++i) {
     if (i > 0) {
       supportedNumChannels << ", ";
     }
@@ -128,14 +128,14 @@ void validateNumChannels(const AVCodec& avCodec, int numChannels) {
     // can't validate, same as above.
     return;
   }
-  // At this point it seems that the encoder doesn't support the requested
-  // number of channels, so we error out.
   for (auto i = 0; avCodec.channel_layouts[i] != 0; ++i) {
     if (numChannels ==
         av_get_channel_layout_nb_channels(avCodec.channel_layouts[i])) {
       return;
     }
   }
+  // At this point it seems that the encoder doesn't support the requested
+  // number of channels, so we error out.
   std::stringstream supportedNumChannels;
   for (auto i = 0; avCodec.channel_layouts[i] != 0; ++i) {
     if (i > 0) {

--- a/src/torchcodec/_core/FFMPEGCommon.h
+++ b/src/torchcodec/_core/FFMPEGCommon.h
@@ -151,9 +151,11 @@ void setDefaultChannelLayout(
     UniqueAVCodecContext& avCodecContext,
     int numChannels);
 
-void setChannelLayout(
-    UniqueAVFrame& dstAVFrame,
-    const UniqueAVCodecContext& avCodecContext);
+void setDefaultChannelLayout(UniqueAVFrame& avFrame, int numChannels);
+
+// void setChannelLayout(
+//     UniqueAVFrame& dstAVFrame,
+//     const UniqueAVCodecContext& avCodecContext);
 
 void setChannelLayout(
     UniqueAVFrame& dstAVFrame,

--- a/src/torchcodec/_core/FFMPEGCommon.h
+++ b/src/torchcodec/_core/FFMPEGCommon.h
@@ -153,9 +153,7 @@ void setDefaultChannelLayout(
 
 void setDefaultChannelLayout(UniqueAVFrame& avFrame, int numChannels);
 
-// void setChannelLayout(
-//     UniqueAVFrame& dstAVFrame,
-//     const UniqueAVCodecContext& avCodecContext);
+void validateNumChannels(const AVCodec& avCodec, int numChannels);
 
 void setChannelLayout(
     UniqueAVFrame& dstAVFrame,

--- a/src/torchcodec/_core/custom_ops.cpp
+++ b/src/torchcodec/_core/custom_ops.cpp
@@ -29,9 +29,9 @@ TORCH_LIBRARY(torchcodec_ns, m) {
       "torchcodec._core.ops", "//pytorch/torchcodec:torchcodec");
   m.def("create_from_file(str filename, str? seek_mode=None) -> Tensor");
   m.def(
-      "encode_audio_to_file(Tensor wf, int sample_rate, str filename, int? bit_rate=None) -> ()");
+      "encode_audio_to_file(Tensor wf, int sample_rate, str filename, int? bit_rate=None, int? num_channels=None) -> ()");
   m.def(
-      "encode_audio_to_tensor(Tensor wf, int sample_rate, str format, int? bit_rate=None) -> Tensor");
+      "encode_audio_to_tensor(Tensor wf, int sample_rate, str format, int? bit_rate=None, int? num_channels=None) -> Tensor");
   m.def(
       "create_from_tensor(Tensor video_tensor, str? seek_mode=None) -> Tensor");
   m.def("_convert_to_tensor(int decoder_ptr) -> Tensor");
@@ -391,8 +391,10 @@ void encode_audio_to_file(
     const at::Tensor wf,
     int64_t sample_rate,
     std::string_view file_name,
-    std::optional<int64_t> bit_rate = std::nullopt) {
-  AudioEncoder(wf, validateSampleRate(sample_rate), file_name, bit_rate)
+    std::optional<int64_t> bit_rate = std::nullopt,
+    std::optional<int64_t> num_channels = std::nullopt) {
+  AudioEncoder(
+      wf, validateSampleRate(sample_rate), file_name, bit_rate, num_channels)
       .encode();
 }
 
@@ -400,14 +402,16 @@ at::Tensor encode_audio_to_tensor(
     const at::Tensor wf,
     int64_t sample_rate,
     std::string_view format,
-    std::optional<int64_t> bit_rate = std::nullopt) {
+    std::optional<int64_t> bit_rate = std::nullopt,
+    std::optional<int64_t> num_channels = std::nullopt) {
   auto avioContextHolder = std::make_unique<AVIOToTensorContext>();
   return AudioEncoder(
              wf,
              validateSampleRate(sample_rate),
              format,
              std::move(avioContextHolder),
-             bit_rate)
+             bit_rate,
+             num_channels)
       .encodeToTensor();
 }
 

--- a/src/torchcodec/_core/ops.py
+++ b/src/torchcodec/_core/ops.py
@@ -163,14 +163,22 @@ def create_from_file_abstract(filename: str, seek_mode: Optional[str]) -> torch.
 
 @register_fake("torchcodec_ns::encode_audio_to_file")
 def encode_audio_to_file_abstract(
-    wf: torch.Tensor, sample_rate: int, filename: str, bit_rate: Optional[int] = None
+    wf: torch.Tensor,
+    sample_rate: int,
+    filename: str,
+    bit_rate: Optional[int] = None,
+    num_channels: Optional[int] = None,
 ) -> None:
     return
 
 
 @register_fake("torchcodec_ns::encode_audio_to_tensor")
 def encode_audio_to_tensor_abstract(
-    wf: torch.Tensor, sample_rate: int, format: str, bit_rate: Optional[int] = None
+    wf: torch.Tensor,
+    sample_rate: int,
+    format: str,
+    bit_rate: Optional[int] = None,
+    num_channels: Optional[int] = None,
 ) -> torch.Tensor:
     return torch.empty([], dtype=torch.long)
 

--- a/src/torchcodec/encoders/_audio_encoder.py
+++ b/src/torchcodec/encoders/_audio_encoder.py
@@ -31,12 +31,14 @@ class AudioEncoder:
         dest: Union[str, Path],
         *,
         bit_rate: Optional[int] = None,
+        num_channels: Optional[int] = None,
     ) -> None:
         _core.encode_audio_to_file(
             wf=self._samples,
             sample_rate=self._sample_rate,
             filename=dest,
             bit_rate=bit_rate,
+            num_channels=num_channels,
         )
 
     def to_tensor(
@@ -44,10 +46,12 @@ class AudioEncoder:
         format: str,
         *,
         bit_rate: Optional[int] = None,
+        num_channels: Optional[int] = None,
     ) -> Tensor:
         return _core.encode_audio_to_tensor(
             wf=self._samples,
             sample_rate=self._sample_rate,
             format=format,
             bit_rate=bit_rate,
+            num_channels=num_channels,
         )

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -6,6 +6,7 @@
 
 import io
 import os
+import re
 from functools import partial
 
 os.environ["TORCH_LOGS"] = "output_code"
@@ -1158,10 +1159,19 @@ class TestAudioEncoderOps:
                 wf=torch.rand(10, 20), sample_rate=10, filename="doesnt_matter"
             )
 
-        encode_audio_to_file(
-            wf=torch.rand(2, 10), sample_rate=16_000, filename="ok.mp3", num_channels=8
-        )
-
+        for num_channels in (0, 3):
+            with pytest.raises(
+                RuntimeError,
+                match=re.escape(
+                    f"Desired number of channels ({num_channels}) is not supported"
+                ),
+            ):
+                encode_audio_to_file(
+                    wf=torch.rand(2, 10),
+                    sample_rate=16_000,
+                    filename="ok.mp3",
+                    num_channels=num_channels,
+                )
 
     @pytest.mark.parametrize(
         "encode_method", (encode_audio_to_file, encode_audio_to_tensor)
@@ -1335,7 +1345,7 @@ class TestAudioEncoderOps:
     def test_num_channels(
         self, num_channels_input, num_channels_output, encode_method, tmp_path
     ):
-        # We just check that the num_channels parmameter is respected.
+        # We just check that the num_channels parameter is respected.
         # Correctness is checked in other tests (like test_against_cli())
 
         sample_rate = 16_000

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1158,6 +1158,11 @@ class TestAudioEncoderOps:
                 wf=torch.rand(10, 20), sample_rate=10, filename="doesnt_matter"
             )
 
+        encode_audio_to_file(
+            wf=torch.rand(2, 10), sample_rate=16_000, filename="ok.mp3", num_channels=8
+        )
+
+
     @pytest.mark.parametrize(
         "encode_method", (encode_audio_to_file, encode_audio_to_tensor)
     )
@@ -1194,8 +1199,9 @@ class TestAudioEncoderOps:
     @pytest.mark.skipif(in_fbcode(), reason="TODO: enable ffmpeg CLI")
     @pytest.mark.parametrize("asset", (NASA_AUDIO_MP3, SINE_MONO_S32))
     @pytest.mark.parametrize("bit_rate", (None, 0, 44_100, 999_999_999))
+    @pytest.mark.parametrize("num_channels", (None, 1, 2))
     @pytest.mark.parametrize("output_format", ("mp3", "wav", "flac"))
-    def test_against_cli(self, asset, bit_rate, output_format, tmp_path):
+    def test_against_cli(self, asset, bit_rate, num_channels, output_format, tmp_path):
         # Encodes samples with our encoder and with the FFmpeg CLI, and checks
         # that both decoded outputs are equal
 
@@ -1206,6 +1212,7 @@ class TestAudioEncoderOps:
         subprocess.run(
             ["ffmpeg", "-i", str(asset.path)]
             + (["-b:a", f"{bit_rate}"] if bit_rate is not None else [])
+            + (["-ac", f"{num_channels}"] if num_channels is not None else [])
             + [
                 str(encoded_by_ffmpeg),
             ],
@@ -1219,9 +1226,19 @@ class TestAudioEncoderOps:
             sample_rate=asset.sample_rate,
             filename=str(encoded_by_us),
             bit_rate=bit_rate,
+            num_channels=num_channels,
         )
 
-        rtol, atol = (0, 1e-4) if output_format == "wav" else (None, None)
+        if output_format == "wav":
+            rtol, atol = 0, 1e-4
+        elif output_format == "mp3" and asset is SINE_MONO_S32 and num_channels == 2:
+            # Not sure why, this one needs slightly higher tol. With default
+            # tolerances, the check fails on ~1% of the samples, so that's
+            # probably fine. It might be that the FFmpeg CLI doesn't rely on
+            # libswresample for converting channels?
+            rtol, atol = 0, 1e-3
+        else:
+            rtol, atol = None, None
         torch.testing.assert_close(
             self.decode(encoded_by_ffmpeg),
             self.decode(encoded_by_us),
@@ -1231,8 +1248,11 @@ class TestAudioEncoderOps:
 
     @pytest.mark.parametrize("asset", (NASA_AUDIO_MP3, SINE_MONO_S32))
     @pytest.mark.parametrize("bit_rate", (None, 0, 44_100, 999_999_999))
+    @pytest.mark.parametrize("num_channels", (None, 1, 2))
     @pytest.mark.parametrize("output_format", ("mp3", "wav", "flac"))
-    def test_tensor_against_file(self, asset, bit_rate, output_format, tmp_path):
+    def test_tensor_against_file(
+        self, asset, bit_rate, num_channels, output_format, tmp_path
+    ):
         if get_ffmpeg_major_version() == 4 and output_format == "wav":
             pytest.skip("Swresample with FFmpeg 4 doesn't work on wav files")
 
@@ -1242,6 +1262,7 @@ class TestAudioEncoderOps:
             sample_rate=asset.sample_rate,
             filename=str(encoded_file),
             bit_rate=bit_rate,
+            num_channels=num_channels,
         )
 
         encoded_tensor = encode_audio_to_tensor(
@@ -1249,6 +1270,7 @@ class TestAudioEncoderOps:
             sample_rate=asset.sample_rate,
             format=output_format,
             bit_rate=bit_rate,
+            num_channels=num_channels,
         )
 
         torch.testing.assert_close(
@@ -1304,6 +1326,42 @@ class TestAudioEncoderOps:
         torch.testing.assert_close(
             encoded_from_contiguous, encoded_from_non_contiguous, rtol=0, atol=0
         )
+
+    @pytest.mark.parametrize("num_channels_input", (1, 2))
+    @pytest.mark.parametrize("num_channels_output", (1, 2, None))
+    @pytest.mark.parametrize(
+        "encode_method", (encode_audio_to_file, encode_audio_to_tensor)
+    )
+    def test_num_channels(
+        self, num_channels_input, num_channels_output, encode_method, tmp_path
+    ):
+        # We just check that the num_channels parmameter is respected.
+        # Correctness is checked in other tests (like test_against_cli())
+
+        sample_rate = 16_000
+        source_samples = torch.rand(num_channels_input, 1_000)
+        format = "mp3"
+
+        if encode_method is encode_audio_to_file:
+            encoded_path = tmp_path / f"output.{format}"
+            encode_audio_to_file(
+                wf=source_samples,
+                sample_rate=sample_rate,
+                filename=str(encoded_path),
+                num_channels=num_channels_output,
+            )
+            encoded_source = encoded_path
+        else:
+            encoded_source = encode_audio_to_tensor(
+                wf=source_samples,
+                sample_rate=sample_rate,
+                format=format,
+                num_channels=num_channels_output,
+            )
+
+        if num_channels_output is None:
+            num_channels_output = num_channels_input
+        assert self.decode(encoded_source).shape[0] == num_channels_output
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds a `num_channels` parameter to the audio encoder, which allows users to specify the number of channels of the **encoded** data (e.g. encode a stereo tensor into a mono file).