### PR TITLE
Migrate encoder tests to public Python APIs

### DIFF
--- a/src/torchcodec/_core/Encoder.cpp
+++ b/src/torchcodec/_core/Encoder.cpp
@@ -179,7 +179,6 @@ void AudioEncoder::initializeEncoder(
 
   desiredNumChannels_ = static_cast<int>(numChannels.value_or(wf_.sizes()[0]));
   validateNumChannels(*avCodec, desiredNumChannels_);
-
   setDefaultChannelLayout(avCodecContext_, desiredNumChannels_);
 
   validateSampleRate(*avCodec, sampleRate);

--- a/src/torchcodec/_core/Encoder.h
+++ b/src/torchcodec/_core/Encoder.h
@@ -13,6 +13,9 @@ class AudioEncoder {
   // like passing 0, which results in choosing the minimum supported bit rate.
   // Passing 44_100 could result in output being 44000 if only 44000 is
   // supported.
+  //
+  // TODO-ENCODING: bundle the optional params like bitRate, numChannels, etc.
+  // into an AudioStreamOptions struct, or similar.
   AudioEncoder(
       const torch::Tensor wf,
       // The *output* sample rate. We can't really decide for the user what it
@@ -21,20 +24,23 @@ class AudioEncoder {
       // encoding will still work but audio will be distorted.
       int sampleRate,
       std::string_view fileName,
-      std::optional<int64_t> bitRate = std::nullopt);
+      std::optional<int64_t> bitRate = std::nullopt,
+      std::optional<int64_t> numChannels = std::nullopt);
   AudioEncoder(
       const torch::Tensor wf,
       int sampleRate,
       std::string_view formatName,
       std::unique_ptr<AVIOToTensorContext> avioContextHolder,
-      std::optional<int64_t> bitRate = std::nullopt);
+      std::optional<int64_t> bitRate = std::nullopt,
+      std::optional<int64_t> numChannels = std::nullopt);
   void encode();
   torch::Tensor encodeToTensor();
 
  private:
   void initializeEncoder(
       int sampleRate,
-      std::optional<int64_t> bitRate = std::nullopt);
+      std::optional<int64_t> bitRate = std::nullopt,
+      std::optional<int64_t> numChannels = std::nullopt);
   void encodeInnerLoop(
       AutoAVPacket& autoAVPacket,
       const UniqueAVFrame& srcAVFrame);
