### PR TITLE
Add pytest tmp_path

### DIFF
--- a/test/test_encoders.py
+++ b/test/test_encoders.py
@@ -56,9 +56,11 @@ class TestAudioEncoder:
             encoder.to_tensor(format=bad_format)
 
     @pytest.mark.parametrize("method", ("to_file", "to_tensor"))
-    def test_bad_input_parametrized(self, method):
+    def test_bad_input_parametrized(self, method, tmp_path):
         valid_params = (
-            dict(dest="output.mp3") if method == "to_file" else dict(format="mp3")
+            dict(dest=str(tmp_path / "output.mp3"))
+            if method == "to_file"
+            else dict(format="mp3")
         )
 
         decoder = AudioEncoder(self.decode(NASA_AUDIO_MP3), sample_rate=10)


### PR DESCRIPTION
This PR adds a [tmp_path](https://docs.pytest.org/en/stable/how-to/tmp_path.html) fixture to `test_bad_input_parametrized`. By adding this argument, pytest will automatically create a temporary directory to store the decoder in when `to_file` is tested.

As a result, 'output.mp3' is not leftover after running the following test:
`pytest test -vvv -k "test_bad_input_parametrized[to_file]"`