### PR TITLE
Support negative index in SimpleVideoDecoder

### DIFF
--- a/src/torchcodec/decoders/_video_decoder.py
+++ b/src/torchcodec/decoders/_video_decoder.py
@@ -195,6 +195,8 @@ class VideoDecoder:
         Returns:
             Frame: The frame at the given index.
         """
+        if index < 0:
+            index += self._num_frames
 
         if not 0 <= index < self._num_frames:
             raise IndexError(
@@ -218,6 +220,9 @@ class VideoDecoder:
         Returns:
             FrameBatch: The frames at the given indices.
         """
+        indices = [
+            index if index >= 0 else index + self._num_frames for index in indices
+        ]
 
         data, pts_seconds, duration_seconds = core.get_frames_at_indices(
             self._decoder, frame_indices=indices

--- a/test/test_decoders.py
+++ b/test/test_decoders.py
@@ -488,6 +488,9 @@ class TestVideoDecoder:
         decoder = VideoDecoder(NASA_VIDEO.path, device=device, seek_mode=seek_mode)
 
         with pytest.raises(IndexError, match="out of bounds"):
+            frame = decoder.get_frame_at(-10000)  # noqa
+
+        with pytest.raises(IndexError, match="out of bounds"):
             frame = decoder.get_frame_at(10000)  # noqa
 
     @pytest.mark.parametrize("device", cpu_and_cuda())
@@ -545,6 +548,12 @@ class TestVideoDecoder:
     @pytest.mark.parametrize("seek_mode", ("exact", "approximate"))
     def test_get_frames_at_fails(self, device, seek_mode):
         decoder = VideoDecoder(NASA_VIDEO.path, device=device, seek_mode=seek_mode)
+
+        expected_converted_index = -10000 + len(decoder)
+        with pytest.raises(
+            RuntimeError, match=f"Invalid frame index={expected_converted_index}"
+        ):
+            decoder.get_frames_at([-10000])
 
         with pytest.raises(RuntimeError, match="Invalid frame index=390"):
             decoder.get_frames_at([390])


### PR DESCRIPTION
This PR adds the missing functionality described in #150, specifically adding support for negative indexing in `get_frame_at()` and `get_frames_at()`.

In both functions, a negative index `n` is converted to `len(decoder) - n`. The tests are updated to reflect this support as well.

The other item in that issue, allowing "upper bound in slices to be greated than `len(decoder)`", is already supported by `getitem_slice`. Specifically, this section of `_video_decoder.py` handles negative and out-of-range indices:
```
    def _getitem_slice(self, key: slice) -> Tensor:
        assert isinstance(key, slice)

        start, stop, step = key.indices(len(self))
```

I added a new test case to `test_getitem_slice` to make this more explicit.