### PR TITLE
Update C++ metadata names to match python

### DIFF
--- a/src/torchcodec/_core/Metadata.h
+++ b/src/torchcodec/_core/Metadata.h
@@ -25,9 +25,9 @@ struct StreamMetadata {
   AVMediaType mediaType;
   std::optional<AVCodecID> codecId;
   std::optional<std::string> codecName;
-  std::optional<double> durationSeconds;
+  std::optional<double> durationSecondsFromHeader;
   std::optional<double> beginStreamFromHeader;
-  std::optional<int64_t> numFrames;
+  std::optional<int64_t> numFramesFromHeader;
   std::optional<int64_t> numKeyFrames;
   std::optional<double> averageFps;
   std::optional<double> bitRate;
@@ -58,7 +58,7 @@ struct ContainerMetadata {
   int numVideoStreams = 0;
   // Note that this is the container-level duration, which is usually the max
   // of all stream durations available in the container.
-  std::optional<double> durationSeconds;
+  std::optional<double> durationSecondsFromHeader;
   // Total BitRate level information at the container level in bit/s
   std::optional<double> bitRate;
   // If set, this is the index to the default audio stream.

--- a/src/torchcodec/_core/Metadata.h
+++ b/src/torchcodec/_core/Metadata.h
@@ -37,10 +37,10 @@ struct StreamMetadata {
   std::optional<int64_t> minPtsFromScan;
   std::optional<int64_t> maxPtsFromScan;
   // These presentation timestamps are in seconds.
-  std::optional<double> minPtsSecondsFromScan;
-  std::optional<double> maxPtsSecondsFromScan;
+  std::optional<double> beginStreamSecondsFromContent;
+  std::optional<double> endStreamFromContentSeconds;
   // This can be useful for index-based seeking.
-  std::optional<int64_t> numFramesFromScan;
+  std::optional<int64_t> numFramesFromContent;
 
   // Video-only fields derived from the AVCodecContext.
   std::optional<int64_t> width;

--- a/src/torchcodec/_core/Metadata.h
+++ b/src/torchcodec/_core/Metadata.h
@@ -34,8 +34,8 @@ struct StreamMetadata {
 
   // More accurate duration, obtained by scanning the file.
   // These presentation timestamps are in time base.
-  std::optional<int64_t> minPtsFromScan;
-  std::optional<int64_t> maxPtsFromScan;
+  std::optional<int64_t> beginStreamPtsFromContent;
+  std::optional<int64_t> endStreamPtsFromContent;
   // These presentation timestamps are in seconds.
   std::optional<double> beginStreamSecondsFromContent;
   std::optional<double> endStreamSecondsFromContent;

--- a/src/torchcodec/_core/Metadata.h
+++ b/src/torchcodec/_core/Metadata.h
@@ -26,10 +26,10 @@ struct StreamMetadata {
   std::optional<AVCodecID> codecId;
   std::optional<std::string> codecName;
   std::optional<double> durationSecondsFromHeader;
-  std::optional<double> beginStreamFromHeader;
+  std::optional<double> beginStreamSecondsFromHeader;
   std::optional<int64_t> numFramesFromHeader;
   std::optional<int64_t> numKeyFrames;
-  std::optional<double> averageFps;
+  std::optional<double> averageFpsFromHeader;
   std::optional<double> bitRate;
 
   // More accurate duration, obtained by scanning the file.

--- a/src/torchcodec/_core/Metadata.h
+++ b/src/torchcodec/_core/Metadata.h
@@ -38,7 +38,7 @@ struct StreamMetadata {
   std::optional<int64_t> maxPtsFromScan;
   // These presentation timestamps are in seconds.
   std::optional<double> beginStreamSecondsFromContent;
-  std::optional<double> endStreamFromContentSeconds;
+  std::optional<double> endStreamSecondsFromContent;
   // This can be useful for index-based seeking.
   std::optional<int64_t> numFramesFromContent;
 

--- a/src/torchcodec/_core/Metadata.h
+++ b/src/torchcodec/_core/Metadata.h
@@ -37,8 +37,8 @@ struct StreamMetadata {
   std::optional<int64_t> beginStreamPtsFromContent;
   std::optional<int64_t> endStreamPtsFromContent;
   // These presentation timestamps are in seconds.
-  std::optional<double> beginStreamSecondsFromContent;
-  std::optional<double> endStreamSecondsFromContent;
+  std::optional<double> beginStreamPtsSecondsFromContent;
+  std::optional<double> endStreamPtsSecondsFromContent;
   // This can be useful for index-based seeking.
   std::optional<int64_t> numFramesFromContent;
 

--- a/src/torchcodec/_core/SingleStreamDecoder.cpp
+++ b/src/torchcodec/_core/SingleStreamDecoder.cpp
@@ -125,11 +125,11 @@ void SingleStreamDecoder::initializeDecoder() {
 
     int64_t frameCount = avStream->nb_frames;
     if (frameCount > 0) {
-      streamMetadata.numFrames = frameCount;
+      streamMetadata.numFramesFromHeader = frameCount;
     }
 
     if (avStream->duration > 0 && avStream->time_base.den > 0) {
-      streamMetadata.durationSeconds =
+      streamMetadata.durationSecondsFromHeader =
           av_q2d(avStream->time_base) * avStream->duration;
     }
     if (avStream->start_time != AV_NOPTS_VALUE) {
@@ -163,7 +163,7 @@ void SingleStreamDecoder::initializeDecoder() {
 
   if (formatContext_->duration > 0) {
     AVRational defaultTimeBase{1, AV_TIME_BASE};
-    containerMetadata_.durationSeconds =
+    containerMetadata_.durationSecondsFromHeader =
         ptsToSeconds(formatContext_->duration, defaultTimeBase);
   }
 
@@ -1463,9 +1463,9 @@ int64_t SingleStreamDecoder::getNumFrames(
       return streamMetadata.numFramesFromScan.value();
     case SeekMode::approximate: {
       TORCH_CHECK(
-          streamMetadata.numFrames.has_value(),
+          streamMetadata.numFramesFromHeader.has_value(),
           "Cannot use approximate mode since we couldn't find the number of frames from the metadata.");
-      return streamMetadata.numFrames.value();
+      return streamMetadata.numFramesFromHeader.value();
     }
     default:
       throw std::runtime_error("Unknown SeekMode");
@@ -1491,9 +1491,9 @@ double SingleStreamDecoder::getMaxSeconds(
       return streamMetadata.maxPtsSecondsFromScan.value();
     case SeekMode::approximate: {
       TORCH_CHECK(
-          streamMetadata.durationSeconds.has_value(),
+          streamMetadata.durationSecondsFromHeader.has_value(),
           "Cannot use approximate mode since we couldn't find the duration from the metadata.");
-      return streamMetadata.durationSeconds.value();
+      return streamMetadata.durationSecondsFromHeader.value();
     }
     default:
       throw std::runtime_error("Unknown SeekMode");

--- a/src/torchcodec/_core/SingleStreamDecoder.cpp
+++ b/src/torchcodec/_core/SingleStreamDecoder.cpp
@@ -1490,10 +1490,7 @@ std::optional<int64_t> SingleStreamDecoder::getNumFrames(
     case SeekMode::exact:
       return streamMetadata.numFramesFromContent.value();
     case SeekMode::approximate: {
-      TORCH_CHECK(
-          streamMetadata.numFramesFromHeader.has_value(),
-          "Cannot use approximate mode since we couldn't find the number of frames from the metadata.");
-      return streamMetadata.numFramesFromHeader.value();
+      return streamMetadata.numFramesFromHeader;
     }
     default:
       throw std::runtime_error("Unknown SeekMode");
@@ -1518,10 +1515,7 @@ std::optional<double> SingleStreamDecoder::getMaxSeconds(
     case SeekMode::exact:
       return streamMetadata.endStreamPtsSecondsFromContent.value();
     case SeekMode::approximate: {
-      TORCH_CHECK(
-          streamMetadata.durationSecondsFromHeader.has_value(),
-          "Cannot use approximate mode since we couldn't find the duration from the metadata.");
-      return streamMetadata.durationSecondsFromHeader.value();
+      return streamMetadata.durationSecondsFromHeader;
     }
     default:
       throw std::runtime_error("Unknown SeekMode");

--- a/src/torchcodec/_core/SingleStreamDecoder.cpp
+++ b/src/torchcodec/_core/SingleStreamDecoder.cpp
@@ -236,10 +236,11 @@ void SingleStreamDecoder::scanFileAndUpdateMetadataAndIndex() {
     // record its relevant metadata.
     int streamIndex = packet->stream_index;
     auto& streamMetadata = containerMetadata_.allStreamMetadata[streamIndex];
-    streamMetadata.minPtsFromScan = std::min(
-        streamMetadata.minPtsFromScan.value_or(INT64_MAX), getPtsOrDts(packet));
-    streamMetadata.maxPtsFromScan = std::max(
-        streamMetadata.maxPtsFromScan.value_or(INT64_MIN),
+    streamMetadata.beginStreamPtsFromContent = std::min(
+        streamMetadata.beginStreamPtsFromContent.value_or(INT64_MAX),
+        getPtsOrDts(packet));
+    streamMetadata.endStreamPtsFromContent = std::max(
+        streamMetadata.endStreamPtsFromContent.value_or(INT64_MIN),
         getPtsOrDts(packet) + packet->duration);
     streamMetadata.numFramesFromContent =
         streamMetadata.numFramesFromContent.value_or(0) + 1;
@@ -265,13 +266,14 @@ void SingleStreamDecoder::scanFileAndUpdateMetadataAndIndex() {
     streamMetadata.numFramesFromContent =
         streamInfos_[streamIndex].allFrames.size();
 
-    if (streamMetadata.minPtsFromScan.has_value()) {
+    if (streamMetadata.beginStreamPtsFromContent.has_value()) {
       streamMetadata.beginStreamSecondsFromContent =
-          *streamMetadata.minPtsFromScan * av_q2d(avStream->time_base);
+          *streamMetadata.beginStreamPtsFromContent *
+          av_q2d(avStream->time_base);
     }
-    if (streamMetadata.maxPtsFromScan.has_value()) {
+    if (streamMetadata.endStreamPtsFromContent.has_value()) {
       streamMetadata.endStreamSecondsFromContent =
-          *streamMetadata.maxPtsFromScan * av_q2d(avStream->time_base);
+          *streamMetadata.endStreamPtsFromContent * av_q2d(avStream->time_base);
     }
   }
 

--- a/src/torchcodec/_core/SingleStreamDecoder.cpp
+++ b/src/torchcodec/_core/SingleStreamDecoder.cpp
@@ -270,7 +270,7 @@ void SingleStreamDecoder::scanFileAndUpdateMetadataAndIndex() {
           *streamMetadata.minPtsFromScan * av_q2d(avStream->time_base);
     }
     if (streamMetadata.maxPtsFromScan.has_value()) {
-      streamMetadata.endStreamFromContentSeconds =
+      streamMetadata.endStreamSecondsFromContent =
           *streamMetadata.maxPtsFromScan * av_q2d(avStream->time_base);
     }
   }
@@ -1489,7 +1489,7 @@ double SingleStreamDecoder::getMaxSeconds(
     const StreamMetadata& streamMetadata) {
   switch (seekMode_) {
     case SeekMode::exact:
-      return streamMetadata.endStreamFromContentSeconds.value();
+      return streamMetadata.endStreamSecondsFromContent.value();
     case SeekMode::approximate: {
       TORCH_CHECK(
           streamMetadata.durationSecondsFromHeader.has_value(),

--- a/src/torchcodec/_core/SingleStreamDecoder.cpp
+++ b/src/torchcodec/_core/SingleStreamDecoder.cpp
@@ -267,12 +267,12 @@ void SingleStreamDecoder::scanFileAndUpdateMetadataAndIndex() {
         streamInfos_[streamIndex].allFrames.size();
 
     if (streamMetadata.beginStreamPtsFromContent.has_value()) {
-      streamMetadata.beginStreamSecondsFromContent =
+      streamMetadata.beginStreamPtsSecondsFromContent =
           *streamMetadata.beginStreamPtsFromContent *
           av_q2d(avStream->time_base);
     }
     if (streamMetadata.endStreamPtsFromContent.has_value()) {
-      streamMetadata.endStreamSecondsFromContent =
+      streamMetadata.endStreamPtsSecondsFromContent =
           *streamMetadata.endStreamPtsFromContent * av_q2d(avStream->time_base);
     }
   }
@@ -1479,7 +1479,7 @@ double SingleStreamDecoder::getMinSeconds(
     const StreamMetadata& streamMetadata) {
   switch (seekMode_) {
     case SeekMode::exact:
-      return streamMetadata.beginStreamSecondsFromContent.value();
+      return streamMetadata.beginStreamPtsSecondsFromContent.value();
     case SeekMode::approximate:
       return 0;
     default:
@@ -1491,7 +1491,7 @@ double SingleStreamDecoder::getMaxSeconds(
     const StreamMetadata& streamMetadata) {
   switch (seekMode_) {
     case SeekMode::exact:
-      return streamMetadata.endStreamSecondsFromContent.value();
+      return streamMetadata.endStreamPtsSecondsFromContent.value();
     case SeekMode::approximate: {
       TORCH_CHECK(
           streamMetadata.durationSecondsFromHeader.has_value(),

--- a/src/torchcodec/_core/SingleStreamDecoder.h
+++ b/src/torchcodec/_core/SingleStreamDecoder.h
@@ -121,7 +121,7 @@ class SingleStreamDecoder {
   //
   // Valid values for startSeconds and stopSeconds are:
   //
-  //   [minPtsSecondsFromScan, maxPtsSecondsFromScan)
+  //   [beginStreamSecondsFromContent, maxPtsSecondsFromScan)
   FrameBatchOutput getFramesPlayedInRange(
       double startSeconds,
       double stopSeconds);

--- a/src/torchcodec/_core/SingleStreamDecoder.h
+++ b/src/torchcodec/_core/SingleStreamDecoder.h
@@ -121,7 +121,7 @@ class SingleStreamDecoder {
   //
   // Valid values for startSeconds and stopSeconds are:
   //
-  //   [beginStreamSecondsFromContent, endStreamSecondsFromContent)
+  //   [beginStreamPtsSecondsFromContent, endStreamPtsSecondsFromContent)
   FrameBatchOutput getFramesPlayedInRange(
       double startSeconds,
       double stopSeconds);

--- a/src/torchcodec/_core/SingleStreamDecoder.h
+++ b/src/torchcodec/_core/SingleStreamDecoder.h
@@ -121,7 +121,7 @@ class SingleStreamDecoder {
   //
   // Valid values for startSeconds and stopSeconds are:
   //
-  //   [beginStreamSecondsFromContent, maxPtsSecondsFromScan)
+  //   [beginStreamSecondsFromContent, endStreamSecondsFromContent)
   FrameBatchOutput getFramesPlayedInRange(
       double startSeconds,
       double stopSeconds);

--- a/src/torchcodec/_core/_metadata.py
+++ b/src/torchcodec/_core/_metadata.py
@@ -225,9 +225,9 @@ def get_container_metadata(decoder: torch.Tensor) -> ContainerMetadata:
     for stream_index in range(container_dict["numStreams"]):
         stream_dict = json.loads(_get_stream_json_metadata(decoder, stream_index))
         common_meta = dict(
-            duration_seconds_from_header=stream_dict.get("durationSeconds"),
+            duration_seconds_from_header=stream_dict.get("durationSecondsFromHeader"),
             bit_rate=stream_dict.get("bitRate"),
-            begin_stream_seconds_from_header=stream_dict.get("beginStreamFromHeader"),
+            begin_stream_seconds_from_header=stream_dict.get("beginStreamSecondsFromHeader"),
             codec=stream_dict.get("codec"),
             stream_index=stream_index,
         )
@@ -242,9 +242,9 @@ def get_container_metadata(decoder: torch.Tensor) -> ContainerMetadata:
                     ),
                     width=stream_dict.get("width"),
                     height=stream_dict.get("height"),
-                    num_frames_from_header=stream_dict.get("numFrames"),
+                    num_frames_from_header=stream_dict.get("numFramesFromHeader"),
                     num_frames_from_content=stream_dict.get("numFramesFromScan"),
-                    average_fps_from_header=stream_dict.get("averageFps"),
+                    average_fps_from_header=stream_dict.get("averageFpsFromHeader"),
                     **common_meta,
                 )
             )
@@ -264,7 +264,7 @@ def get_container_metadata(decoder: torch.Tensor) -> ContainerMetadata:
             streams_metadata.append(StreamMetadata(**common_meta))
 
     return ContainerMetadata(
-        duration_seconds_from_header=container_dict.get("durationSeconds"),
+        duration_seconds_from_header=container_dict.get("durationSecondsFromHeader"),
         bit_rate_from_header=container_dict.get("bitRate"),
         best_video_stream_index=container_dict.get("bestVideoStreamIndex"),
         best_audio_stream_index=container_dict.get("bestAudioStreamIndex"),

--- a/src/torchcodec/_core/_metadata.py
+++ b/src/torchcodec/_core/_metadata.py
@@ -240,7 +240,7 @@ def get_container_metadata(decoder: torch.Tensor) -> ContainerMetadata:
                         "beginStreamSecondsFromContent"
                     ),
                     end_stream_seconds_from_content=stream_dict.get(
-                        "endStreamFromContentSeconds"
+                        "endStreamSecondsFromContent"
                     ),
                     width=stream_dict.get("width"),
                     height=stream_dict.get("height"),

--- a/src/torchcodec/_core/_metadata.py
+++ b/src/torchcodec/_core/_metadata.py
@@ -227,7 +227,9 @@ def get_container_metadata(decoder: torch.Tensor) -> ContainerMetadata:
         common_meta = dict(
             duration_seconds_from_header=stream_dict.get("durationSecondsFromHeader"),
             bit_rate=stream_dict.get("bitRate"),
-            begin_stream_seconds_from_header=stream_dict.get("beginStreamSecondsFromHeader"),
+            begin_stream_seconds_from_header=stream_dict.get(
+                "beginStreamSecondsFromHeader"
+            ),
             codec=stream_dict.get("codec"),
             stream_index=stream_index,
         )
@@ -235,15 +237,15 @@ def get_container_metadata(decoder: torch.Tensor) -> ContainerMetadata:
             streams_metadata.append(
                 VideoStreamMetadata(
                     begin_stream_seconds_from_content=stream_dict.get(
-                        "minPtsSecondsFromScan"
+                        "beginStreamSecondsFromContent"
                     ),
                     end_stream_seconds_from_content=stream_dict.get(
-                        "maxPtsSecondsFromScan"
+                        "endStreamFromContentSeconds"
                     ),
                     width=stream_dict.get("width"),
                     height=stream_dict.get("height"),
                     num_frames_from_header=stream_dict.get("numFramesFromHeader"),
-                    num_frames_from_content=stream_dict.get("numFramesFromScan"),
+                    num_frames_from_content=stream_dict.get("numFramesFromContent"),
                     average_fps_from_header=stream_dict.get("averageFpsFromHeader"),
                     **common_meta,
                 )

--- a/src/torchcodec/_core/custom_ops.cpp
+++ b/src/torchcodec/_core/custom_ops.cpp
@@ -460,11 +460,7 @@ std::string get_json_metadata(at::Tensor& decoder) {
   if (maybeBestVideoStreamIndex.has_value() &&
       videoMetadata.allStreamMetadata[*maybeBestVideoStreamIndex]
           .durationSecondsFromHeader.has_value()) {
-<<<<<<< HEAD
-            durationSecondsFromHeader =
-=======
     durationSecondsFromHeader =
->>>>>>> e932590 (Update C++ metadata names to match python)
         videoMetadata.allStreamMetadata[*maybeBestVideoStreamIndex]
             .durationSecondsFromHeader.value_or(0);
   } else {

--- a/src/torchcodec/_core/custom_ops.cpp
+++ b/src/torchcodec/_core/custom_ops.cpp
@@ -489,9 +489,9 @@ std::string get_json_metadata(at::Tensor& decoder) {
       metadataMap["beginStreamSecondsFromContent"] =
           std::to_string(*streamMetadata.beginStreamSecondsFromContent);
     }
-    if (streamMetadata.endStreamFromContentSeconds.has_value()) {
-      metadataMap["endStreamFromContentSeconds"] =
-          std::to_string(*streamMetadata.endStreamFromContentSeconds);
+    if (streamMetadata.endStreamSecondsFromContent.has_value()) {
+      metadataMap["endStreamSecondsFromContent"] =
+          std::to_string(*streamMetadata.endStreamSecondsFromContent);
     }
     if (streamMetadata.codecName.has_value()) {
       metadataMap["codec"] = quoteValue(streamMetadata.codecName.value());
@@ -590,9 +590,9 @@ std::string get_stream_json_metadata(
     map["beginStreamSecondsFromContent"] =
         std::to_string(*streamMetadata.beginStreamSecondsFromContent);
   }
-  if (streamMetadata.endStreamFromContentSeconds.has_value()) {
-    map["endStreamFromContentSeconds"] =
-        std::to_string(*streamMetadata.endStreamFromContentSeconds);
+  if (streamMetadata.endStreamSecondsFromContent.has_value()) {
+    map["endStreamSecondsFromContent"] =
+        std::to_string(*streamMetadata.endStreamSecondsFromContent);
   }
   if (streamMetadata.codecName.has_value()) {
     map["codec"] = quoteValue(streamMetadata.codecName.value());

--- a/src/torchcodec/_core/custom_ops.cpp
+++ b/src/torchcodec/_core/custom_ops.cpp
@@ -460,14 +460,20 @@ std::string get_json_metadata(at::Tensor& decoder) {
   if (maybeBestVideoStreamIndex.has_value() &&
       videoMetadata.allStreamMetadata[*maybeBestVideoStreamIndex]
           .durationSecondsFromHeader.has_value()) {
+<<<<<<< HEAD
             durationSecondsFromHeader =
+=======
+    durationSecondsFromHeader =
+>>>>>>> e932590 (Update C++ metadata names to match python)
         videoMetadata.allStreamMetadata[*maybeBestVideoStreamIndex]
             .durationSecondsFromHeader.value_or(0);
   } else {
     // Fallback to container-level duration if stream duration is not found.
-    durationSecondsFromHeader = videoMetadata.durationSecondsFromHeader.value_or(0);
+    durationSecondsFromHeader =
+        videoMetadata.durationSecondsFromHeader.value_or(0);
   }
-  metadataMap["durationSecondsFromHeader"] = std::to_string(durationSecondsFromHeader);
+  metadataMap["durationSecondsFromHeader"] =
+      std::to_string(durationSecondsFromHeader);
 
   if (videoMetadata.bitRate.has_value()) {
     metadataMap["bitRate"] = std::to_string(videoMetadata.bitRate.value());
@@ -479,8 +485,9 @@ std::string get_json_metadata(at::Tensor& decoder) {
     if (streamMetadata.numFramesFromScan.has_value()) {
       metadataMap["numFrames"] =
           std::to_string(*streamMetadata.numFramesFromScan);
-    } else if (streamMetadata.numFrames.has_value()) {
-      metadataMap["numFrames"] = std::to_string(*streamMetadata.numFrames);
+    } else if (streamMetadata.numFramesFromHeader.has_value()) {
+      metadataMap["numFrames"] =
+          std::to_string(*streamMetadata.numFramesFromHeader);
     }
     if (streamMetadata.minPtsSecondsFromScan.has_value()) {
       metadataMap["minPtsSecondsFromScan"] =
@@ -499,8 +506,9 @@ std::string get_json_metadata(at::Tensor& decoder) {
     if (streamMetadata.height.has_value()) {
       metadataMap["height"] = std::to_string(*streamMetadata.height);
     }
-    if (streamMetadata.averageFps.has_value()) {
-      metadataMap["averageFps"] = std::to_string(*streamMetadata.averageFps);
+    if (streamMetadata.averageFpsFromHeader.has_value()) {
+      metadataMap["averageFpsFromHeader"] =
+          std::to_string(*streamMetadata.averageFpsFromHeader);
     }
   }
   if (videoMetadata.bestVideoStreamIndex.has_value()) {
@@ -524,7 +532,8 @@ std::string get_container_json_metadata(at::Tensor& decoder) {
   std::map<std::string, std::string> map;
 
   if (containerMetadata.durationSecondsFromHeader.has_value()) {
-    map["durationSecondsFromHeader"] = std::to_string(*containerMetadata.durationSecondsFromHeader);
+    map["durationSecondsFromHeader"] =
+        std::to_string(*containerMetadata.durationSecondsFromHeader);
   }
 
   if (containerMetadata.bitRate.has_value()) {
@@ -563,7 +572,8 @@ std::string get_stream_json_metadata(
   std::map<std::string, std::string> map;
 
   if (streamMetadata.durationSecondsFromHeader.has_value()) {
-    map["durationSecondsFromHeader"] = std::to_string(*streamMetadata.durationSecondsFromHeader);
+    map["durationSecondsFromHeader"] =
+        std::to_string(*streamMetadata.durationSecondsFromHeader);
   }
   if (streamMetadata.bitRate.has_value()) {
     map["bitRate"] = std::to_string(*streamMetadata.bitRate);
@@ -573,11 +583,12 @@ std::string get_stream_json_metadata(
         std::to_string(*streamMetadata.numFramesFromScan);
   }
   if (streamMetadata.numFramesFromHeader.has_value()) {
-    map["numFramesFromHeader"] = std::to_string(*streamMetadata.numFramesFromHeader);
+    map["numFramesFromHeader"] =
+        std::to_string(*streamMetadata.numFramesFromHeader);
   }
-  if (streamMetadata.beginStreamFromHeader.has_value()) {
+  if (streamMetadata.beginStreamSecondsFromHeader.has_value()) {
     map["beginStreamSecondsFromHeader"] =
-        std::to_string(*streamMetadata.beginStreamFromHeader);
+        std::to_string(*streamMetadata.beginStreamSecondsFromHeader);
   }
   if (streamMetadata.minPtsSecondsFromScan.has_value()) {
     map["minPtsSecondsFromScan"] =
@@ -596,8 +607,9 @@ std::string get_stream_json_metadata(
   if (streamMetadata.height.has_value()) {
     map["height"] = std::to_string(*streamMetadata.height);
   }
-  if (streamMetadata.averageFps.has_value()) {
-    map["averageFpsFromHeader"] = std::to_string(*streamMetadata.averageFps);
+  if (streamMetadata.averageFpsFromHeader.has_value()) {
+    map["averageFpsFromHeader"] =
+        std::to_string(*streamMetadata.averageFpsFromHeader);
   }
   if (streamMetadata.sampleRate.has_value()) {
     map["sampleRate"] = std::to_string(*streamMetadata.sampleRate);

--- a/src/torchcodec/_core/custom_ops.cpp
+++ b/src/torchcodec/_core/custom_ops.cpp
@@ -485,13 +485,13 @@ std::string get_json_metadata(at::Tensor& decoder) {
       metadataMap["numFramesFromHeader"] =
           std::to_string(*streamMetadata.numFramesFromHeader);
     }
-    if (streamMetadata.beginStreamSecondsFromContent.has_value()) {
+    if (streamMetadata.beginStreamPtsSecondsFromContent.has_value()) {
       metadataMap["beginStreamSecondsFromContent"] =
-          std::to_string(*streamMetadata.beginStreamSecondsFromContent);
+          std::to_string(*streamMetadata.beginStreamPtsSecondsFromContent);
     }
-    if (streamMetadata.endStreamSecondsFromContent.has_value()) {
+    if (streamMetadata.endStreamPtsSecondsFromContent.has_value()) {
       metadataMap["endStreamSecondsFromContent"] =
-          std::to_string(*streamMetadata.endStreamSecondsFromContent);
+          std::to_string(*streamMetadata.endStreamPtsSecondsFromContent);
     }
     if (streamMetadata.codecName.has_value()) {
       metadataMap["codec"] = quoteValue(streamMetadata.codecName.value());
@@ -586,13 +586,13 @@ std::string get_stream_json_metadata(
     map["beginStreamSecondsFromHeader"] =
         std::to_string(*streamMetadata.beginStreamSecondsFromHeader);
   }
-  if (streamMetadata.beginStreamSecondsFromContent.has_value()) {
+  if (streamMetadata.beginStreamPtsSecondsFromContent.has_value()) {
     map["beginStreamSecondsFromContent"] =
-        std::to_string(*streamMetadata.beginStreamSecondsFromContent);
+        std::to_string(*streamMetadata.beginStreamPtsSecondsFromContent);
   }
-  if (streamMetadata.endStreamSecondsFromContent.has_value()) {
+  if (streamMetadata.endStreamPtsSecondsFromContent.has_value()) {
     map["endStreamSecondsFromContent"] =
-        std::to_string(*streamMetadata.endStreamSecondsFromContent);
+        std::to_string(*streamMetadata.endStreamPtsSecondsFromContent);
   }
   if (streamMetadata.codecName.has_value()) {
     map["codec"] = quoteValue(streamMetadata.codecName.value());

--- a/src/torchcodec/_core/custom_ops.cpp
+++ b/src/torchcodec/_core/custom_ops.cpp
@@ -456,18 +456,18 @@ std::string get_json_metadata(at::Tensor& decoder) {
 
   std::map<std::string, std::string> metadataMap;
   // serialize the metadata into a string std::stringstream ss;
-  double durationSeconds = 0;
+  double durationSecondsFromHeader = 0;
   if (maybeBestVideoStreamIndex.has_value() &&
       videoMetadata.allStreamMetadata[*maybeBestVideoStreamIndex]
-          .durationSeconds.has_value()) {
-    durationSeconds =
+          .durationSecondsFromHeader.has_value()) {
+            durationSecondsFromHeader =
         videoMetadata.allStreamMetadata[*maybeBestVideoStreamIndex]
-            .durationSeconds.value_or(0);
+            .durationSecondsFromHeader.value_or(0);
   } else {
     // Fallback to container-level duration if stream duration is not found.
-    durationSeconds = videoMetadata.durationSeconds.value_or(0);
+    durationSecondsFromHeader = videoMetadata.durationSecondsFromHeader.value_or(0);
   }
-  metadataMap["durationSeconds"] = std::to_string(durationSeconds);
+  metadataMap["durationSecondsFromHeader"] = std::to_string(durationSecondsFromHeader);
 
   if (videoMetadata.bitRate.has_value()) {
     metadataMap["bitRate"] = std::to_string(videoMetadata.bitRate.value());
@@ -523,8 +523,8 @@ std::string get_container_json_metadata(at::Tensor& decoder) {
 
   std::map<std::string, std::string> map;
 
-  if (containerMetadata.durationSeconds.has_value()) {
-    map["durationSeconds"] = std::to_string(*containerMetadata.durationSeconds);
+  if (containerMetadata.durationSecondsFromHeader.has_value()) {
+    map["durationSecondsFromHeader"] = std::to_string(*containerMetadata.durationSecondsFromHeader);
   }
 
   if (containerMetadata.bitRate.has_value()) {
@@ -562,8 +562,8 @@ std::string get_stream_json_metadata(
 
   std::map<std::string, std::string> map;
 
-  if (streamMetadata.durationSeconds.has_value()) {
-    map["durationSeconds"] = std::to_string(*streamMetadata.durationSeconds);
+  if (streamMetadata.durationSecondsFromHeader.has_value()) {
+    map["durationSecondsFromHeader"] = std::to_string(*streamMetadata.durationSecondsFromHeader);
   }
   if (streamMetadata.bitRate.has_value()) {
     map["bitRate"] = std::to_string(*streamMetadata.bitRate);
@@ -572,11 +572,11 @@ std::string get_stream_json_metadata(
     map["numFramesFromScan"] =
         std::to_string(*streamMetadata.numFramesFromScan);
   }
-  if (streamMetadata.numFrames.has_value()) {
-    map["numFrames"] = std::to_string(*streamMetadata.numFrames);
+  if (streamMetadata.numFramesFromHeader.has_value()) {
+    map["numFramesFromHeader"] = std::to_string(*streamMetadata.numFramesFromHeader);
   }
   if (streamMetadata.beginStreamFromHeader.has_value()) {
-    map["beginStreamFromHeader"] =
+    map["beginStreamSecondsFromHeader"] =
         std::to_string(*streamMetadata.beginStreamFromHeader);
   }
   if (streamMetadata.minPtsSecondsFromScan.has_value()) {
@@ -597,7 +597,7 @@ std::string get_stream_json_metadata(
     map["height"] = std::to_string(*streamMetadata.height);
   }
   if (streamMetadata.averageFps.has_value()) {
-    map["averageFps"] = std::to_string(*streamMetadata.averageFps);
+    map["averageFpsFromHeader"] = std::to_string(*streamMetadata.averageFps);
   }
   if (streamMetadata.sampleRate.has_value()) {
     map["sampleRate"] = std::to_string(*streamMetadata.sampleRate);

--- a/src/torchcodec/_core/custom_ops.cpp
+++ b/src/torchcodec/_core/custom_ops.cpp
@@ -478,20 +478,20 @@ std::string get_json_metadata(at::Tensor& decoder) {
   if (maybeBestVideoStreamIndex.has_value()) {
     auto streamMetadata =
         videoMetadata.allStreamMetadata[*maybeBestVideoStreamIndex];
-    if (streamMetadata.numFramesFromScan.has_value()) {
+    if (streamMetadata.numFramesFromContent.has_value()) {
       metadataMap["numFramesFromHeader"] =
-          std::to_string(*streamMetadata.numFramesFromScan);
+          std::to_string(*streamMetadata.numFramesFromContent);
     } else if (streamMetadata.numFramesFromHeader.has_value()) {
       metadataMap["numFramesFromHeader"] =
           std::to_string(*streamMetadata.numFramesFromHeader);
     }
-    if (streamMetadata.minPtsSecondsFromScan.has_value()) {
-      metadataMap["minPtsSecondsFromScan"] =
-          std::to_string(*streamMetadata.minPtsSecondsFromScan);
+    if (streamMetadata.beginStreamSecondsFromContent.has_value()) {
+      metadataMap["beginStreamSecondsFromContent"] =
+          std::to_string(*streamMetadata.beginStreamSecondsFromContent);
     }
-    if (streamMetadata.maxPtsSecondsFromScan.has_value()) {
-      metadataMap["maxPtsSecondsFromScan"] =
-          std::to_string(*streamMetadata.maxPtsSecondsFromScan);
+    if (streamMetadata.endStreamFromContentSeconds.has_value()) {
+      metadataMap["endStreamFromContentSeconds"] =
+          std::to_string(*streamMetadata.endStreamFromContentSeconds);
     }
     if (streamMetadata.codecName.has_value()) {
       metadataMap["codec"] = quoteValue(streamMetadata.codecName.value());
@@ -574,9 +574,9 @@ std::string get_stream_json_metadata(
   if (streamMetadata.bitRate.has_value()) {
     map["bitRate"] = std::to_string(*streamMetadata.bitRate);
   }
-  if (streamMetadata.numFramesFromScan.has_value()) {
-    map["numFramesFromScan"] =
-        std::to_string(*streamMetadata.numFramesFromScan);
+  if (streamMetadata.numFramesFromContent.has_value()) {
+    map["numFramesFromContent"] =
+        std::to_string(*streamMetadata.numFramesFromContent);
   }
   if (streamMetadata.numFramesFromHeader.has_value()) {
     map["numFramesFromHeader"] =
@@ -586,13 +586,13 @@ std::string get_stream_json_metadata(
     map["beginStreamSecondsFromHeader"] =
         std::to_string(*streamMetadata.beginStreamSecondsFromHeader);
   }
-  if (streamMetadata.minPtsSecondsFromScan.has_value()) {
-    map["minPtsSecondsFromScan"] =
-        std::to_string(*streamMetadata.minPtsSecondsFromScan);
+  if (streamMetadata.beginStreamSecondsFromContent.has_value()) {
+    map["beginStreamSecondsFromContent"] =
+        std::to_string(*streamMetadata.beginStreamSecondsFromContent);
   }
-  if (streamMetadata.maxPtsSecondsFromScan.has_value()) {
-    map["maxPtsSecondsFromScan"] =
-        std::to_string(*streamMetadata.maxPtsSecondsFromScan);
+  if (streamMetadata.endStreamFromContentSeconds.has_value()) {
+    map["endStreamFromContentSeconds"] =
+        std::to_string(*streamMetadata.endStreamFromContentSeconds);
   }
   if (streamMetadata.codecName.has_value()) {
     map["codec"] = quoteValue(streamMetadata.codecName.value());

--- a/src/torchcodec/_core/custom_ops.cpp
+++ b/src/torchcodec/_core/custom_ops.cpp
@@ -479,10 +479,10 @@ std::string get_json_metadata(at::Tensor& decoder) {
     auto streamMetadata =
         videoMetadata.allStreamMetadata[*maybeBestVideoStreamIndex];
     if (streamMetadata.numFramesFromScan.has_value()) {
-      metadataMap["numFrames"] =
+      metadataMap["numFramesFromHeader"] =
           std::to_string(*streamMetadata.numFramesFromScan);
     } else if (streamMetadata.numFramesFromHeader.has_value()) {
-      metadataMap["numFrames"] =
+      metadataMap["numFramesFromHeader"] =
           std::to_string(*streamMetadata.numFramesFromHeader);
     }
     if (streamMetadata.minPtsSecondsFromScan.has_value()) {

--- a/src/torchcodec/_samplers/video_clip_sampler.py
+++ b/src/torchcodec/_samplers/video_clip_sampler.py
@@ -213,7 +213,7 @@ class VideoClipSampler(nn.Module):
         sample_end_index = (
             min(
                 index_based_sampler_args.sample_end_index + 1,
-                metadata_json["numFrames"],
+                metadata_json["numFramesFromHeader"],
             )
             - index_based_sampler_args.video_frame_dilation
             * index_based_sampler_args.frames_per_clip
@@ -263,13 +263,13 @@ class VideoClipSampler(nn.Module):
         Returns:
             (`List[float]`): List of the sampled clip start position in seconds
         """
-        video_duration_in_seconds = metadata_json["durationSeconds"]
+        video_duration_in_seconds = metadata_json["durationSecondsFromHeader"]
 
         clip_duration_in_seconds = (
             time_based_sampler_args.frames_per_clip
             * time_based_sampler_args.video_frame_dilation
             + 1
-        ) / metadata_json["averageFps"]
+        ) / metadata_json["averageFpsFromHeader"]
 
         minPtsSecondsFromScan = (
             metadata_json["minPtsSecondsFromScan"]

--- a/src/torchcodec/_samplers/video_clip_sampler.py
+++ b/src/torchcodec/_samplers/video_clip_sampler.py
@@ -271,18 +271,18 @@ class VideoClipSampler(nn.Module):
             + 1
         ) / metadata_json["averageFpsFromHeader"]
 
-        minPtsSecondsFromScan = (
-            metadata_json["minPtsSecondsFromScan"]
-            if metadata_json["minPtsSecondsFromScan"]
+        beginStreamSecondsFromContent = (
+            metadata_json["beginStreamSecondsFromContent"]
+            if metadata_json["beginStreamSecondsFromContent"]
             else 0
         )
-        maxPtsSecondsFromScan = (
-            metadata_json["maxPtsSecondsFromScan"]
-            if metadata_json["maxPtsSecondsFromScan"] > 0
+        endStreamFromContentSeconds = (
+            metadata_json["endStreamFromContentSeconds"]
+            if metadata_json["endStreamFromContentSeconds"] > 0
             else video_duration_in_seconds
         )
         last_possible_clip_start_in_seconds = (
-            maxPtsSecondsFromScan - clip_duration_in_seconds
+            endStreamFromContentSeconds - clip_duration_in_seconds
         )
         if last_possible_clip_start_in_seconds < 0:
             raise VideoTooShortException(
@@ -292,7 +292,7 @@ class VideoClipSampler(nn.Module):
         clip_starts_in_seconds: List[float] = []
         sample_start_second = max(
             time_based_sampler_args.sample_start_second,
-            minPtsSecondsFromScan,
+            beginStreamSecondsFromContent,
         )
         sample_end_second = min(
             last_possible_clip_start_in_seconds,

--- a/src/torchcodec/_samplers/video_clip_sampler.py
+++ b/src/torchcodec/_samplers/video_clip_sampler.py
@@ -276,13 +276,13 @@ class VideoClipSampler(nn.Module):
             if metadata_json["beginStreamSecondsFromContent"]
             else 0
         )
-        endStreamFromContentSeconds = (
-            metadata_json["endStreamFromContentSeconds"]
-            if metadata_json["endStreamFromContentSeconds"] > 0
+        endStreamSecondsFromContent = (
+            metadata_json["endStreamSecondsFromContent"]
+            if metadata_json["endStreamSecondsFromContent"] > 0
             else video_duration_in_seconds
         )
         last_possible_clip_start_in_seconds = (
-            endStreamFromContentSeconds - clip_duration_in_seconds
+            endStreamSecondsFromContent - clip_duration_in_seconds
         )
         if last_possible_clip_start_in_seconds < 0:
             raise VideoTooShortException(

--- a/test/VideoDecoderTest.cpp
+++ b/test/VideoDecoderTest.cpp
@@ -80,10 +80,10 @@ TEST_P(SingleStreamDecoderTest, ReturnsFpsAndDurationForVideoInMetadata) {
   const auto& videoStream = metadata.allStreamMetadata[3];
   EXPECT_EQ(videoStream.mediaType, AVMEDIA_TYPE_VIDEO);
   EXPECT_EQ(videoStream.codecName, "h264");
-  EXPECT_NEAR(*videoStream.averageFps, 29.97f, 1e-1);
+  EXPECT_NEAR(*videoStream.averageFpsFromHeader, 29.97f, 1e-1);
   EXPECT_NEAR(*videoStream.bitRate, 128783, 1e-1);
-  EXPECT_NEAR(*videoStream.durationSeconds, 13.013, 1e-1);
-  EXPECT_EQ(videoStream.numFrames, 390);
+  EXPECT_NEAR(*videoStream.durationSecondsFromHeader, 13.013, 1e-1);
+  EXPECT_EQ(videoStream.numFramesFromHeader, 390);
   EXPECT_FALSE(videoStream.beginStreamSecondsFromContent.has_value());
   EXPECT_FALSE(videoStream.endStreamSecondsFromContent.has_value());
   EXPECT_FALSE(videoStream.numFramesFromContent.has_value());
@@ -434,7 +434,7 @@ TEST_P(SingleStreamDecoderTest, GetAudioMetadata) {
 
   const auto& audioStream = metadata.allStreamMetadata[0];
   EXPECT_EQ(audioStream.mediaType, AVMEDIA_TYPE_AUDIO);
-  EXPECT_NEAR(*audioStream.durationSeconds, 13.25, 1e-1);
+  EXPECT_NEAR(*audioStream.durationSecondsFromHeader, 13.25, 1e-1);
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/test/VideoDecoderTest.cpp
+++ b/test/VideoDecoderTest.cpp
@@ -85,13 +85,13 @@ TEST_P(SingleStreamDecoderTest, ReturnsFpsAndDurationForVideoInMetadata) {
   EXPECT_NEAR(*videoStream.durationSeconds, 13.013, 1e-1);
   EXPECT_EQ(videoStream.numFrames, 390);
   EXPECT_FALSE(videoStream.beginStreamSecondsFromContent.has_value());
-  EXPECT_FALSE(videoStream.endStreamFromContentSeconds.has_value());
+  EXPECT_FALSE(videoStream.endStreamSecondsFromContent.has_value());
   EXPECT_FALSE(videoStream.numFramesFromContent.has_value());
   decoder->scanFileAndUpdateMetadataAndIndex();
   metadata = decoder->getContainerMetadata();
   const auto& videoStream1 = metadata.allStreamMetadata[3];
   EXPECT_EQ(*videoStream1.beginStreamSecondsFromContent, 0);
-  EXPECT_EQ(*videoStream1.endStreamFromContentSeconds, 13.013);
+  EXPECT_EQ(*videoStream1.endStreamSecondsFromContent, 13.013);
   EXPECT_EQ(*videoStream1.numFramesFromContent, 390);
 }
 

--- a/test/VideoDecoderTest.cpp
+++ b/test/VideoDecoderTest.cpp
@@ -84,14 +84,14 @@ TEST_P(SingleStreamDecoderTest, ReturnsFpsAndDurationForVideoInMetadata) {
   EXPECT_NEAR(*videoStream.bitRate, 128783, 1e-1);
   EXPECT_NEAR(*videoStream.durationSecondsFromHeader, 13.013, 1e-1);
   EXPECT_EQ(videoStream.numFramesFromHeader, 390);
-  EXPECT_FALSE(videoStream.beginStreamSecondsFromContent.has_value());
-  EXPECT_FALSE(videoStream.endStreamSecondsFromContent.has_value());
+  EXPECT_FALSE(videoStream.beginStreamPtsSecondsFromContent.has_value());
+  EXPECT_FALSE(videoStream.endStreamPtsSecondsFromContent.has_value());
   EXPECT_FALSE(videoStream.numFramesFromContent.has_value());
   decoder->scanFileAndUpdateMetadataAndIndex();
   metadata = decoder->getContainerMetadata();
   const auto& videoStream1 = metadata.allStreamMetadata[3];
-  EXPECT_EQ(*videoStream1.beginStreamSecondsFromContent, 0);
-  EXPECT_EQ(*videoStream1.endStreamSecondsFromContent, 13.013);
+  EXPECT_EQ(*videoStream1.beginStreamPtsSecondsFromContent, 0);
+  EXPECT_EQ(*videoStream1.endStreamPtsSecondsFromContent, 13.013);
   EXPECT_EQ(*videoStream1.numFramesFromContent, 390);
 }
 

--- a/test/VideoDecoderTest.cpp
+++ b/test/VideoDecoderTest.cpp
@@ -84,15 +84,15 @@ TEST_P(SingleStreamDecoderTest, ReturnsFpsAndDurationForVideoInMetadata) {
   EXPECT_NEAR(*videoStream.bitRate, 128783, 1e-1);
   EXPECT_NEAR(*videoStream.durationSeconds, 13.013, 1e-1);
   EXPECT_EQ(videoStream.numFrames, 390);
-  EXPECT_FALSE(videoStream.minPtsSecondsFromScan.has_value());
-  EXPECT_FALSE(videoStream.maxPtsSecondsFromScan.has_value());
-  EXPECT_FALSE(videoStream.numFramesFromScan.has_value());
+  EXPECT_FALSE(videoStream.beginStreamSecondsFromContent.has_value());
+  EXPECT_FALSE(videoStream.endStreamFromContentSeconds.has_value());
+  EXPECT_FALSE(videoStream.numFramesFromContent.has_value());
   decoder->scanFileAndUpdateMetadataAndIndex();
   metadata = decoder->getContainerMetadata();
   const auto& videoStream1 = metadata.allStreamMetadata[3];
-  EXPECT_EQ(*videoStream1.minPtsSecondsFromScan, 0);
-  EXPECT_EQ(*videoStream1.maxPtsSecondsFromScan, 13.013);
-  EXPECT_EQ(*videoStream1.numFramesFromScan, 390);
+  EXPECT_EQ(*videoStream1.beginStreamSecondsFromContent, 0);
+  EXPECT_EQ(*videoStream1.endStreamFromContentSeconds, 13.013);
+  EXPECT_EQ(*videoStream1.numFramesFromContent, 390);
 }
 
 TEST(SingleStreamDecoderTest, MissingVideoFileThrowsException) {

--- a/test/test_encoders.py
+++ b/test/test_encoders.py
@@ -56,9 +56,11 @@ class TestAudioEncoder:
             encoder.to_tensor(format=bad_format)
 
     @pytest.mark.parametrize("method", ("to_file", "to_tensor"))
-    def test_bad_input_parametrized(self, method):
+    def test_bad_input_parametrized(self, method, tmp_path):
         valid_params = (
-            dict(dest="output.mp3") if method == "to_file" else dict(format="mp3")
+            dict(dest=str(tmp_path / "output.mp3"))
+            if method == "to_file"
+            else dict(format="mp3")
         )
 
         decoder = AudioEncoder(self.decode(NASA_AUDIO_MP3), sample_rate=10)

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -415,7 +415,7 @@ class TestVideoDecoderOps:
         assert metadata_dict["width"] == 480
         assert metadata_dict["height"] == 270
         assert metadata_dict["beginStreamSecondsFromContent"] == 0
-        assert metadata_dict["endStreamFromContentSeconds"] == 13.013
+        assert metadata_dict["endStreamSecondsFromContent"] == 13.013
 
     def test_get_ffmpeg_version(self):
         ffmpeg_dict = get_ffmpeg_library_versions()

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -215,7 +215,7 @@ class TestVideoDecoderOps:
 
         metadata = get_json_metadata(decoder)
         metadata_dict = json.loads(metadata)
-        num_frames = metadata_dict["numFrames"]
+        num_frames = metadata_dict["numFramesFromHeader"]
         assert num_frames == 390
 
         _, all_pts_seconds_ref, _ = zip(
@@ -395,9 +395,11 @@ class TestVideoDecoderOps:
         metadata_dict = json.loads(metadata)
 
         # We should be able to see all of this metadata without adding a video stream
-        assert metadata_dict["durationSeconds"] == pytest.approx(13.013, abs=0.001)
-        assert metadata_dict["numFrames"] == 390
-        assert metadata_dict["averageFps"] == pytest.approx(29.97, abs=0.001)
+        assert metadata_dict["durationSecondsFromHeader"] == pytest.approx(
+            13.013, abs=0.001
+        )
+        assert metadata_dict["numFramesFromHeader"] == 390
+        assert metadata_dict["averageFpsFromHeader"] == pytest.approx(29.97, abs=0.001)
         assert metadata_dict["codec"] == "h264"
         ffmpeg_dict = get_ffmpeg_library_versions()
         if ffmpeg_dict["libavformat"][0] >= 60:

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -414,8 +414,8 @@ class TestVideoDecoderOps:
         metadata_dict = json.loads(metadata)
         assert metadata_dict["width"] == 480
         assert metadata_dict["height"] == 270
-        assert metadata_dict["minPtsSecondsFromScan"] == 0
-        assert metadata_dict["maxPtsSecondsFromScan"] == 13.013
+        assert metadata_dict["beginStreamSecondsFromContent"] == 0
+        assert metadata_dict["endStreamFromContentSeconds"] == 13.013
 
     def test_get_ffmpeg_version(self):
         ffmpeg_dict = get_ffmpeg_library_versions()


### PR DESCRIPTION
This PR updates the fields of StreamMetadata and ContainerMetadata in Metadata.h to match the names of the equivalent fields in Python. This aligns the mismatched variables observed in #125.

In StreamMetadata: 
- `durationSeconds` -> `durationSecondsFromHeader`
- `beginStreamFromHeader` -> `beginStreamSecondsFromHeader`
- `numFrames` -> `numFramesFromHeader`
- `averageFps` -> `averageFpsFromHeader`
- `minPtsSecondsFromScan` -> `beginStreamSecondsFromContent`
- `maxPtsSecondsFromScan` -> `endStreamSecondsFromContent`
- `numFramesFromScan` -> `numFramesFromContent`

In ContainerMetadata:
- `durationSeconds` -> `durationSecondsFromHeader`

These changes are reflected in other references to these metadata classes, in `SingleStreamDecoder.h/.cpp`, `custom_ops.cpp`, `video_clip_sampler.py`, and to the references in test files `test_ops.py`, `VideoDecoderTest.cpp`
