### PR TITLE
Turn BytesContext into FromTensorContext

### DIFF
--- a/src/torchcodec/_core/AVIOBytesContext.h
+++ b/src/torchcodec/_core/AVIOBytesContext.h
@@ -11,23 +11,19 @@
 
 namespace facebook::torchcodec {
 
+struct TensorContext {
+  torch::Tensor data;
+  int64_t current;
+};
+
 // For Decoding: enables users to pass in the entire video or audio as bytes.
 // Our read and seek functions then traverse the bytes in memory.
-class AVIOBytesContext : public AVIOContextHolder {
+class AVIOFromTensorContext : public AVIOContextHolder {
  public:
-  explicit AVIOBytesContext(const void* data, int64_t dataSize);
+  explicit AVIOFromTensorContext(torch::Tensor data);
 
  private:
-  struct DataContext {
-    const uint8_t* data;
-    int64_t size;
-    int64_t current;
-  };
-
-  static int read(void* opaque, uint8_t* buf, int buf_size);
-  static int64_t seek(void* opaque, int64_t offset, int whence);
-
-  DataContext dataContext_;
+  TensorContext tensorContext_;
 };
 
 // For Encoding: used to encode into an output uint8 (bytes) tensor.
@@ -37,18 +33,7 @@ class AVIOToTensorContext : public AVIOContextHolder {
   torch::Tensor getOutputTensor();
 
  private:
-  struct DataContext {
-    torch::Tensor outputTensor;
-    int64_t current;
-  };
-
-  static constexpr int64_t INITIAL_TENSOR_SIZE = 10'000'000; // 10MB
-  static constexpr int64_t MAX_TENSOR_SIZE = 320'000'000; // 320 MB
-  static int write(void* opaque, const uint8_t* buf, int buf_size);
-  // We need to expose seek() for some formats like mp3.
-  static int64_t seek(void* opaque, int64_t offset, int whence);
-
-  DataContext dataContext_;
+  TensorContext tensorContext_;
 };
 
 } // namespace facebook::torchcodec

--- a/src/torchcodec/_core/custom_ops.cpp
+++ b/src/torchcodec/_core/custom_ops.cpp
@@ -196,15 +196,13 @@ at::Tensor create_from_tensor(
   TORCH_CHECK(
       video_tensor.scalar_type() == torch::kUInt8,
       "video_tensor must be kUInt8");
-  void* data = video_tensor.mutable_data_ptr();
-  size_t length = video_tensor.numel();
 
   SingleStreamDecoder::SeekMode realSeek = SingleStreamDecoder::SeekMode::exact;
   if (seek_mode.has_value()) {
     realSeek = seekModeFromString(seek_mode.value());
   }
 
-  auto contextHolder = std::make_unique<AVIOBytesContext>(data, length);
+  auto contextHolder = std::make_unique<AVIOFromTensorContext>(video_tensor);
 
   std::unique_ptr<SingleStreamDecoder> uniqueDecoder =
       std::make_unique<SingleStreamDecoder>(std::move(contextHolder), realSeek);

--- a/test/test_decoders.py
+++ b/test/test_decoders.py
@@ -93,6 +93,7 @@ class TestDecoder:
         decoder = Decoder(source)
         assert isinstance(decoder.metadata, _core._metadata.StreamMetadata)
 
+
     @pytest.mark.parametrize("Decoder", (VideoDecoder, AudioDecoder))
     def test_create_fails(self, Decoder):
         with pytest.raises(TypeError, match="Unknown source type"):
@@ -125,6 +126,22 @@ class TestVideoDecoder:
         assert decoder.metadata.num_frames == 390
         assert decoder.metadata.height == 270
         assert decoder.metadata.width == 480
+
+    def test_create_bytes_ownership(self):
+        # Note that the bytes object we use to instantiate the decoder does not
+        # live past the VideoDecoder destructor. That is what we're testing:
+        # that the VideoDecoder takes ownership of the bytes. If it does not,
+        # then we will hit errors when we try to actually decode from the bytes
+        # later on. By the time we actually decode, the reference on the Python
+        # side has gone away, and if we don't have ownership on the C++ side, we
+        # will hit runtime errors or segfaults.
+        with open(NASA_VIDEO.path, "rb") as f:
+            decoder = VideoDecoder(f.read())
+
+        assert decoder[0] is not None
+        assert decoder[len(decoder)//2] is not None
+        assert decoder[-1] is not None
+
 
     def test_create_fails(self):
         with pytest.raises(ValueError, match="Invalid seek mode"):

--- a/test/test_decoders.py
+++ b/test/test_decoders.py
@@ -93,7 +93,6 @@ class TestDecoder:
         decoder = Decoder(source)
         assert isinstance(decoder.metadata, _core._metadata.StreamMetadata)
 
-
     @pytest.mark.parametrize("Decoder", (VideoDecoder, AudioDecoder))
     def test_create_fails(self, Decoder):
         with pytest.raises(TypeError, match="Unknown source type"):
@@ -139,9 +138,8 @@ class TestVideoDecoder:
             decoder = VideoDecoder(f.read())
 
         assert decoder[0] is not None
-        assert decoder[len(decoder)//2] is not None
+        assert decoder[len(decoder) // 2] is not None
         assert decoder[-1] is not None
-
 
     def test_create_fails(self):
         with pytest.raises(ValueError, match="Invalid seek mode"):


### PR DESCRIPTION
Fixes #720.

Reading from a raw `void*` is problematic because we have no way of claiming ownership of it. This PR makes sure reading from bytes only happens through a tensor. The tensor is effectively a smart pointer, so it ensures that we actually keep the data around. We now have both a tensor-reading context and a tensor-writing context. This PR also refactors both to share code - which we thought we may eventually need to do.

The test added by this PR fails without these changes in the C++ level.