### PR TITLE
Allow num_frames and duration to be absent in C++ decoder

### DIFF
--- a/src/torchcodec/_core/SingleStreamDecoder.cpp
+++ b/src/torchcodec/_core/SingleStreamDecoder.cpp
@@ -1487,7 +1487,7 @@ std::optional<int64_t> SingleStreamDecoder::getNumFrames(
     case SeekMode::exact:
       return streamMetadata.numFramesFromScan.value();
     case SeekMode::approximate: {
-      return streamMetadata.numFrames.value();
+      return streamMetadata.numFrames;
     }
     default:
       throw std::runtime_error("Unknown SeekMode");

--- a/src/torchcodec/_core/SingleStreamDecoder.h
+++ b/src/torchcodec/_core/SingleStreamDecoder.h
@@ -304,9 +304,9 @@ class SingleStreamDecoder {
   // index. Note that this index may be truncated for some files.
   int getBestStreamIndex(AVMediaType mediaType);
 
-  int64_t getNumFrames(const StreamMetadata& streamMetadata);
+  std::optional<int64_t> getNumFrames(const StreamMetadata& streamMetadata);
   double getMinSeconds(const StreamMetadata& streamMetadata);
-  double getMaxSeconds(const StreamMetadata& streamMetadata);
+  std::optional<double> getMaxSeconds(const StreamMetadata& streamMetadata);
 
   // --------------------------------------------------------------------------
   // VALIDATION UTILS

--- a/test/test_decoders.py
+++ b/test/test_decoders.py
@@ -597,10 +597,10 @@ class TestVideoDecoder:
     def test_get_frames_played_at_fails(self, device, seek_mode):
         decoder = VideoDecoder(NASA_VIDEO.path, device=device, seek_mode=seek_mode)
 
-        with pytest.raises(RuntimeError, match="must be in range"):
+        with pytest.raises(RuntimeError, match="must be greater than or equal to"):
             decoder.get_frames_played_at([-1])
 
-        with pytest.raises(RuntimeError, match="must be in range"):
+        with pytest.raises(RuntimeError, match="must be less than"):
             decoder.get_frames_played_at([14])
 
         with pytest.raises(RuntimeError, match="Expected a value of type"):


### PR DESCRIPTION
This is necessary to decode live streaming data (#695), but not sufficient. It's necessary because we need the C++ layer to be robust to the number of frames and duration being missing from the metadata, as that will not be available when decoding a live stream. But it's also not sufficient because the Python layer for `VideoDecoder` also asserts that metadata is present.

In fact, because `VideoDecoder` uses the number frames from the metadata in its `__len__()` method, we will need to expose a different public Python API to support live streaming. We should, however, be able to reuse the C++ layer.

I don't particularly love the way I'm currently achieving this, so I'm open to alternatives. I'm also concerned that when the number of frames or duration are missing, we might actually be open to segfaults. I _think_ we should just get the exceptions from the inner decoding loop about not being able to decode frames, but I'm not sure.

Discussion points:

1. Are we comfortable relaxing these requirements at the C++ level? We can (and do) still enforce some of this at the Python level if the Python APIs require this.
2. If yes to 1, is this the best way to do it?
3. We don't have any explicit tests for what happens when this data is not present. We don't have any files which have it missing. We could write some C++ tests that go in an just remove the values from the C++ `VideoDecoder`. That's ugly - is it worth it?