### PR TITLE
test/: fix failing tests due to missing argument (fixup d6ce5703)

### DIFF
--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -167,6 +167,7 @@ def test_calculate_num_frames_using_fps_and_duration(
         codec="whatever",
         width=123,
         height=321,
+        pixel_aspect_ratio=Fraction(10, 11),
         average_fps_from_header=average_fps_from_header,
         stream_index=0,
     )
@@ -198,6 +199,7 @@ def test_duration_seconds_fallback(
         codec="whatever",
         width=123,
         height=321,
+        pixel_aspect_ratio=Fraction(10, 11),
         average_fps_from_header=5,
         stream_index=0,
     )
@@ -226,6 +228,7 @@ def test_calculate_duration_seconds_using_fps_and_num_frames(
         codec="whatever",
         width=123,
         height=321,
+        pixel_aspect_ratio=Fraction(10, 11),
         average_fps_from_header=average_fps_from_header,
         stream_index=0,
     )


### PR DESCRIPTION
The new tests introduced in ffac96c8 (#732) are failing since d6ce5703 (#737) because d6ce5703 was merged by rebase (testes passed on the PR but it was branched off before #732 was merged).