### PR TITLE
StreamMetadata: always display Fractions in num/den form

### DIFF
--- a/src/torchcodec/_core/_metadata.py
+++ b/src/torchcodec/_core/_metadata.py
@@ -41,7 +41,14 @@ class StreamMetadata:
     def __repr__(self):
         s = self.__class__.__name__ + ":\n"
         for field in dataclasses.fields(self):
-            s += f"{SPACES}{field.name}: {getattr(self, field.name)}\n"
+            attr = getattr(self, field.name)
+            if isinstance(attr, Fraction):
+                # Fractions are displayed as integers when possible,
+                # but we want to always display num/den.  Once we
+                # require Python >=3.13 we can use format(.., "#").
+                s += f"{SPACES}{field.name}: {attr.numerator}/{attr.denominator}\n"
+            else:
+                s += f"{SPACES}{field.name}: {attr}\n"
         return s
 
 

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -254,7 +254,7 @@ def test_repr():
   num_frames_from_header: 390
   num_frames_from_content: 390
   average_fps_from_header: 29.97003
-  pixel_aspect_ratio: 1
+  pixel_aspect_ratio: 1/1
   duration_seconds: 13.013
   begin_stream_seconds: 0.0
   end_stream_seconds: 13.013


### PR DESCRIPTION
During the review of PR #733 I suggested that fractions should always be displayed in num/den form:

> On the `__repr__`: I personally I don't think it's worth the hassle, but let's consider that in a separate PR so we can get this one merged first.

_Originally posted by @NicolasHug in https://github.com/pytorch/torchcodec/pull/737#pullrequestreview-2954198659_

So here's that separate PR.