@@ -44,6 +50,9 @@ class AudioEncoder {
   UniqueAVCodecContext avCodecContext_;
   int streamIndex_;
   UniqueSwrContext swrContext_;
+  // TODO-ENCODING: desiredNumChannels should just be part of an options struct,
+  // see other TODO above.
+  int desiredNumChannels_ = -1;
 
   const torch::Tensor wf_;
 

--- a/src/torchcodec/_core/FFMPEGCommon.cpp
+++ b/src/torchcodec/_core/FFMPEGCommon.cpp
@@ -101,7 +101,7 @@ void setDefaultChannelLayout(UniqueAVFrame& avFrame, int numChannels) {
 }
 
 void validateNumChannels(const AVCodec& avCodec, int numChannels) {
-#if LIBAVFILTER_VERSION_MAJOR > 8 // FFmpeg > 5
+#if LIBAVFILTER_VERSION_MAJOR > 7 // FFmpeg > 4
   if (avCodec.ch_layouts == nullptr) {
     // If we can't validate, we must assume it'll be fine. If not, FFmpeg will
     // eventually raise.

--- a/src/torchcodec/_core/FFMPEGCommon.cpp
+++ b/src/torchcodec/_core/FFMPEGCommon.cpp
@@ -88,22 +88,34 @@ void setDefaultChannelLayout(
 #endif
 }
 
-void setChannelLayout(
-    UniqueAVFrame& dstAVFrame,
-    const UniqueAVCodecContext& avCodecContext) {
+void setDefaultChannelLayout(UniqueAVFrame& avFrame, int numChannels) {
 #if LIBAVFILTER_VERSION_MAJOR > 7 // FFmpeg > 4
-  auto status = av_channel_layout_copy(
-      &dstAVFrame->ch_layout, &avCodecContext->ch_layout);
-  TORCH_CHECK(
-      status == AVSUCCESS,
-      "Couldn't copy channel layout to avFrame: ",
-      getFFMPEGErrorStringFromErrorCode(status));
+  AVChannelLayout channel_layout;
+  av_channel_layout_default(&channel_layout, numChannels);
+  avFrame->ch_layout = channel_layout;
 #else
-  dstAVFrame->channel_layout = avCodecContext->channel_layout;
-  dstAVFrame->channels = avCodecContext->channels;
-
+  uint64_t channel_layout = av_get_default_channel_layout(numChannels);
+  avFrame->channel_layout = channel_layout;
+  avFrame->channels = numChannels;
 #endif
 }
+
+// void setChannelLayout(
+//     UniqueAVFrame& dstAVFrame,
+//     const UniqueAVCodecContext& avCodecContext) {
+// #if LIBAVFILTER_VERSION_MAJOR > 7 // FFmpeg > 4
+//   auto status = av_channel_layout_copy(
+//       &dstAVFrame->ch_layout, &avCodecContext->ch_layout);
+//   TORCH_CHECK(
+//       status == AVSUCCESS,
+//       "Couldn't copy channel layout to avFrame: ",
+//       getFFMPEGErrorStringFromErrorCode(status));
+// #else
+//   dstAVFrame->channel_layout = avCodecContext->channel_layout;
+//   dstAVFrame->channels = avCodecContext->channels;
+
+// #endif
+// }
 
 namespace {
 #if LIBAVFILTER_VERSION_MAJOR > 7 // FFmpeg > 4

--- a/src/torchcodec/_core/FFMPEGCommon.h
+++ b/src/torchcodec/_core/FFMPEGCommon.h
@@ -151,9 +151,11 @@ void setDefaultChannelLayout(
     UniqueAVCodecContext& avCodecContext,
     int numChannels);
 
-void setChannelLayout(
-    UniqueAVFrame& dstAVFrame,
-    const UniqueAVCodecContext& avCodecContext);
+void setDefaultChannelLayout(UniqueAVFrame& avFrame, int numChannels);
+
+// void setChannelLayout(
+//     UniqueAVFrame& dstAVFrame,
+//     const UniqueAVCodecContext& avCodecContext);
 
 void setChannelLayout(
     UniqueAVFrame& dstAVFrame,

--- a/src/torchcodec/_core/FFMPEGCommon.h
+++ b/src/torchcodec/_core/FFMPEGCommon.h
@@ -153,9 +153,7 @@ void setDefaultChannelLayout(
 
 void setDefaultChannelLayout(UniqueAVFrame& avFrame, int numChannels);
 
-// void setChannelLayout(
-//     UniqueAVFrame& dstAVFrame,
-//     const UniqueAVCodecContext& avCodecContext);
+void validateNumChannels(const AVCodec& avCodec, int numChannels);
 
 void setChannelLayout(
     UniqueAVFrame& dstAVFrame,

--- a/src/torchcodec/_core/custom_ops.cpp
+++ b/src/torchcodec/_core/custom_ops.cpp
@@ -29,9 +29,9 @@ TORCH_LIBRARY(torchcodec_ns, m) {
       "torchcodec._core.ops", "//pytorch/torchcodec:torchcodec");
   m.def("create_from_file(str filename, str? seek_mode=None) -> Tensor");
   m.def(
-      "encode_audio_to_file(Tensor wf, int sample_rate, str filename, int? bit_rate=None) -> ()");
+      "encode_audio_to_file(Tensor wf, int sample_rate, str filename, int? bit_rate=None, int? num_channels=None) -> ()");
   m.def(
-      "encode_audio_to_tensor(Tensor wf, int sample_rate, str format, int? bit_rate=None) -> Tensor");
+      "encode_audio_to_tensor(Tensor wf, int sample_rate, str format, int? bit_rate=None, int? num_channels=None) -> Tensor");
   m.def(
       "create_from_tensor(Tensor video_tensor, str? seek_mode=None) -> Tensor");
   m.def("_convert_to_tensor(int decoder_ptr) -> Tensor");
@@ -391,8 +391,10 @@ void encode_audio_to_file(
     const at::Tensor wf,
     int64_t sample_rate,
     std::string_view file_name,
-    std::optional<int64_t> bit_rate = std::nullopt) {
-  AudioEncoder(wf, validateSampleRate(sample_rate), file_name, bit_rate)
+    std::optional<int64_t> bit_rate = std::nullopt,
+    std::optional<int64_t> num_channels = std::nullopt) {
+  AudioEncoder(
+      wf, validateSampleRate(sample_rate), file_name, bit_rate, num_channels)
       .encode();
 }
 
@@ -400,14 +402,16 @@ at::Tensor encode_audio_to_tensor(
     const at::Tensor wf,
     int64_t sample_rate,
     std::string_view format,
-    std::optional<int64_t> bit_rate = std::nullopt) {
+    std::optional<int64_t> bit_rate = std::nullopt,
+    std::optional<int64_t> num_channels = std::nullopt) {
   auto avioContextHolder = std::make_unique<AVIOToTensorContext>();
   return AudioEncoder(
              wf,
              validateSampleRate(sample_rate),
              format,
              std::move(avioContextHolder),
-             bit_rate)
+             bit_rate,
+             num_channels)
       .encodeToTensor();
 }
 

--- a/src/torchcodec/_core/ops.py
+++ b/src/torchcodec/_core/ops.py
@@ -163,14 +163,22 @@ def create_from_file_abstract(filename: str, seek_mode: Optional[str]) -> torch.
 
 @register_fake("torchcodec_ns::encode_audio_to_file")
 def encode_audio_to_file_abstract(
-    wf: torch.Tensor, sample_rate: int, filename: str, bit_rate: Optional[int] = None
+    wf: torch.Tensor,
+    sample_rate: int,
+    filename: str,
+    bit_rate: Optional[int] = None,
+    num_channels: Optional[int] = None,
 ) -> None:
     return
 
 
 @register_fake("torchcodec_ns::encode_audio_to_tensor")
 def encode_audio_to_tensor_abstract(
-    wf: torch.Tensor, sample_rate: int, format: str, bit_rate: Optional[int] = None
+    wf: torch.Tensor,
+    sample_rate: int,
+    format: str,
+    bit_rate: Optional[int] = None,
+    num_channels: Optional[int] = None,
 ) -> torch.Tensor:
     return torch.empty([], dtype=torch.long)
 

--- a/src/torchcodec/encoders/_audio_encoder.py
+++ b/src/torchcodec/encoders/_audio_encoder.py
@@ -31,12 +31,14 @@ class AudioEncoder:
         dest: Union[str, Path],
         *,
         bit_rate: Optional[int] = None,
+        num_channels: Optional[int] = None,
     ) -> None:
         _core.encode_audio_to_file(
             wf=self._samples,
             sample_rate=self._sample_rate,
             filename=dest,
             bit_rate=bit_rate,
+            num_channels=num_channels,
         )
 
     def to_tensor(
@@ -44,10 +46,12 @@ class AudioEncoder:
         format: str,
         *,
         bit_rate: Optional[int] = None,
+        num_channels: Optional[int] = None,
     ) -> Tensor:
         return _core.encode_audio_to_tensor(
             wf=self._samples,
             sample_rate=self._sample_rate,
             format=format,
             bit_rate=bit_rate,
+            num_channels=num_channels,
         )

--- a/test/test_encoders.py
+++ b/test/test_encoders.py
@@ -1,12 +1,27 @@
 import re
+import subprocess
 
 import pytest
 import torch
+from torchcodec.decoders import AudioDecoder
 
 from torchcodec.encoders import AudioEncoder
 
+from .utils import (
+    get_ffmpeg_major_version,
+    in_fbcode,
+    NASA_AUDIO_MP3,
+    SINE_MONO_S32,
+    TestContainerFile,
+)
+
 
 class TestAudioEncoder:
+
+    def decode(self, source) -> torch.Tensor:
+        if isinstance(source, TestContainerFile):
+            source = str(source.path)
+        return AudioDecoder(source).get_all_samples().data
 
     def test_bad_input(self):
         with pytest.raises(ValueError, match="Expected samples to be a Tensor"):
@@ -39,3 +54,210 @@ class TestAudioEncoder:
             match=re.escape(f"Check the desired format? Got format={bad_format}"),
         ):
             encoder.to_tensor(format=bad_format)
+
+    @pytest.mark.parametrize("method", ("to_file", "to_tensor"))
+    def test_bad_input_parametrized(self, method):
+        valid_params = (
+            dict(dest="output.mp3") if method == "to_file" else dict(format="mp3")
+        )
+
+        decoder = AudioEncoder(self.decode(NASA_AUDIO_MP3), sample_rate=10)
+        with pytest.raises(RuntimeError, match="invalid sample rate=10"):
+            getattr(decoder, method)(**valid_params)
+
+        decoder = AudioEncoder(
+            self.decode(NASA_AUDIO_MP3), sample_rate=NASA_AUDIO_MP3.sample_rate
+        )
+        with pytest.raises(RuntimeError, match="bit_rate=-1 must be >= 0"):
+            getattr(decoder, method)(**valid_params, bit_rate=-1)
+
+        bad_num_channels = 10
+        decoder = AudioEncoder(torch.rand(bad_num_channels, 20), sample_rate=16_000)
+        with pytest.raises(
+            RuntimeError, match=f"Trying to encode {bad_num_channels} channels"
+        ):
+            getattr(decoder, method)(**valid_params)
+
+        decoder = AudioEncoder(
+            self.decode(NASA_AUDIO_MP3), sample_rate=NASA_AUDIO_MP3.sample_rate
+        )
+        for num_channels in (0, 3):
+            with pytest.raises(
+                RuntimeError,
+                match=re.escape(
+                    f"Desired number of channels ({num_channels}) is not supported"
+                ),
+            ):
+                getattr(decoder, method)(**valid_params, num_channels=num_channels)
+
+    @pytest.mark.parametrize("method", ("to_file", "to_tensor"))
+    @pytest.mark.parametrize("format", ("wav", "flac"))
+    def test_round_trip(self, method, format, tmp_path):
+        # Check that decode(encode(samples)) == samples on lossless formats
+
+        if get_ffmpeg_major_version() == 4 and format == "wav":
+            pytest.skip("Swresample with FFmpeg 4 doesn't work on wav files")
+
+        asset = NASA_AUDIO_MP3
+        source_samples = self.decode(asset)
+
+        encoder = AudioEncoder(source_samples, sample_rate=asset.sample_rate)
+
+        if method == "to_file":
+            encoded_path = str(tmp_path / f"output.{format}")
+            encoded_source = encoded_path
+            encoder.to_file(dest=encoded_path)
+        else:
+            encoded_source = encoder.to_tensor(format=format)
+            assert encoded_source.dtype == torch.uint8
+            assert encoded_source.ndim == 1
+
+        rtol, atol = (0, 1e-4) if format == "wav" else (None, None)
+        torch.testing.assert_close(
+            self.decode(encoded_source), source_samples, rtol=rtol, atol=atol
+        )
+
+    @pytest.mark.skipif(in_fbcode(), reason="TODO: enable ffmpeg CLI")
+    @pytest.mark.parametrize("asset", (NASA_AUDIO_MP3, SINE_MONO_S32))
+    @pytest.mark.parametrize("bit_rate", (None, 0, 44_100, 999_999_999))
+    @pytest.mark.parametrize("num_channels", (None, 1, 2))
+    @pytest.mark.parametrize("format", ("mp3", "wav", "flac"))
+    @pytest.mark.parametrize("method", ("to_file", "to_tensor"))
+    def test_against_cli(self, asset, bit_rate, num_channels, format, method, tmp_path):
+        # Encodes samples with our encoder and with the FFmpeg CLI, and checks
+        # that both decoded outputs are equal
+
+        if get_ffmpeg_major_version() == 4 and format == "wav":
+            pytest.skip("Swresample with FFmpeg 4 doesn't work on wav files")
+
+        encoded_by_ffmpeg = tmp_path / f"ffmpeg_output.{format}"
+        subprocess.run(
+            ["ffmpeg", "-i", str(asset.path)]
+            + (["-b:a", f"{bit_rate}"] if bit_rate is not None else [])
+            + (["-ac", f"{num_channels}"] if num_channels is not None else [])
+            + [
+                str(encoded_by_ffmpeg),
+            ],
+            capture_output=True,
+            check=True,
+        )
+
+        encoder = AudioEncoder(self.decode(asset), sample_rate=asset.sample_rate)
+        params = dict(bit_rate=bit_rate, num_channels=num_channels)
+        if method == "to_file":
+            encoded_by_us = tmp_path / f"output.{format}"
+            encoder.to_file(dest=str(encoded_by_us), **params)
+        else:
+            encoded_by_us = encoder.to_tensor(format=format, **params)
+
+        if format == "wav":
+            rtol, atol = 0, 1e-4
+        elif format == "mp3" and asset is SINE_MONO_S32 and num_channels == 2:
+            # Not sure why, this one needs slightly higher tol. With default
+            # tolerances, the check fails on ~1% of the samples, so that's
+            # probably fine. It might be that the FFmpeg CLI doesn't rely on
+            # libswresample for converting channels?
+            rtol, atol = 0, 1e-3
+        else:
+            rtol, atol = None, None
+        torch.testing.assert_close(
+            self.decode(encoded_by_ffmpeg),
+            self.decode(encoded_by_us),
+            rtol=rtol,
+            atol=atol,
+        )
+
+    @pytest.mark.parametrize("asset", (NASA_AUDIO_MP3, SINE_MONO_S32))
+    @pytest.mark.parametrize("bit_rate", (None, 0, 44_100, 999_999_999))
+    @pytest.mark.parametrize("num_channels", (None, 1, 2))
+    @pytest.mark.parametrize("format", ("mp3", "wav", "flac"))
+    def test_to_tensor_against_to_file(
+        self, asset, bit_rate, num_channels, format, tmp_path
+    ):
+        if get_ffmpeg_major_version() == 4 and format == "wav":
+            pytest.skip("Swresample with FFmpeg 4 doesn't work on wav files")
+
+        encoder = AudioEncoder(self.decode(asset), sample_rate=asset.sample_rate)
+
+        params = dict(bit_rate=bit_rate, num_channels=num_channels)
+        encoded_file = tmp_path / f"output.{format}"
+        encoder.to_file(dest=str(encoded_file), **params)
+        encoded_tensor = encoder.to_tensor(
+            format=format, bit_rate=bit_rate, num_channels=num_channels
+        )
+
+        torch.testing.assert_close(
+            self.decode(encoded_file), self.decode(encoded_tensor)
+        )
+
+    def test_encode_to_tensor_long_output(self):
+        # Check that we support re-allocating the output tensor when the encoded
+        # data is large.
+        samples = torch.rand(1, int(1e7))
+        encoded_tensor = AudioEncoder(samples, sample_rate=16_000).to_tensor(
+            format="flac", bit_rate=44_000
+        )
+
+        # Note: this should be in sync with its C++ counterpart for the test to
+        # be meaningful.
+        INITIAL_TENSOR_SIZE = 10_000_000
+        assert encoded_tensor.numel() > INITIAL_TENSOR_SIZE
+
+        torch.testing.assert_close(self.decode(encoded_tensor), samples)
+
+    def test_contiguity(self):
+        # Ensure that 2 waveforms with the same values are encoded in the same
+        # way, regardless of their memory layout. Here we encode 2 equal
+        # waveforms, one is row-aligned while the other is column-aligned.
+        # TODO: Ideally we'd be testing all encoding methods here
+
+        num_samples = 10_000  # per channel
+        contiguous_samples = torch.rand(2, num_samples).contiguous()
+        assert contiguous_samples.stride() == (num_samples, 1)
+
+        params = dict(format="flac", bit_rate=44_000)
+        encoded_from_contiguous = AudioEncoder(
+            contiguous_samples, sample_rate=16_000
+        ).to_tensor(**params)
+
+        non_contiguous_samples = contiguous_samples.T.contiguous().T
+        assert non_contiguous_samples.stride() == (1, 2)
+
+        torch.testing.assert_close(
+            contiguous_samples, non_contiguous_samples, rtol=0, atol=0
+        )
+
+        encoded_from_non_contiguous = AudioEncoder(
+            non_contiguous_samples, sample_rate=16_000
+        ).to_tensor(**params)
+
+        torch.testing.assert_close(
+            encoded_from_contiguous, encoded_from_non_contiguous, rtol=0, atol=0
+        )
+
+    @pytest.mark.parametrize("num_channels_input", (1, 2))
+    @pytest.mark.parametrize("num_channels_output", (1, 2, None))
+    @pytest.mark.parametrize("method", ("to_file", "to_tensor"))
+    def test_num_channels(
+        self, num_channels_input, num_channels_output, method, tmp_path
+    ):
+        # We just check that the num_channels parameter is respected.
+        # Correctness is checked in other tests (like test_against_cli())
+
+        sample_rate = 16_000
+        source_samples = torch.rand(num_channels_input, 1_000)
+        format = "mp3"
+
+        encoder = AudioEncoder(source_samples, sample_rate=sample_rate)
+        params = dict(num_channels=num_channels_output)
+
+        if method == "to_file":
+            encoded_path = str(tmp_path / f"output.{format}")
+            encoded_source = encoded_path
+            encoder.to_file(dest=encoded_path, **params)
+        else:
+            encoded_source = encoder.to_tensor(format=format, **params)
+
+        if num_channels_output is None:
+            num_channels_output = num_channels_input
+        assert self.decode(encoded_source).shape[0] == num_channels_output

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -6,6 +6,7 @@
 
 import io
 import os
+import re
 from functools import partial
 
 os.environ["TORCH_LOGS"] = "output_code"
@@ -1158,10 +1159,19 @@ class TestAudioEncoderOps:
                 wf=torch.rand(10, 20), sample_rate=10, filename="doesnt_matter"
             )
 
-        encode_audio_to_file(
-            wf=torch.rand(2, 10), sample_rate=16_000, filename="ok.mp3", num_channels=8
-        )
-
+        for num_channels in (0, 3):
+            with pytest.raises(
+                RuntimeError,
+                match=re.escape(
+                    f"Desired number of channels ({num_channels}) is not supported"
+                ),
+            ):
+                encode_audio_to_file(
+                    wf=torch.rand(2, 10),
+                    sample_rate=16_000,
+                    filename="ok.mp3",
+                    num_channels=num_channels,
+                )
 
     @pytest.mark.parametrize(
         "encode_method", (encode_audio_to_file, encode_audio_to_tensor)
@@ -1335,7 +1345,7 @@ class TestAudioEncoderOps:
     def test_num_channels(
         self, num_channels_input, num_channels_output, encode_method, tmp_path
     ):
-        # We just check that the num_channels parmameter is respected.
+        # We just check that the num_channels parameter is respected.
         # Correctness is checked in other tests (like test_against_cli())
 
         sample_rate = 16_000

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -6,7 +6,6 @@
 
 import io
 import os
-import re
 from functools import partial
 
 os.environ["TORCH_LOGS"] = "output_code"
@@ -28,7 +27,6 @@ from torchcodec._core import (
     create_from_file_like,
     create_from_tensor,
     encode_audio_to_file,
-    encode_audio_to_tensor,
     get_ffmpeg_library_versions,
     get_frame_at_index,
     get_frame_at_pts,
@@ -45,8 +43,6 @@ from torchcodec._core import (
 from .utils import (
     assert_frames_equal,
     cpu_and_cuda,
-    get_ffmpeg_major_version,
-    in_fbcode,
     NASA_AUDIO,
     NASA_AUDIO_MP3,
     NASA_VIDEO,
@@ -54,7 +50,6 @@ from .utils import (
     SINE_MONO_S32,
     SINE_MONO_S32_44100,
     SINE_MONO_S32_8000,
-    TestContainerFile,
 )
 
 torch._dynamo.config.capture_dynamic_output_shape_ops = True
@@ -1100,22 +1095,6 @@ class TestAudioDecoderOps:
 
 class TestAudioEncoderOps:
 
-    def decode(self, source) -> torch.Tensor:
-        if isinstance(source, torch.Tensor):
-            decoder = create_from_tensor(source, seek_mode="approximate")
-        else:
-            if isinstance(source, TestContainerFile):
-                source = str(source.path)
-            else:
-                source = str(source)
-            decoder = create_from_file(source, seek_mode="approximate")
-
-        add_audio_stream(decoder)
-        frames, *_ = get_frames_by_pts_in_range_audio(
-            decoder, start_seconds=0, stop_seconds=None
-        )
-        return frames
-
     def test_bad_input(self, tmp_path):
 
         valid_output_file = str(tmp_path / ".mp3")
@@ -1139,239 +1118,6 @@ class TestAudioEncoderOps:
             encode_audio_to_file(
                 wf=torch.rand(2, 10), sample_rate=10, filename="./file.bad_extension"
             )
-
-        with pytest.raises(RuntimeError, match="invalid sample rate=10"):
-            encode_audio_to_file(
-                wf=self.decode(NASA_AUDIO_MP3),
-                sample_rate=10,
-                filename=valid_output_file,
-            )
-        with pytest.raises(RuntimeError, match="bit_rate=-1 must be >= 0"):
-            encode_audio_to_file(
-                wf=self.decode(NASA_AUDIO_MP3),
-                sample_rate=NASA_AUDIO_MP3.sample_rate,
-                filename=valid_output_file,
-                bit_rate=-1,  # bad
-            )
-
-        with pytest.raises(RuntimeError, match="Trying to encode 10 channels"):
-            encode_audio_to_file(
-                wf=torch.rand(10, 20), sample_rate=10, filename="doesnt_matter"
-            )
-
-        for num_channels in (0, 3):
-            with pytest.raises(
-                RuntimeError,
-                match=re.escape(
-                    f"Desired number of channels ({num_channels}) is not supported"
-                ),
-            ):
-                encode_audio_to_file(
-                    wf=torch.rand(2, 10),
-                    sample_rate=16_000,
-                    filename="ok.mp3",
-                    num_channels=num_channels,
-                )
-
-    @pytest.mark.parametrize(
-        "encode_method", (encode_audio_to_file, encode_audio_to_tensor)
-    )
-    @pytest.mark.parametrize("output_format", ("wav", "flac"))
-    def test_round_trip(self, encode_method, output_format, tmp_path):
-        # Check that decode(encode(samples)) == samples on lossless formats
-
-        if get_ffmpeg_major_version() == 4 and output_format == "wav":
-            pytest.skip("Swresample with FFmpeg 4 doesn't work on wav files")
-
-        asset = NASA_AUDIO_MP3
-        source_samples = self.decode(asset)
-
-        if encode_method is encode_audio_to_file:
-            encoded_path = tmp_path / f"output.{output_format}"
-            encode_audio_to_file(
-                wf=source_samples,
-                sample_rate=asset.sample_rate,
-                filename=str(encoded_path),
-            )
-            encoded_source = encoded_path
-        else:
-            encoded_source = encode_audio_to_tensor(
-                wf=source_samples, sample_rate=asset.sample_rate, format=output_format
-            )
-            assert encoded_source.dtype == torch.uint8
-            assert encoded_source.ndim == 1
-
-        rtol, atol = (0, 1e-4) if output_format == "wav" else (None, None)
-        torch.testing.assert_close(
-            self.decode(encoded_source), source_samples, rtol=rtol, atol=atol
-        )
-
-    @pytest.mark.skipif(in_fbcode(), reason="TODO: enable ffmpeg CLI")
-    @pytest.mark.parametrize("asset", (NASA_AUDIO_MP3, SINE_MONO_S32))
-    @pytest.mark.parametrize("bit_rate", (None, 0, 44_100, 999_999_999))
-    @pytest.mark.parametrize("num_channels", (None, 1, 2))
-    @pytest.mark.parametrize("output_format", ("mp3", "wav", "flac"))
-    def test_against_cli(self, asset, bit_rate, num_channels, output_format, tmp_path):
-        # Encodes samples with our encoder and with the FFmpeg CLI, and checks
-        # that both decoded outputs are equal
-
-        if get_ffmpeg_major_version() == 4 and output_format == "wav":
-            pytest.skip("Swresample with FFmpeg 4 doesn't work on wav files")
-
-        encoded_by_ffmpeg = tmp_path / f"ffmpeg_output.{output_format}"
-        subprocess.run(
-            ["ffmpeg", "-i", str(asset.path)]
-            + (["-b:a", f"{bit_rate}"] if bit_rate is not None else [])
-            + (["-ac", f"{num_channels}"] if num_channels is not None else [])
-            + [
-                str(encoded_by_ffmpeg),
-            ],
-            capture_output=True,
-            check=True,
-        )
-
-        encoded_by_us = tmp_path / f"our_output.{output_format}"
-        encode_audio_to_file(
-            wf=self.decode(asset),
-            sample_rate=asset.sample_rate,
-            filename=str(encoded_by_us),
-            bit_rate=bit_rate,
-            num_channels=num_channels,
-        )
-
-        if output_format == "wav":
-            rtol, atol = 0, 1e-4
-        elif output_format == "mp3" and asset is SINE_MONO_S32 and num_channels == 2:
-            # Not sure why, this one needs slightly higher tol. With default
-            # tolerances, the check fails on ~1% of the samples, so that's
-            # probably fine. It might be that the FFmpeg CLI doesn't rely on
-            # libswresample for converting channels?
-            rtol, atol = 0, 1e-3
-        else:
-            rtol, atol = None, None
-        torch.testing.assert_close(
-            self.decode(encoded_by_ffmpeg),
-            self.decode(encoded_by_us),
-            rtol=rtol,
-            atol=atol,
-        )
-
-    @pytest.mark.parametrize("asset", (NASA_AUDIO_MP3, SINE_MONO_S32))
-    @pytest.mark.parametrize("bit_rate", (None, 0, 44_100, 999_999_999))
-    @pytest.mark.parametrize("num_channels", (None, 1, 2))
-    @pytest.mark.parametrize("output_format", ("mp3", "wav", "flac"))
-    def test_tensor_against_file(
-        self, asset, bit_rate, num_channels, output_format, tmp_path
-    ):
-        if get_ffmpeg_major_version() == 4 and output_format == "wav":
-            pytest.skip("Swresample with FFmpeg 4 doesn't work on wav files")
-
-        encoded_file = tmp_path / f"our_output.{output_format}"
-        encode_audio_to_file(
-            wf=self.decode(asset),
-            sample_rate=asset.sample_rate,
-            filename=str(encoded_file),
-            bit_rate=bit_rate,
-            num_channels=num_channels,
-        )
-
-        encoded_tensor = encode_audio_to_tensor(
-            wf=self.decode(asset),
-            sample_rate=asset.sample_rate,
-            format=output_format,
-            bit_rate=bit_rate,
-            num_channels=num_channels,
-        )
-
-        torch.testing.assert_close(
-            self.decode(encoded_file), self.decode(encoded_tensor)
-        )
-
-    def test_encode_to_tensor_long_output(self):
-        # Check that we support re-allocating the output tensor when the encoded
-        # data is large.
-        samples = torch.rand(1, int(1e7))
-        encoded_tensor = encode_audio_to_tensor(
-            wf=samples,
-            sample_rate=16_000,
-            format="flac",
-            bit_rate=44_000,
-        )
-        # Note: this should be in sync with its C++ counterpart for the test to
-        # be meaningful.
-        INITIAL_TENSOR_SIZE = 10_000_000
-        assert encoded_tensor.numel() > INITIAL_TENSOR_SIZE
-
-        torch.testing.assert_close(self.decode(encoded_tensor), samples)
-
-    def test_contiguity(self):
-        # Ensure that 2 waveforms with the same values are encoded in the same
-        # way, regardless of their memory layout. Here we encode 2 equal
-        # waveforms, one is row-aligned while the other is column-aligned.
-
-        num_samples = 10_000  # per channel
-        contiguous_samples = torch.rand(2, num_samples).contiguous()
-        assert contiguous_samples.stride() == (num_samples, 1)
-
-        encoded_from_contiguous = encode_audio_to_tensor(
-            wf=contiguous_samples,
-            sample_rate=16_000,
-            format="flac",
-            bit_rate=44_000,
-        )
-        non_contiguous_samples = contiguous_samples.T.contiguous().T
-        assert non_contiguous_samples.stride() == (1, 2)
-
-        torch.testing.assert_close(
-            contiguous_samples, non_contiguous_samples, rtol=0, atol=0
-        )
-
-        encoded_from_non_contiguous = encode_audio_to_tensor(
-            wf=non_contiguous_samples,
-            sample_rate=16_000,
-            format="flac",
-            bit_rate=44_000,
-        )
-
-        torch.testing.assert_close(
-            encoded_from_contiguous, encoded_from_non_contiguous, rtol=0, atol=0
-        )
-
-    @pytest.mark.parametrize("num_channels_input", (1, 2))
-    @pytest.mark.parametrize("num_channels_output", (1, 2, None))
-    @pytest.mark.parametrize(
-        "encode_method", (encode_audio_to_file, encode_audio_to_tensor)
-    )
-    def test_num_channels(
-        self, num_channels_input, num_channels_output, encode_method, tmp_path
-    ):
-        # We just check that the num_channels parameter is respected.
-        # Correctness is checked in other tests (like test_against_cli())
-
-        sample_rate = 16_000
-        source_samples = torch.rand(num_channels_input, 1_000)
-        format = "mp3"
-
-        if encode_method is encode_audio_to_file:
-            encoded_path = tmp_path / f"output.{format}"
-            encode_audio_to_file(
-                wf=source_samples,
-                sample_rate=sample_rate,
-                filename=str(encoded_path),
-                num_channels=num_channels_output,
-            )
-            encoded_source = encoded_path
-        else:
-            encoded_source = encode_audio_to_tensor(
-                wf=source_samples,
-                sample_rate=sample_rate,
-                format=format,
-                num_channels=num_channels_output,
-            )
-
-        if num_channels_output is None:
-            num_channels_output = num_channels_input
-        assert self.decode(encoded_source).shape[0] == num_channels_output
 
 
 if __name__ == "__main__":

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1158,6 +1158,11 @@ class TestAudioEncoderOps:
                 wf=torch.rand(10, 20), sample_rate=10, filename="doesnt_matter"
             )
 
+        encode_audio_to_file(
+            wf=torch.rand(2, 10), sample_rate=16_000, filename="ok.mp3", num_channels=8
+        )
+
+
     @pytest.mark.parametrize(
         "encode_method", (encode_audio_to_file, encode_audio_to_tensor)
     )
@@ -1194,8 +1199,9 @@ class TestAudioEncoderOps:
     @pytest.mark.skipif(in_fbcode(), reason="TODO: enable ffmpeg CLI")
     @pytest.mark.parametrize("asset", (NASA_AUDIO_MP3, SINE_MONO_S32))
     @pytest.mark.parametrize("bit_rate", (None, 0, 44_100, 999_999_999))
+    @pytest.mark.parametrize("num_channels", (None, 1, 2))
     @pytest.mark.parametrize("output_format", ("mp3", "wav", "flac"))
-    def test_against_cli(self, asset, bit_rate, output_format, tmp_path):
+    def test_against_cli(self, asset, bit_rate, num_channels, output_format, tmp_path):
         # Encodes samples with our encoder and with the FFmpeg CLI, and checks
         # that both decoded outputs are equal
 
@@ -1206,6 +1212,7 @@ class TestAudioEncoderOps:
         subprocess.run(
             ["ffmpeg", "-i", str(asset.path)]
             + (["-b:a", f"{bit_rate}"] if bit_rate is not None else [])
+            + (["-ac", f"{num_channels}"] if num_channels is not None else [])
             + [
                 str(encoded_by_ffmpeg),
             ],
@@ -1219,9 +1226,19 @@ class TestAudioEncoderOps:
             sample_rate=asset.sample_rate,
             filename=str(encoded_by_us),
             bit_rate=bit_rate,
+            num_channels=num_channels,
         )
 
-        rtol, atol = (0, 1e-4) if output_format == "wav" else (None, None)
+        if output_format == "wav":
+            rtol, atol = 0, 1e-4
+        elif output_format == "mp3" and asset is SINE_MONO_S32 and num_channels == 2:
+            # Not sure why, this one needs slightly higher tol. With default
+            # tolerances, the check fails on ~1% of the samples, so that's
+            # probably fine. It might be that the FFmpeg CLI doesn't rely on
+            # libswresample for converting channels?
+            rtol, atol = 0, 1e-3
+        else:
+            rtol, atol = None, None
         torch.testing.assert_close(
             self.decode(encoded_by_ffmpeg),
             self.decode(encoded_by_us),
@@ -1231,8 +1248,11 @@ class TestAudioEncoderOps:
 
     @pytest.mark.parametrize("asset", (NASA_AUDIO_MP3, SINE_MONO_S32))
     @pytest.mark.parametrize("bit_rate", (None, 0, 44_100, 999_999_999))
+    @pytest.mark.parametrize("num_channels", (None, 1, 2))
     @pytest.mark.parametrize("output_format", ("mp3", "wav", "flac"))
-    def test_tensor_against_file(self, asset, bit_rate, output_format, tmp_path):
+    def test_tensor_against_file(
+        self, asset, bit_rate, num_channels, output_format, tmp_path
+    ):
         if get_ffmpeg_major_version() == 4 and output_format == "wav":
             pytest.skip("Swresample with FFmpeg 4 doesn't work on wav files")
 
@@ -1242,6 +1262,7 @@ class TestAudioEncoderOps:
             sample_rate=asset.sample_rate,
             filename=str(encoded_file),
             bit_rate=bit_rate,
+            num_channels=num_channels,
         )
 
         encoded_tensor = encode_audio_to_tensor(
@@ -1249,6 +1270,7 @@ class TestAudioEncoderOps:
             sample_rate=asset.sample_rate,
             format=output_format,
             bit_rate=bit_rate,
+            num_channels=num_channels,
         )
 
         torch.testing.assert_close(
@@ -1304,6 +1326,42 @@ class TestAudioEncoderOps:
         torch.testing.assert_close(
             encoded_from_contiguous, encoded_from_non_contiguous, rtol=0, atol=0
         )
+
+    @pytest.mark.parametrize("num_channels_input", (1, 2))
+    @pytest.mark.parametrize("num_channels_output", (1, 2, None))
+    @pytest.mark.parametrize(
+        "encode_method", (encode_audio_to_file, encode_audio_to_tensor)
+    )
+    def test_num_channels(
+        self, num_channels_input, num_channels_output, encode_method, tmp_path
+    ):
+        # We just check that the num_channels parmameter is respected.
+        # Correctness is checked in other tests (like test_against_cli())
+
+        sample_rate = 16_000
+        source_samples = torch.rand(num_channels_input, 1_000)
+        format = "mp3"
+
+        if encode_method is encode_audio_to_file:
+            encoded_path = tmp_path / f"output.{format}"
+            encode_audio_to_file(
+                wf=source_samples,
+                sample_rate=sample_rate,
+                filename=str(encoded_path),
+                num_channels=num_channels_output,
+            )
+            encoded_source = encoded_path
+        else:
+            encoded_source = encode_audio_to_tensor(
+                wf=source_samples,
+                sample_rate=sample_rate,
+                format=format,
+                num_channels=num_channels_output,
+            )
+
+        if num_channels_output is None:
+            num_channels_output = num_channels_input
+        assert self.decode(encoded_source).shape[0] == num_channels_output
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Needs https://github.com/pytorch/torchcodec/pull/693 first, so if you want to review, it'll be easier to just look at https://github.com/pytorch/torchcodec/commit/5d9eb547de0aaa896cab00404f6cce43a9aa39d5