### PR TITLE
Avoid warning in tests due to torch deprecation

### DIFF
--- a/test/test_frame_dataclasses.py
+++ b/test/test_frame_dataclasses.py
@@ -139,7 +139,7 @@ def test_framebatch_indexing():
     assert isinstance(fb_fancy, FrameBatch)
     assert fb_fancy.data.shape == (3, N, C, H, W)
 
-    fb_fancy = fb[[[0], [1]]]  # select T=0 and N=1.
+    fb_fancy = fb[([0], [1])]  # select T=0 and N=1.
     assert isinstance(fb_fancy, FrameBatch)
     assert fb_fancy.data.shape == (1, C, H, W)
 


### PR DESCRIPTION
Closes https://github.com/pytorch/torchcodec/issues/748

We started getting warnings in `main` due to torch not allowing lists for multi-indexing anymore:

```
test/test_frame_dataclasses.py::test_framebatch_indexing
  /home/nicolashug/dev/torchcodec/src/torchcodec/_frame.py:107: UserWarning: Using a non-tuple sequence for multidimensional indexing is deprecated and will be changed in pytorch 2.9; use x[tuple(seq)] instead of x[seq]. In pytorch 2.9 this will be interpreted as tensor index, x[torch.tensor(seq)], which will result either in an error or a different result (Triggered internally at /pytorch/torch/csrc/autograd/python_variable_indexing.cpp:306.)
    data=self.data[key],
```

It's our tests we need to change, not our indexing code in `frame.py`. I can confirm the warnings aren't visible locally anymore (they were before).