### PR TITLE
Verify decoder outputs

### DIFF
--- a/benchmarks/decoders/benchmark_decoders.py
+++ b/benchmarks/decoders/benchmark_decoders.py
@@ -8,65 +8,16 @@ import argparse
 import importlib.resources
 import os
 import platform
-import typing
-from dataclasses import dataclass, field
 from pathlib import Path
 
 import torch
 
 from benchmark_decoders_library import (
-    AbstractDecoder,
-    DecordAccurate,
-    DecordAccurateBatch,
-    OpenCVDecoder,
+    decoder_registry,
     plot_data,
     run_benchmarks,
-    TorchAudioDecoder,
-    TorchCodecCore,
-    TorchCodecCoreBatch,
-    TorchCodecCoreCompiled,
-    TorchCodecCoreNonBatch,
-    TorchCodecPublic,
-    TorchCodecPublicNonBatch,
-    TorchVision,
+    verify_outputs,
 )
-
-
-@dataclass
-class DecoderKind:
-    display_name: str
-    kind: typing.Type[AbstractDecoder]
-    default_options: dict[str, str] = field(default_factory=dict)
-
-
-decoder_registry = {
-    "decord": DecoderKind("DecordAccurate", DecordAccurate),
-    "decord_batch": DecoderKind("DecordAccurateBatch", DecordAccurateBatch),
-    "torchcodec_core": DecoderKind("TorchCodecCore", TorchCodecCore),
-    "torchcodec_core_batch": DecoderKind("TorchCodecCoreBatch", TorchCodecCoreBatch),
-    "torchcodec_core_nonbatch": DecoderKind(
-        "TorchCodecCoreNonBatch", TorchCodecCoreNonBatch
-    ),
-    "torchcodec_core_compiled": DecoderKind(
-        "TorchCodecCoreCompiled", TorchCodecCoreCompiled
-    ),
-    "torchcodec_public": DecoderKind("TorchCodecPublic", TorchCodecPublic),
-    "torchcodec_public_nonbatch": DecoderKind(
-        "TorchCodecPublicNonBatch", TorchCodecPublicNonBatch
-    ),
-    "torchvision": DecoderKind(
-        # We don't compare against TorchVision's "pyav" backend because it doesn't support
-        # accurate seeks.
-        "TorchVision[backend=video_reader]",
-        TorchVision,
-        {"backend": "video_reader"},
-    ),
-    "torchaudio": DecoderKind("TorchAudio", TorchAudioDecoder),
-    "opencv": DecoderKind(
-        "OpenCV[backend=FFMPEG]", OpenCVDecoder, {"backend": "FFMPEG"}
-    ),
-}
-
 
 def in_fbcode() -> bool:
     return "FB_PAR_RUNTIME_FILES" in os.environ
@@ -148,6 +99,12 @@ def main() -> None:
         type=str,
         default="benchmarks.png",
     )
+    parser.add_argument(
+        "--verify-outputs",
+        help="Verify that the outputs of the decoders are the same",
+        default=False,
+        action=argparse.BooleanOptionalAction,
+    )
 
     args = parser.parse_args()
     specified_decoders = set(args.decoders.split(","))
@@ -176,6 +133,10 @@ def main() -> None:
         for entry in os.scandir(args.video_dir):
             if entry.is_file() and entry.name.endswith(".mp4"):
                 video_paths.append(entry.path)
