### PR TITLE
Add testing against CUDA 12.9

### DIFF
--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -67,7 +67,9 @@ jobs:
           # For the actual release we should add that label and change this to
           # include more python versions.
         python-version: ['3.9']
-        cuda-version: ['12.6', '12.8']
+        # We test against 12.6 and 12.9 to avoid having too big of a CI matrix,
+        # but for releases we should add 12.8.
+        cuda-version: ['12.6', '12.9']
         # TODO: put back ffmpeg 5 https://github.com/pytorch/torchcodec/issues/325
         ffmpeg-version-for-tests: ['4.4.2', '6', '7']
 


### PR DESCRIPTION
We are already building wheels for 12.9, see e.g. [these jobs](https://github.com/pytorch/torchcodec/actions/runs/16089375037/job/45404692423?pr=755)

This PR adds the **testing** jobs for 12.9.

Related to https://github.com/pytorch/torchcodec/pull/757