### PR TITLE
Use constant refs for passing samples into encoder

### DIFF
--- a/src/torchcodec/_core/Encoder.cpp
+++ b/src/torchcodec/_core/Encoder.cpp
@@ -8,7 +8,7 @@ namespace facebook::torchcodec {
 
 namespace {
 
-torch::Tensor validateSamples(torch::Tensor samples) {
+torch::Tensor validateSamples(const torch::Tensor& samples) {
   TORCH_CHECK(
       samples.dtype() == torch::kFloat32,
       "samples must have float32 dtype, got ",
@@ -101,7 +101,7 @@ AVSampleFormat findBestOutputSampleFormat(const AVCodec& avCodec) {
 AudioEncoder::~AudioEncoder() {}
 
 AudioEncoder::AudioEncoder(
-    const torch::Tensor samples,
+    const torch::Tensor& samples,
     int sampleRate,
     std::string_view fileName,
     const AudioStreamOptions& audioStreamOptions)
@@ -132,7 +132,7 @@ AudioEncoder::AudioEncoder(
 }
 
 AudioEncoder::AudioEncoder(
-    const torch::Tensor samples,
+    const torch::Tensor& samples,
     int sampleRate,
     std::string_view formatName,
     std::unique_ptr<AVIOToTensorContext> avioContextHolder,

--- a/src/torchcodec/_core/Encoder.h
+++ b/src/torchcodec/_core/Encoder.h
@@ -15,7 +15,7 @@ class AudioEncoder {
   // Passing 44_100 could result in output being 44000 if only 44000 is
   // supported.
   AudioEncoder(
-      const torch::Tensor samples,
+      const torch::Tensor& samples,
       // TODO-ENCODING: update this comment when we support an output sample
       // rate. This will become the input sample rate.
       // The *output* sample rate. We can't really decide for the user what it
@@ -26,7 +26,7 @@ class AudioEncoder {
       std::string_view fileName,
       const AudioStreamOptions& audioStreamOptions);
   AudioEncoder(
-      const torch::Tensor samples,
+      const torch::Tensor& samples,
       int sampleRate,
       std::string_view formatName,
       std::unique_ptr<AVIOToTensorContext> avioContextHolder,

--- a/src/torchcodec/_core/custom_ops.cpp
+++ b/src/torchcodec/_core/custom_ops.cpp
@@ -388,7 +388,7 @@ OpsAudioFramesOutput get_frames_by_pts_in_range_audio(
 }
 
 void encode_audio_to_file(
-    const at::Tensor samples,
+    const at::Tensor& samples,
     int64_t sample_rate,
     std::string_view file_name,
     std::optional<int64_t> bit_rate = std::nullopt,
@@ -404,7 +404,7 @@ void encode_audio_to_file(
 }
 
 at::Tensor encode_audio_to_tensor(
-    const at::Tensor samples,
+    const at::Tensor& samples,
     int64_t sample_rate,
     std::string_view format,
     std::optional<int64_t> bit_rate = std::nullopt,


### PR DESCRIPTION
Since we're using these values in a constant ref context anyway, we should pass them that way. In practice, this probably won't make much of a performance difference even if the samples are large since I believe tensors are already basically smart pointers. But it's good code hygiene.