+
+    if args.verify_outputs:
+        verify_outputs(decoders_to_run, video_paths, num_uniform_samples)
+        return
 
     results = run_benchmarks(
         decoders_to_run,

--- a/benchmarks/decoders/benchmark_decoders.py
+++ b/benchmarks/decoders/benchmark_decoders.py
@@ -136,7 +136,6 @@ def main() -> None:
 
     if args.verify_outputs:
         verify_outputs(decoders_to_run, video_paths, num_uniform_samples)
-        return
 
     results = run_benchmarks(
         decoders_to_run,

--- a/benchmarks/decoders/benchmark_decoders.py
+++ b/benchmarks/decoders/benchmark_decoders.py
@@ -136,7 +136,7 @@ def main() -> None:
                 video_paths.append(entry.path)
 
     if args.verify_outputs:
-        verify_outputs(decoders_to_run, video_paths, 1)
+        verify_outputs(decoders_to_run, video_paths, num_uniform_samples)
     else:
         results = run_benchmarks(
             decoders_to_run,

--- a/benchmarks/decoders/benchmark_decoders.py
+++ b/benchmarks/decoders/benchmark_decoders.py
@@ -19,6 +19,7 @@ from benchmark_decoders_library import (
     verify_outputs,
 )
 
+
 def in_fbcode() -> bool:
     return "FB_PAR_RUNTIME_FILES" in os.environ
 

--- a/benchmarks/decoders/benchmark_decoders.py
+++ b/benchmarks/decoders/benchmark_decoders.py
@@ -136,31 +136,31 @@ def main() -> None:
                 video_paths.append(entry.path)
 
     if args.verify_outputs:
-        verify_outputs(decoders_to_run, video_paths, num_uniform_samples)
-
-    results = run_benchmarks(
-        decoders_to_run,
-        video_paths,
-        num_uniform_samples,
-        num_sequential_frames_from_start=[1, 10, 100],
-        min_runtime_seconds=args.min_run_seconds,
-        benchmark_video_creation=args.bm_video_creation,
-    )
-    data = {
-        "experiments": results,
-        "system_metadata": {
-            "cpu_count": os.cpu_count(),
-            "system": platform.system(),
-            "machine": platform.machine(),
-            "python_version": str(platform.python_version()),
-            "cuda": (
-                torch.cuda.get_device_properties(0).name
-                if torch.cuda.is_available()
-                else "not available"
-            ),
-        },
-    }
-    plot_data(data, args.plot_path)
+        verify_outputs(decoders_to_run, video_paths, 1)
+    else:
+        results = run_benchmarks(
+            decoders_to_run,
+            video_paths,
+            num_uniform_samples,
+            num_sequential_frames_from_start=[1, 10, 100],
+            min_runtime_seconds=args.min_run_seconds,
+            benchmark_video_creation=args.bm_video_creation,
+        )
+        data = {
+            "experiments": results,
+            "system_metadata": {
+                "cpu_count": os.cpu_count(),
+                "system": platform.system(),
+                "machine": platform.machine(),
+                "python_version": str(platform.python_version()),
+                "cuda": (
+                    torch.cuda.get_device_properties(0).name
+                    if torch.cuda.is_available()
+                    else "not available"
+                ),
+            },
+        }
+        plot_data(data, args.plot_path)
 
 
 if __name__ == "__main__":

--- a/benchmarks/decoders/benchmark_decoders_library.py
+++ b/benchmarks/decoders/benchmark_decoders_library.py
@@ -1031,12 +1031,18 @@ def verify_outputs(decoders_to_run, video_paths, num_samples):
     # Import library to show frames that don't match
     from tensorcat import tensorcat
 
-    # Create TorchCodecPublic decoder to use as a baseline
-    torchcodec_display_name = decoder_registry["torchcodec_public"].display_name
-    options = decoder_registry["torchcodec_public"].default_options
-    kind = decoder_registry["torchcodec_public"].kind
-    torchcodec_public_decoder = kind(**options)
-
+    # Reuse TorchCodecPublic decoder with options, if provided, as the baseline
+    if torchcodec_display_name := next(
+        (name for name in decoders_to_run if "TorchCodecPublic" in name),
+        None,
+    ):
+        torchcodec_public_decoder = decoders_to_run[torchcodec_display_name]
+    # Create default TorchCodecPublic decoder to use as a baseline
+    else:
+        torchcodec_display_name = decoder_registry["torchcodec_public"].display_name
+        options = decoder_registry["torchcodec_public"].default_options
+        kind = decoder_registry["torchcodec_public"].kind
+        torchcodec_public_decoder = kind(**options)
     # Get frames using each decoder
     for video_file_path in video_paths:
         metadata = get_metadata(video_file_path)

--- a/benchmarks/decoders/benchmark_decoders_library.py
+++ b/benchmarks/decoders/benchmark_decoders_library.py
@@ -894,7 +894,6 @@ def run_benchmarks(
         # The decoder items are sorted to perform and display the benchmarks in a consistent order.
         for decoder_name, decoder in sorted(decoder_dict.items(), key=lambda x: x[0]):
             print(f"video={video_file_path}, decoder={decoder_name}")
-            print(f"metadata={metadata_label}")
 
             if dataloader_parameters:
                 bp = dataloader_parameters.batch_parameters

--- a/benchmarks/decoders/benchmark_decoders_library.py
+++ b/benchmarks/decoders/benchmark_decoders_library.py
@@ -1074,6 +1074,7 @@ def verify_outputs(decoders_to_run, video_paths, num_samples):
             )
             for f1, f2 in zip(torchcodec_public_results, frames):
                 torch.testing.assert_close(f1, f2)
+            print(f"Results of baseline TorchCodecPublic and {decoder_name} match!")
 
 
 def decode_and_adjust_frames(

--- a/benchmarks/decoders/benchmark_decoders_library.py
+++ b/benchmarks/decoders/benchmark_decoders_library.py
@@ -1082,11 +1082,11 @@ def decode_and_adjust_frames(
 ):
     frames = []
     # Decode non-sequential frames using decode_frames function
-    random_frames = decoder.decode_frames(video_file_path, pts_list)
+    non_seq_frames = decoder.decode_frames(video_file_path, pts_list)
     # TorchCodec's batch APIs return a FrameBatch, so we need to extract the frames
-    if isinstance(random_frames, FrameBatch):
-        random_frames = random_frames.data
-    frames.extend(random_frames)
+    if isinstance(non_seq_frames, FrameBatch):
+        non_seq_frames = non_seq_frames.data
+    frames.extend(non_seq_frames)
 
     # Decode sequential frames using decode_first_n_frames function
     seq_frames = decoder.decode_first_n_frames(video_file_path, num_samples)

--- a/benchmarks/decoders/benchmark_decoders_library.py
+++ b/benchmarks/decoders/benchmark_decoders_library.py
@@ -1030,18 +1030,20 @@ def verify_outputs(decoders_to_run, video_paths, num_samples):
     # Import library to show frames that don't match
     from tensorcat import tensorcat
 
-    # Reuse TorchCodecPublic decoder with options, if provided, as the baseline
-    if torchcodec_display_name := next(
-        (name for name in decoders_to_run if "TorchCodecPublic" in name),
+    # Reuse TorchCodecPublic decoder stream_index option, if provided.
+    options = decoder_registry["torchcodec_public"].default_options
+    if torchcodec_decoder := next(
+        (
+            decoder
+            for name, decoder in decoders_to_run.items()
+            if "TorchCodecPublic" in name
+        ),
         None,
     ):
-        torchcodec_public_decoder = decoders_to_run[torchcodec_display_name]
+        options["stream_index"] = str(torchcodec_decoder._stream_index)
     # Create default TorchCodecPublic decoder to use as a baseline
-    else:
-        torchcodec_display_name = decoder_registry["torchcodec_public"].display_name
-        options = decoder_registry["torchcodec_public"].default_options
-        kind = decoder_registry["torchcodec_public"].kind
-        torchcodec_public_decoder = kind(**options)
+    torchcodec_public_decoder = TorchCodecPublic(**options)
+
     # Get frames using each decoder
     for video_file_path in video_paths:
         metadata = get_metadata(video_file_path)
@@ -1086,12 +1088,12 @@ def verify_outputs(decoders_to_run, video_paths, num_samples):
                     tensorcat(f2)
                     all_match = False
                     print(
-                        f"Error while comparing {torchcodec_display_name} and {curr_decoder_name}: {e}"
+                        f"Error while comparing baseline TorchCodecPublic and {curr_decoder_name}: {e}"
                     )
                     break
             if all_match:
                 print(
-                    f"Results of {torchcodec_display_name} and {curr_decoder_name} match!"
+                    f"Results of baseline TorchCodecPublic and {curr_decoder_name} match!"
                 )
 
 


### PR DESCRIPTION
#### Overview
While adding the OpenCV decoder in #711, we realized that OpenCV was decoding a different stream than TorchCodec, resulting in unexpected benchmark results. This PR implements a function to compare the outputs of decoders. 

#### Example usage
By adding `--verify-outputs` to the benchmark command, the script outputs a warning indicating that the output frames are different for TorchCodec in approximate mode compared to OpenCV on `nasa_13013.mp4`:
```
python benchmarks/decoders/benchmark_decoders.py --decoders torchaudio,torchcodec_public:seek_mode=approximate,opencv   --verify-outputs 
```
<img width="344" alt="Screenshot 2025-06-13 at 4 19 47 PM" src="https://github.com/user-attachments/assets/e140d877-a0d0-43bb-b4c4-da1bb38998b5" />

```
Error while comparing TorchCodecPublic:seek_mode=approximate and OpenCV[backend=FFMPEG]: The values for attribute 'shape' do not match: torch.Size([3, 270, 480]) != torch.Size([3, 180, 320]).
```

The dimensions match when `stream_index` is utilized, but the tensors are unequal:
```
python benchmarks/decoders/benchmark_decoders.py --decoders torchaudio:stream_index=0,torchcodec_public:seek_mode=approximate+stream_index=0,opencv   --verify-outputs --video-paths output.mp4
```
```

AssertionError: Tensor-likes are not equal!

Mismatched elements: 38759 / 172800 (22.4%)
Greatest absolute difference: 16 at index (0, 98, 96)
Greatest relative difference: inf at index (0, 44, 210)
```


For further testing, I generated a video using ffmpeg, where all results matched:
```
ffmpeg -f lavfi -i testsrc=duration=10:size=1280x720:rate=30 -vf "drawtext=fontfile=/path/to/font.ttf: text='%{pts\:hms}': x=(w-text_w)/2: y=(h-text_h)/2: fontsize=48: fontcolor=white: box=1: boxcolor=black@0.5: boxborderw=5, hue=H=2*t" -pix_fmt yuv420p output.mp4
```
```
python benchmarks/decoders/benchmark_decoders.py --decoders torchaudio:stream_index=0,torchcodec_public:seek_mode=approximate+stream_index=0,opencv   --verify-outputs --video-paths output.mp4
```
```
video=output.mp4, decoder=OpenCV[backend=FFMPEG]
Results of baseline TorchCodecPublic and OpenCV[backend=FFMPEG] match!
video=output.mp4, decoder=TorchAudio:stream_index=0
Results of baseline TorchCodecPublic and TorchAudio:stream_index=0 match!
video=output.mp4, decoder=TorchCodecPublic:seek_mode=approximate+stream_index=0
Results of baseline TorchCodecPublic and TorchCodecPublic:seek_mode=approximate+stream_index=0 match!
```