### PR TITLE
Unify use of 'output' and 'desired' in audio code-base

### DIFF
--- a/src/torchcodec/_core/Encoder.h
+++ b/src/torchcodec/_core/Encoder.h
@@ -50,9 +50,9 @@ class AudioEncoder {
   UniqueAVCodecContext avCodecContext_;
   int streamIndex_;
   UniqueSwrContext swrContext_;
-  // TODO-ENCODING: desiredNumChannels should just be part of an options struct,
+  // TODO-ENCODING: outNumChannels should just be part of an options struct,
   // see other TODO above.
-  int desiredNumChannels_ = -1;
+  int outNumChannels_ = -1;
 
   const torch::Tensor wf_;
 


### PR DESCRIPTION
I've been a bit slopy with the use of the `desired` and `output` prefixes in the audio stuff, which are becoming more evident as I'm working on sample rate conversions (PR to come). I want to establish a clearer convention:

- "desired" is for stuff that are desired **by the user**, e.g. `desiredNumChannels`. In C++ we should just represent this as fields in AudioStreamOptions (will create follow-up PR). It usually is an `std::optional`. When these fields are in `AudioStreamOptions` (as they should and will), we can ommit the `desired` prefix.
- "output", as in "outNumChannels" are for properties of the actual output. It can  e.g. refer to the number of channels of the decoded tensor (when decoding), or to the number of channels of the encoded data (when encoding). `outputStuff` is never an `std::optional` and it is typically set to `desiredStuff.value_or(value_of_the_source)`.