### PR TITLE
Explicitly close encoded file

### DIFF
--- a/src/torchcodec/_core/Encoder.cpp
+++ b/src/torchcodec/_core/Encoder.cpp
@@ -98,7 +98,11 @@ AVSampleFormat findBestOutputSampleFormat(const AVCodec& avCodec) {
 
 } // namespace
 
-AudioEncoder::~AudioEncoder() {}
+AudioEncoder::~AudioEncoder() {
+  if (avFormatContext_ && avFormatContext_->pb && !avioContextHolder_) {
+    avio_close(avFormatContext_->pb);
+  }
+}
 
 AudioEncoder::AudioEncoder(
     const torch::Tensor& samples,


### PR DESCRIPTION
Fixes https://github.com/pytorch/torchcodec/issues/724

I hope that this is the fix for the errors we're seeing in https://github.com/pytorch/torchcodec/issues/724.:

```
FAILED test/test_encoders.py::TestAudioEncoder::test_num_channels[to_file-2-2] - RuntimeError: Could not open input file: /tmp/pytest-of-root/pytest-0/test_num_channels_to_file_2_2_0/output.mp3 Invalid data found when processing input
```

I think the error was that we were trying to read an encoded file that we had just encoded, and because that file wasn't fully `close()`ed yet, something was going wrong.

Hard to test for this. Let's monitor the repo and see if we still notice the same kind of issues.