### PR TITLE
Add stream_index seek mode, read frame index and update metadata

### DIFF
--- a/src/torchcodec/_core/Frame.h
+++ b/src/torchcodec/_core/Frame.h
@@ -45,6 +45,20 @@ struct AudioFramesOutput {
   double ptsSeconds;
 };
 
+// FrameMappings is used for the custom_frame_mappings seek mode to store
+// metadata of frames in a stream. The size of all tensors in this struct must
+// match.
+struct FrameMappings {
+  // 1D tensor of int64, each value is the PTS of a frame in timebase units.
+  torch::Tensor all_frames;
+  // 1D tensor of bool, each value indicates if the corresponding frame in
+  // all_frames is a key frame.
+  torch::Tensor is_key_frame;
+  // 1D tensor of int64, each value is the duration of the corresponding frame
+  // in all_frames in timebase units.
+  torch::Tensor duration;
+};
+
 // --------------------------------------------------------------------------
 // FRAME TENSOR ALLOCATION APIs
 // --------------------------------------------------------------------------

--- a/src/torchcodec/_core/Frame.h
+++ b/src/torchcodec/_core/Frame.h
@@ -45,20 +45,6 @@ struct AudioFramesOutput {
   double ptsSeconds;
 };
 
-// FrameMappings is used for the custom_frame_mappings seek mode to store
-// metadata of frames in a stream. The size of all tensors in this struct must
-// match.
-struct FrameMappings {
-  // 1D tensor of int64, each value is the PTS of a frame in timebase units.
-  torch::Tensor all_frames;
-  // 1D tensor of bool, each value indicates if the corresponding frame in
-  // all_frames is a key frame.
-  torch::Tensor is_key_frame;
-  // 1D tensor of int64, each value is the duration of the corresponding frame
-  // in all_frames in timebase units.
-  torch::Tensor duration;
-};
-
 // --------------------------------------------------------------------------
 // FRAME TENSOR ALLOCATION APIs
 // --------------------------------------------------------------------------

--- a/src/torchcodec/_core/SingleStreamDecoder.cpp
+++ b/src/torchcodec/_core/SingleStreamDecoder.cpp
@@ -348,8 +348,8 @@ void SingleStreamDecoder::readCustomFrameMappingsUpdateMetadataAndIndex(
 
   streamMetadata.numFramesFromContent = all_frames.size(0);
   for (int64_t i = 0; i < all_frames.size(0); ++i) {
-    // FrameInfo struct utilizes PTS
-    FrameInfo frameInfo = {.pts = all_frames[i].item<int64_t>()};
+    FrameInfo frameInfo;
+    frameInfo.pts = all_frames[i].item<int64_t>();
     frameInfo.isKeyFrame = (is_key_frame[i].item<bool>() == true);
     streamInfos_[streamIndex].allFrames.push_back(frameInfo);
     if (frameInfo.isKeyFrame) {

--- a/src/torchcodec/_core/SingleStreamDecoder.cpp
+++ b/src/torchcodec/_core/SingleStreamDecoder.cpp
@@ -346,7 +346,7 @@ void SingleStreamDecoder::readCustomFrameMappingsUpdateMetadataAndIndex(
   streamMetadata.numFramesFromContent = all_frames.size(0);
   for (int64_t i = 0; i < all_frames.size(0); ++i) {
     // FrameInfo struct utilizes PTS
-    FrameInfo frameInfo = {.pts=all_frames[i].item<int64_t>()};
+    FrameInfo frameInfo = {.pts = all_frames[i].item<int64_t>()};
     frameInfo.isKeyFrame = (is_key_frame[i].item<bool>() == true);
     frameInfo.nextPts = (i + 1 < all_frames.size(0))
         ? all_frames[i + 1].item<int64_t>()
@@ -354,7 +354,7 @@ void SingleStreamDecoder::readCustomFrameMappingsUpdateMetadataAndIndex(
     streamInfos_[streamIndex].allFrames.push_back(frameInfo);
     if (frameInfo.isKeyFrame) {
       streamInfos_[streamIndex].keyFrames.push_back(frameInfo);
-    } 
+    }
   }
 }
 

--- a/src/torchcodec/_core/SingleStreamDecoder.cpp
+++ b/src/torchcodec/_core/SingleStreamDecoder.cpp
@@ -346,12 +346,15 @@ void SingleStreamDecoder::readCustomFrameMappingsUpdateMetadataAndIndex(
   streamMetadata.numFramesFromContent = all_frames.size(0);
   for (int64_t i = 0; i < all_frames.size(0); ++i) {
     // FrameInfo struct utilizes PTS
-    FrameInfo frameInfo = {all_frames[i].item<int64_t>()};
+    FrameInfo frameInfo = {.pts=all_frames[i].item<int64_t>()};
     frameInfo.isKeyFrame = (is_key_frame[i].item<bool>() == true);
     frameInfo.nextPts = (i + 1 < all_frames.size(0))
         ? all_frames[i + 1].item<int64_t>()
         : INT64_MAX;
     streamInfos_[streamIndex].allFrames.push_back(frameInfo);
+    if (frameInfo.isKeyFrame) {
+      streamInfos_[streamIndex].keyFrames.push_back(frameInfo);
+    } 
   }
 }
 

--- a/src/torchcodec/_core/SingleStreamDecoder.cpp
+++ b/src/torchcodec/_core/SingleStreamDecoder.cpp
@@ -199,6 +199,10 @@ int SingleStreamDecoder::getBestStreamIndex(AVMediaType mediaType) {
 // --------------------------------------------------------------------------
 
 void SingleStreamDecoder::sortAllFrames() {
+  // Sort the allFrames and keyFrames vecs in each stream, and also sets
+  // additional fields of the FrameInfo entries like nextPts and frameIndex
+  // This is called at the end of a scan, or when setting a user-defined frame
+  // mapping.
   for (auto& [streamIndex, streamInfo] : streamInfos_) {
     std::sort(
         streamInfo.keyFrames.begin(),
@@ -350,7 +354,7 @@ void SingleStreamDecoder::readCustomFrameMappingsUpdateMetadataAndIndex(
   for (int64_t i = 0; i < all_frames.size(0); ++i) {
     FrameInfo frameInfo;
     frameInfo.pts = all_frames[i].item<int64_t>();
-    frameInfo.isKeyFrame = (is_key_frame[i].item<bool>() == true);
+    frameInfo.isKeyFrame = is_key_frame[i].item<bool>();
     streamInfos_[streamIndex].allFrames.push_back(frameInfo);
     if (frameInfo.isKeyFrame) {
       streamInfos_[streamIndex].keyFrames.push_back(frameInfo);

--- a/src/torchcodec/_core/SingleStreamDecoder.cpp
+++ b/src/torchcodec/_core/SingleStreamDecoder.cpp
@@ -321,10 +321,10 @@ void SingleStreamDecoder::scanFileAndUpdateMetadataAndIndex() {
 
 void SingleStreamDecoder::readCustomFrameMappingsUpdateMetadataAndIndex(
     int streamIndex,
-    CustomFrameMappings customFrameMappings) {
-  auto& all_frames = customFrameMappings.all_frames;
-  auto& is_key_frame = customFrameMappings.is_key_frame;
-  auto& duration = customFrameMappings.duration;
+    std::tuple<at::Tensor, at::Tensor, at::Tensor> customFrameMappings) {
+  auto& all_frames = std::get<0>(customFrameMappings);
+  auto& is_key_frame = std::get<1>(customFrameMappings);
+  auto& duration = std::get<2>(customFrameMappings);
   TORCH_CHECK(
       all_frames.size(0) == is_key_frame.size(0) &&
           is_key_frame.size(0) == duration.size(0),
@@ -468,7 +468,8 @@ void SingleStreamDecoder::addStream(
 void SingleStreamDecoder::addVideoStream(
     int streamIndex,
     const VideoStreamOptions& videoStreamOptions,
-    std::optional<CustomFrameMappings> customFrameMappings) {
+    std::optional<std::tuple<at::Tensor, at::Tensor, at::Tensor>>
+        customFrameMappings) {
   addStream(
       streamIndex,
       AVMEDIA_TYPE_VIDEO,

--- a/src/torchcodec/_core/SingleStreamDecoder.cpp
+++ b/src/torchcodec/_core/SingleStreamDecoder.cpp
@@ -326,7 +326,8 @@ void SingleStreamDecoder::readCustomFrameMappingsUpdateMetadataAndIndex(
   auto& is_key_frame = std::get<1>(customFrameMappings);
   auto& duration = std::get<2>(customFrameMappings);
   TORCH_CHECK(
-      all_frames.size(0) == is_key_frame.size(0) && is_key_frame.size(0) == duration.size(0),
+      all_frames.size(0) == is_key_frame.size(0) &&
+          is_key_frame.size(0) == duration.size(0),
       "all_frames, is_key_frame, and duration from custom_frame_mappings were not same size.");
 
   auto& streamMetadata = containerMetadata_.allStreamMetadata[streamIndex];
@@ -346,8 +347,7 @@ void SingleStreamDecoder::readCustomFrameMappingsUpdateMetadataAndIndex(
   for (int64_t i = 0; i < all_frames.size(0); ++i) {
     // FrameInfo struct utilizes PTS
     FrameInfo frameInfo = {all_frames[i].item<int64_t>()};
-    frameInfo.isKeyFrame =
-        (is_key_frame[i].item<int64_t>() == 1);
+    frameInfo.isKeyFrame = (is_key_frame[i].item<int64_t>() == 1);
     frameInfo.nextPts = (i + 1 < all_frames.size(0))
         ? all_frames[i + 1].item<int64_t>()
         : INT64_MAX;
@@ -468,7 +468,8 @@ void SingleStreamDecoder::addStream(
 void SingleStreamDecoder::addVideoStream(
     int streamIndex,
     const VideoStreamOptions& videoStreamOptions,
-    std::optional<std::tuple<at::Tensor, at::Tensor, at::Tensor>> customFrameMappings) {
+    std::optional<std::tuple<at::Tensor, at::Tensor, at::Tensor>>
+        customFrameMappings) {
   addStream(
       streamIndex,
       AVMEDIA_TYPE_VIDEO,
@@ -498,7 +499,8 @@ void SingleStreamDecoder::addVideoStream(
     TORCH_CHECK(
         customFrameMappings.has_value(),
         "Please provide frame mappings when using custom_frame_mappings seek mode.");
-    readCustomFrameMappingsUpdateMetadataAndIndex(streamIndex, customFrameMappings.value());
+    readCustomFrameMappingsUpdateMetadataAndIndex(
+        streamIndex, customFrameMappings.value());
   }
 }
 

--- a/src/torchcodec/_core/SingleStreamDecoder.cpp
+++ b/src/torchcodec/_core/SingleStreamDecoder.cpp
@@ -351,9 +351,6 @@ void SingleStreamDecoder::readCustomFrameMappingsUpdateMetadataAndIndex(
     // FrameInfo struct utilizes PTS
     FrameInfo frameInfo = {.pts = all_frames[i].item<int64_t>()};
     frameInfo.isKeyFrame = (is_key_frame[i].item<bool>() == true);
-    frameInfo.nextPts = (i + 1 < all_frames.size(0))
-        ? all_frames[i + 1].item<int64_t>()
-        : INT64_MAX;
     streamInfos_[streamIndex].allFrames.push_back(frameInfo);
     if (frameInfo.isKeyFrame) {
       streamInfos_[streamIndex].keyFrames.push_back(frameInfo);

--- a/src/torchcodec/_core/SingleStreamDecoder.cpp
+++ b/src/torchcodec/_core/SingleStreamDecoder.cpp
@@ -321,10 +321,10 @@ void SingleStreamDecoder::scanFileAndUpdateMetadataAndIndex() {
 
 void SingleStreamDecoder::readCustomFrameMappingsUpdateMetadataAndIndex(
     int streamIndex,
-    std::tuple<at::Tensor, at::Tensor, at::Tensor> customFrameMappings) {
-  auto& all_frames = std::get<0>(customFrameMappings);
-  auto& is_key_frame = std::get<1>(customFrameMappings);
-  auto& duration = std::get<2>(customFrameMappings);
+    FrameMappings customFrameMappings) {
+  auto& all_frames = customFrameMappings.all_frames;
+  auto& is_key_frame = customFrameMappings.is_key_frame;
+  auto& duration = customFrameMappings.duration;
   TORCH_CHECK(
       all_frames.size(0) == is_key_frame.size(0) &&
           is_key_frame.size(0) == duration.size(0),
@@ -471,8 +471,7 @@ void SingleStreamDecoder::addStream(
 void SingleStreamDecoder::addVideoStream(
     int streamIndex,
     const VideoStreamOptions& videoStreamOptions,
-    std::optional<std::tuple<at::Tensor, at::Tensor, at::Tensor>>
-        customFrameMappings) {
+    std::optional<FrameMappings> customFrameMappings) {
   addStream(
       streamIndex,
       AVMEDIA_TYPE_VIDEO,

--- a/src/torchcodec/_core/SingleStreamDecoder.cpp
+++ b/src/torchcodec/_core/SingleStreamDecoder.cpp
@@ -319,8 +319,9 @@ void SingleStreamDecoder::scanFileAndUpdateMetadataAndIndex() {
   scannedAllStreams_ = true;
 }
 
-
-void SingleStreamDecoder::readFrameIndexUpdateMetadataAndIndex(int streamIndex, std::tuple<at::Tensor, at::Tensor, at::Tensor> frameIndex){
+void SingleStreamDecoder::readFrameIndexUpdateMetadataAndIndex(
+    int streamIndex,
+    std::tuple<at::Tensor, at::Tensor, at::Tensor> frameIndex) {
   if (readFrameIndex_) {
     return;
   }
@@ -333,12 +334,12 @@ void SingleStreamDecoder::readFrameIndexUpdateMetadataAndIndex(int streamIndex, 
   // Get the last index for key_frames and duration
   auto last_idx = all_frames.size(0) - 1;
   streamMetadata.beginStreamPtsFromContent = all_frames[0].item<int64_t>();
-  streamMetadata.endStreamPtsFromContent = all_frames[last_idx].item<int64_t>() + duration[last_idx].item<int64_t>();
+  streamMetadata.endStreamPtsFromContent =
+      all_frames[last_idx].item<int64_t>() + duration[last_idx].item<int64_t>();
 
   auto avStream = formatContext_->streams[streamIndex];
   streamMetadata.beginStreamPtsSecondsFromContent =
-      *streamMetadata.beginStreamPtsFromContent *
-      av_q2d(avStream->time_base);
+      *streamMetadata.beginStreamPtsFromContent * av_q2d(avStream->time_base);
 
   streamMetadata.endStreamPtsSecondsFromContent =
       *streamMetadata.endStreamPtsFromContent * av_q2d(avStream->time_base);
@@ -347,8 +348,11 @@ void SingleStreamDecoder::readFrameIndexUpdateMetadataAndIndex(int streamIndex, 
   for (int64_t i = 0; i < all_frames.size(0); ++i) {
     // FrameInfo struct utilizes PTS
     FrameInfo frameInfo = {all_frames[i].item<int64_t>()};
-    frameInfo.isKeyFrame = (i < key_frames.size(0) && key_frames[i].item<int64_t>() == 1);
-    frameInfo.nextPts = (i + 1 < all_frames.size(0)) ? all_frames[i + 1].item<int64_t>() : INT64_MAX;
+    frameInfo.isKeyFrame =
+        (i < key_frames.size(0) && key_frames[i].item<int64_t>() == 1);
+    frameInfo.nextPts = (i + 1 < all_frames.size(0))
+        ? all_frames[i + 1].item<int64_t>()
+        : INT64_MAX;
     streamInfos_[streamIndex].allFrames.push_back(frameInfo);
   }
   readFrameIndex_ = true;
@@ -466,7 +470,7 @@ void SingleStreamDecoder::addStream(
 
 void SingleStreamDecoder::addVideoStream(
     int streamIndex,
-    const VideoStreamOptions& videoStreamOptions, 
+    const VideoStreamOptions& videoStreamOptions,
     std::optional<std::tuple<at::Tensor, at::Tensor, at::Tensor>> frameIndex) {
   addStream(
       streamIndex,
@@ -494,7 +498,9 @@ void SingleStreamDecoder::addVideoStream(
       streamInfo.codecContext->sample_aspect_ratio;
 
   if (seekMode_ == SeekMode::frame_index) {
-    TORCH_CHECK(frameIndex.has_value(), "Please provide a frame index when using frame_index seek mode.");
+    TORCH_CHECK(
+        frameIndex.has_value(),
+        "Please provide a frame index when using frame_index seek mode.");
     readFrameIndexUpdateMetadataAndIndex(streamIndex, frameIndex.value());
   }
 }
@@ -638,7 +644,7 @@ FrameBatchOutput SingleStreamDecoder::getFramesInRange(
     int64_t stop,
     int64_t step) {
   validateActiveStream(AVMEDIA_TYPE_VIDEO);
-  
+
   const auto& streamMetadata =
       containerMetadata_.allStreamMetadata[activeStreamIndex_];
   const auto& streamInfo = streamInfos_[activeStreamIndex_];
@@ -1487,7 +1493,7 @@ int64_t SingleStreamDecoder::secondsToIndexUpperBound(double seconds) {
           });
 
       return frame - streamInfo.allFrames.begin();
-    } 
+    }
     case SeekMode::approximate: {
       auto& streamMetadata =
           containerMetadata_.allStreamMetadata[activeStreamIndex_];

--- a/src/torchcodec/_core/SingleStreamDecoder.h
+++ b/src/torchcodec/_core/SingleStreamDecoder.h
@@ -29,7 +29,7 @@ class SingleStreamDecoder {
   // CONSTRUCTION API
   // --------------------------------------------------------------------------
 
-  enum class SeekMode { exact, approximate, frame_index };
+  enum class SeekMode { exact, approximate, custom_frame_mappings };
 
   // Creates a SingleStreamDecoder from the video at videoFilePath.
   explicit SingleStreamDecoder(
@@ -56,9 +56,9 @@ class SingleStreamDecoder {
   // Reads the user provided frame index and updates each StreamInfo's index,
   // i.e. the allFrames and keyFrames vectors, and the
   // endStreamPtsSecondsFromContent
-  void readFrameIndexUpdateMetadataAndIndex(
+  void readCustomFrameMappingsUpdateMetadataAndIndex(
       int streamIndex,
-      std::tuple<at::Tensor, at::Tensor, at::Tensor> frameIndex);
+      std::tuple<at::Tensor, at::Tensor, at::Tensor> customFrameMappings);
 
   // Returns the metadata for the container.
   ContainerMetadata getContainerMetadata() const;
@@ -74,7 +74,7 @@ class SingleStreamDecoder {
   void addVideoStream(
       int streamIndex,
       const VideoStreamOptions& videoStreamOptions = VideoStreamOptions(),
-      std::optional<std::tuple<at::Tensor, at::Tensor, at::Tensor>> frameIndex =
+      std::optional<std::tuple<at::Tensor, at::Tensor, at::Tensor>> customFrameMappings =
           std::nullopt);
   void addAudioStream(
       int streamIndex,

--- a/src/torchcodec/_core/SingleStreamDecoder.h
+++ b/src/torchcodec/_core/SingleStreamDecoder.h
@@ -58,7 +58,7 @@ class SingleStreamDecoder {
   // endStreamPtsSecondsFromContent
   void readCustomFrameMappingsUpdateMetadataAndIndex(
       int streamIndex,
-      std::tuple<at::Tensor, at::Tensor, at::Tensor> customFrameMappings);
+      FrameMappings customFrameMappings);
 
   // Returns the metadata for the container.
   ContainerMetadata getContainerMetadata() const;
@@ -74,8 +74,7 @@ class SingleStreamDecoder {
   void addVideoStream(
       int streamIndex,
       const VideoStreamOptions& videoStreamOptions = VideoStreamOptions(),
-      std::optional<std::tuple<at::Tensor, at::Tensor, at::Tensor>>
-          customFrameMappings = std::nullopt);
+      std::optional<FrameMappings> customFrameMappings = std::nullopt);
   void addAudioStream(
       int streamIndex,
       const AudioStreamOptions& audioStreamOptions = AudioStreamOptions());

--- a/src/torchcodec/_core/SingleStreamDecoder.h
+++ b/src/torchcodec/_core/SingleStreamDecoder.h
@@ -74,8 +74,8 @@ class SingleStreamDecoder {
   void addVideoStream(
       int streamIndex,
       const VideoStreamOptions& videoStreamOptions = VideoStreamOptions(),
-      std::optional<std::tuple<at::Tensor, at::Tensor, at::Tensor>> customFrameMappings =
-          std::nullopt);
+      std::optional<std::tuple<at::Tensor, at::Tensor, at::Tensor>>
+          customFrameMappings = std::nullopt);
   void addAudioStream(
       int streamIndex,
       const AudioStreamOptions& audioStreamOptions = AudioStreamOptions());

--- a/src/torchcodec/_core/SingleStreamDecoder.h
+++ b/src/torchcodec/_core/SingleStreamDecoder.h
@@ -63,19 +63,19 @@ class SingleStreamDecoder {
   // int64 values, where each value is the frame index for a key frame.
   torch::Tensor getKeyFrameIndices();
 
-// FrameMappings is used for the custom_frame_mappings seek mode to store
-// metadata of frames in a stream. The size of all tensors in this struct must
-// match.
-struct FrameMappings {
-  // 1D tensor of int64, each value is the PTS of a frame in timebase units.
-  torch::Tensor all_frames;
-  // 1D tensor of bool, each value indicates if the corresponding frame in
-  // all_frames is a key frame.
-  torch::Tensor is_key_frame;
-  // 1D tensor of int64, each value is the duration of the corresponding frame
-  // in all_frames in timebase units.
-  torch::Tensor duration;
-};
+  // FrameMappings is used for the custom_frame_mappings seek mode to store
+  // metadata of frames in a stream. The size of all tensors in this struct must
+  // match.
+  struct FrameMappings {
+    // 1D tensor of int64, each value is the PTS of a frame in timebase units.
+    torch::Tensor all_frames;
+    // 1D tensor of bool, each value indicates if the corresponding frame in
+    // all_frames is a key frame.
+    torch::Tensor is_key_frame;
+    // 1D tensor of int64, each value is the duration of the corresponding frame
+    // in all_frames in timebase units.
+    torch::Tensor duration;
+  };
 
   // Reads the user provided frame index and updates each StreamInfo's index,
   // i.e. the allFrames and keyFrames vectors, and

--- a/src/torchcodec/_core/SingleStreamDecoder.h
+++ b/src/torchcodec/_core/SingleStreamDecoder.h
@@ -29,7 +29,7 @@ class SingleStreamDecoder {
   // CONSTRUCTION API
   // --------------------------------------------------------------------------
 
-  enum class SeekMode { exact, approximate };
+  enum class SeekMode { exact, approximate, frame_index };
 
   // Creates a SingleStreamDecoder from the video at videoFilePath.
   explicit SingleStreamDecoder(
@@ -53,6 +53,10 @@ class SingleStreamDecoder {
   // the allFrames and keyFrames vectors.
   void scanFileAndUpdateMetadataAndIndex();
 
+  // Reads the user provided frame index and updates each StreamInfo's index, i.e.
+  // the allFrames and keyFrames vectors, and the endStreamPtsSecondsFromContent
+  void readFrameIndexUpdateMetadataAndIndex(int streamIndex, std::tuple<at::Tensor, at::Tensor, at::Tensor> frameIndex);
+
   // Returns the metadata for the container.
   ContainerMetadata getContainerMetadata() const;
 
@@ -66,7 +70,8 @@ class SingleStreamDecoder {
 
   void addVideoStream(
       int streamIndex,
-      const VideoStreamOptions& videoStreamOptions = VideoStreamOptions());
+      const VideoStreamOptions& videoStreamOptions = VideoStreamOptions(),
+      std::optional<std::tuple<at::Tensor, at::Tensor, at::Tensor>> frameIndex = std::nullopt);
   void addAudioStream(
       int streamIndex,
       const AudioStreamOptions& audioStreamOptions = AudioStreamOptions());
@@ -343,6 +348,8 @@ class SingleStreamDecoder {
   bool scannedAllStreams_ = false;
   // Tracks that we've already been initialized.
   bool initialized_ = false;
+  // Tracks that frame index has been ingested
+  bool readFrameIndex_ = false;
 };
 
 // Prints the SingleStreamDecoder::DecodeStats to the ostream.

--- a/src/torchcodec/_core/SingleStreamDecoder.h
+++ b/src/torchcodec/_core/SingleStreamDecoder.h
@@ -53,19 +53,32 @@ class SingleStreamDecoder {
   // the allFrames and keyFrames vectors.
   void scanFileAndUpdateMetadataAndIndex();
 
-  // Reads the user provided frame index and updates each StreamInfo's index,
-  // i.e. the allFrames and keyFrames vectors, and the
-  // endStreamPtsSecondsFromContent
-  void readCustomFrameMappingsUpdateMetadataAndIndex(
-      int streamIndex,
-      std::tuple<at::Tensor, at::Tensor, at::Tensor> customFrameMappings);
-
   // Returns the metadata for the container.
   ContainerMetadata getContainerMetadata() const;
 
   // Returns the key frame indices as a tensor. The tensor is 1D and contains
   // int64 values, where each value is the frame index for a key frame.
   torch::Tensor getKeyFrameIndices();
+
+  struct CustomFrameMappings {
+    // all_frames is a 1D tensor of int64 values, where each value is the PTS
+    // for a frame in the stream.
+    // The size of all tensors in this struct must match.
+    torch::Tensor all_frames;
+    // is_key_frame is a 1D tensor of bool values, and indicates
+    // whether the corresponding frame in all_frames is a key frame.
+    torch::Tensor is_key_frame;
+    // duration is a 1D tensor of int64 values, where each value is the duration
+    // of the corresponding frame in all_frames.
+    torch::Tensor duration;
+  };
+
+  // Reads the user provided frame index and updates each StreamInfo's index,
+  // i.e. the allFrames and keyFrames vectors, and
+  // endStreamPtsSecondsFromContent
+  void readCustomFrameMappingsUpdateMetadataAndIndex(
+      int streamIndex,
+      CustomFrameMappings customFrameMappings);
 
   // --------------------------------------------------------------------------
   // ADDING STREAMS API
@@ -74,8 +87,7 @@ class SingleStreamDecoder {
   void addVideoStream(
       int streamIndex,
       const VideoStreamOptions& videoStreamOptions = VideoStreamOptions(),
-      std::optional<std::tuple<at::Tensor, at::Tensor, at::Tensor>>
-          customFrameMappings = std::nullopt);
+      std::optional<CustomFrameMappings> customFrameMappings = std::nullopt);
   void addAudioStream(
       int streamIndex,
       const AudioStreamOptions& audioStreamOptions = AudioStreamOptions());

--- a/src/torchcodec/_core/SingleStreamDecoder.h
+++ b/src/torchcodec/_core/SingleStreamDecoder.h
@@ -53,32 +53,19 @@ class SingleStreamDecoder {
   // the allFrames and keyFrames vectors.
   void scanFileAndUpdateMetadataAndIndex();
 
+  // Reads the user provided frame index and updates each StreamInfo's index,
+  // i.e. the allFrames and keyFrames vectors, and
+  // endStreamPtsSecondsFromContent
+  void readCustomFrameMappingsUpdateMetadataAndIndex(
+      int streamIndex,
+      std::tuple<at::Tensor, at::Tensor, at::Tensor> customFrameMappings);
+
   // Returns the metadata for the container.
   ContainerMetadata getContainerMetadata() const;
 
   // Returns the key frame indices as a tensor. The tensor is 1D and contains
   // int64 values, where each value is the frame index for a key frame.
   torch::Tensor getKeyFrameIndices();
-
-  struct CustomFrameMappings {
-    // all_frames is a 1D tensor of int64 values, where each value is the PTS
-    // for a frame in the stream.
-    // The size of all tensors in this struct must match.
-    torch::Tensor all_frames;
-    // is_key_frame is a 1D tensor of bool values, and indicates
-    // whether the corresponding frame in all_frames is a key frame.
-    torch::Tensor is_key_frame;
-    // duration is a 1D tensor of int64 values, where each value is the duration
-    // of the corresponding frame in all_frames.
-    torch::Tensor duration;
-  };
-
-  // Reads the user provided frame index and updates each StreamInfo's index,
-  // i.e. the allFrames and keyFrames vectors, and
-  // endStreamPtsSecondsFromContent
-  void readCustomFrameMappingsUpdateMetadataAndIndex(
-      int streamIndex,
-      CustomFrameMappings customFrameMappings);
 
   // --------------------------------------------------------------------------
   // ADDING STREAMS API
@@ -87,7 +74,8 @@ class SingleStreamDecoder {
   void addVideoStream(
       int streamIndex,
       const VideoStreamOptions& videoStreamOptions = VideoStreamOptions(),
-      std::optional<CustomFrameMappings> customFrameMappings = std::nullopt);
+      std::optional<std::tuple<at::Tensor, at::Tensor, at::Tensor>>
+          customFrameMappings = std::nullopt);
   void addAudioStream(
       int streamIndex,
       const AudioStreamOptions& audioStreamOptions = AudioStreamOptions());

--- a/src/torchcodec/_core/SingleStreamDecoder.h
+++ b/src/torchcodec/_core/SingleStreamDecoder.h
@@ -53,9 +53,12 @@ class SingleStreamDecoder {
   // the allFrames and keyFrames vectors.
   void scanFileAndUpdateMetadataAndIndex();
 
-  // Reads the user provided frame index and updates each StreamInfo's index, i.e.
-  // the allFrames and keyFrames vectors, and the endStreamPtsSecondsFromContent
-  void readFrameIndexUpdateMetadataAndIndex(int streamIndex, std::tuple<at::Tensor, at::Tensor, at::Tensor> frameIndex);
+  // Reads the user provided frame index and updates each StreamInfo's index,
+  // i.e. the allFrames and keyFrames vectors, and the
+  // endStreamPtsSecondsFromContent
+  void readFrameIndexUpdateMetadataAndIndex(
+      int streamIndex,
+      std::tuple<at::Tensor, at::Tensor, at::Tensor> frameIndex);
 
   // Returns the metadata for the container.
   ContainerMetadata getContainerMetadata() const;
@@ -71,7 +74,8 @@ class SingleStreamDecoder {
   void addVideoStream(
       int streamIndex,
       const VideoStreamOptions& videoStreamOptions = VideoStreamOptions(),
-      std::optional<std::tuple<at::Tensor, at::Tensor, at::Tensor>> frameIndex = std::nullopt);
+      std::optional<std::tuple<at::Tensor, at::Tensor, at::Tensor>> frameIndex =
+          std::nullopt);
   void addAudioStream(
       int streamIndex,
       const AudioStreamOptions& audioStreamOptions = AudioStreamOptions());

--- a/src/torchcodec/_core/SingleStreamDecoder.h
+++ b/src/torchcodec/_core/SingleStreamDecoder.h
@@ -53,13 +53,6 @@ class SingleStreamDecoder {
   // the allFrames and keyFrames vectors.
   void scanFileAndUpdateMetadataAndIndex();
 
-  // Reads the user provided frame index and updates each StreamInfo's index,
-  // i.e. the allFrames and keyFrames vectors, and
-  // endStreamPtsSecondsFromContent
-  void readCustomFrameMappingsUpdateMetadataAndIndex(
-      int streamIndex,
-      FrameMappings customFrameMappings);
-
   // Sorts the keyFrames and allFrames vectors in each StreamInfo by pts.
   void sortAllFrames();
 
@@ -69,6 +62,27 @@ class SingleStreamDecoder {
   // Returns the key frame indices as a tensor. The tensor is 1D and contains
   // int64 values, where each value is the frame index for a key frame.
   torch::Tensor getKeyFrameIndices();
+
+// FrameMappings is used for the custom_frame_mappings seek mode to store
+// metadata of frames in a stream. The size of all tensors in this struct must
+// match.
+struct FrameMappings {
+  // 1D tensor of int64, each value is the PTS of a frame in timebase units.
+  torch::Tensor all_frames;
+  // 1D tensor of bool, each value indicates if the corresponding frame in
+  // all_frames is a key frame.
+  torch::Tensor is_key_frame;
+  // 1D tensor of int64, each value is the duration of the corresponding frame
+  // in all_frames in timebase units.
+  torch::Tensor duration;
+};
+
+  // Reads the user provided frame index and updates each StreamInfo's index,
+  // i.e. the allFrames and keyFrames vectors, and
+  // endStreamPtsSecondsFromContent
+  void readCustomFrameMappingsUpdateMetadataAndIndex(
+      int streamIndex,
+      FrameMappings customFrameMappings);
 
   // --------------------------------------------------------------------------
   // ADDING STREAMS API

--- a/src/torchcodec/_core/SingleStreamDecoder.h
+++ b/src/torchcodec/_core/SingleStreamDecoder.h
@@ -60,6 +60,9 @@ class SingleStreamDecoder {
       int streamIndex,
       FrameMappings customFrameMappings);
 
+  // Sorts the keyFrames and allFrames vectors in each StreamInfo by pts.
+  void sortAllFrames();
+
   // Returns the metadata for the container.
   ContainerMetadata getContainerMetadata() const;
 

--- a/src/torchcodec/_core/SingleStreamDecoder.h
+++ b/src/torchcodec/_core/SingleStreamDecoder.h
@@ -352,8 +352,6 @@ class SingleStreamDecoder {
   bool scannedAllStreams_ = false;
   // Tracks that we've already been initialized.
   bool initialized_ = false;
-  // Tracks that frame index has been ingested
-  bool readFrameIndex_ = false;
 };
 
 // Prints the SingleStreamDecoder::DecodeStats to the ostream.

--- a/src/torchcodec/_core/SingleStreamDecoder.h
+++ b/src/torchcodec/_core/SingleStreamDecoder.h
@@ -66,6 +66,10 @@ class SingleStreamDecoder {
   // FrameMappings is used for the custom_frame_mappings seek mode to store
   // metadata of frames in a stream. The size of all tensors in this struct must
   // match.
+
+  // --------------------------------------------------------------------------
+  // ADDING STREAMS API
+  // --------------------------------------------------------------------------
   struct FrameMappings {
     // 1D tensor of int64, each value is the PTS of a frame in timebase units.
     torch::Tensor all_frames;
@@ -76,17 +80,6 @@ class SingleStreamDecoder {
     // in all_frames in timebase units.
     torch::Tensor duration;
   };
-
-  // Reads the user provided frame index and updates each StreamInfo's index,
-  // i.e. the allFrames and keyFrames vectors, and
-  // endStreamPtsSecondsFromContent
-  void readCustomFrameMappingsUpdateMetadataAndIndex(
-      int streamIndex,
-      FrameMappings customFrameMappings);
-
-  // --------------------------------------------------------------------------
-  // ADDING STREAMS API
-  // --------------------------------------------------------------------------
 
   void addVideoStream(
       int streamIndex,
@@ -251,6 +244,13 @@ class SingleStreamDecoder {
   // --------------------------------------------------------------------------
 
   void initializeDecoder();
+
+  // Reads the user provided frame index and updates each StreamInfo's index,
+  // i.e. the allFrames and keyFrames vectors, and
+  // endStreamPtsSecondsFromContent
+  void readCustomFrameMappingsUpdateMetadataAndIndex(
+      int streamIndex,
+      FrameMappings customFrameMappings);
   // --------------------------------------------------------------------------
   // DECODING APIS AND RELATED UTILS
   // --------------------------------------------------------------------------

--- a/src/torchcodec/_core/custom_ops.cpp
+++ b/src/torchcodec/_core/custom_ops.cpp
@@ -255,10 +255,17 @@ void _add_video_stream(
   if (device.has_value()) {
     videoStreamOptions.device = createTorchDevice(std::string(device.value()));
   }
+  std::optional<SingleStreamDecoder::CustomFrameMappings> converted_mappings =
+      custom_frame_mappings.has_value()
+      ? std::make_optional(SingleStreamDecoder::CustomFrameMappings{
+            std::get<0>(custom_frame_mappings.value()),
+            std::get<1>(custom_frame_mappings.value()),
+            std::get<2>(custom_frame_mappings.value())})
+      : std::nullopt;
 
   auto videoDecoder = unwrapTensorToGetDecoder(decoder);
   videoDecoder->addVideoStream(
-      stream_index.value_or(-1), videoStreamOptions, custom_frame_mappings);
+      stream_index.value_or(-1), videoStreamOptions, converted_mappings);
 }
 
 // Add a new video stream at `stream_index` using the provided options.

--- a/src/torchcodec/_core/custom_ops.cpp
+++ b/src/torchcodec/_core/custom_ops.cpp
@@ -223,8 +223,8 @@ void _add_video_stream(
     std::optional<std::string_view> dimension_order = std::nullopt,
     std::optional<int64_t> stream_index = std::nullopt,
     std::optional<std::string_view> device = std::nullopt,
-    std::optional<std::tuple<at::Tensor, at::Tensor, at::Tensor>> custom_frame_mappings =
-        std::nullopt,
+    std::optional<std::tuple<at::Tensor, at::Tensor, at::Tensor>>
+        custom_frame_mappings = std::nullopt,
     std::optional<std::string_view> color_conversion_library = std::nullopt) {
   VideoStreamOptions videoStreamOptions;
   videoStreamOptions.width = width;
@@ -270,8 +270,8 @@ void add_video_stream(
     std::optional<std::string_view> dimension_order = std::nullopt,
     std::optional<int64_t> stream_index = std::nullopt,
     std::optional<std::string_view> device = std::nullopt,
-    std::optional<std::tuple<at::Tensor, at::Tensor, at::Tensor>> custom_frame_mappings =
-        std::nullopt) {
+    std::optional<std::tuple<at::Tensor, at::Tensor, at::Tensor>>
+        custom_frame_mappings = std::nullopt) {
   _add_video_stream(
       decoder,
       width,

--- a/src/torchcodec/_core/custom_ops.cpp
+++ b/src/torchcodec/_core/custom_ops.cpp
@@ -36,9 +36,9 @@ TORCH_LIBRARY(torchcodec_ns, m) {
       "create_from_tensor(Tensor video_tensor, str? seek_mode=None) -> Tensor");
   m.def("_convert_to_tensor(int decoder_ptr) -> Tensor");
   m.def(
-      "_add_video_stream(Tensor(a!) decoder, *, int? width=None, int? height=None, int? num_threads=None, str? dimension_order=None, int? stream_index=None, str? device=None, (Tensor, Tensor, Tensor)? frame_index=None, str? color_conversion_library=None) -> ()");
+      "_add_video_stream(Tensor(a!) decoder, *, int? width=None, int? height=None, int? num_threads=None, str? dimension_order=None, int? stream_index=None, str? device=None, (Tensor, Tensor, Tensor)? custom_frame_mappings=None, str? color_conversion_library=None) -> ()");
   m.def(
-      "add_video_stream(Tensor(a!) decoder, *, int? width=None, int? height=None, int? num_threads=None, str? dimension_order=None, int? stream_index=None, str? device=None, (Tensor, Tensor, Tensor)? frame_index=None) -> ()");
+      "add_video_stream(Tensor(a!) decoder, *, int? width=None, int? height=None, int? num_threads=None, str? dimension_order=None, int? stream_index=None, str? device=None, (Tensor, Tensor, Tensor)? custom_frame_mappings=None) -> ()");
   m.def(
       "add_audio_stream(Tensor(a!) decoder, *, int? stream_index=None, int? sample_rate=None, int? num_channels=None) -> ()");
   m.def("seek_to_pts(Tensor(a!) decoder, float seconds) -> ()");
@@ -223,7 +223,7 @@ void _add_video_stream(
     std::optional<std::string_view> dimension_order = std::nullopt,
     std::optional<int64_t> stream_index = std::nullopt,
     std::optional<std::string_view> device = std::nullopt,
-    std::optional<std::tuple<at::Tensor, at::Tensor, at::Tensor>> frame_index =
+    std::optional<std::tuple<at::Tensor, at::Tensor, at::Tensor>> custom_frame_mappings =
         std::nullopt,
     std::optional<std::string_view> color_conversion_library = std::nullopt) {
   VideoStreamOptions videoStreamOptions;
@@ -258,7 +258,7 @@ void _add_video_stream(
 
   auto videoDecoder = unwrapTensorToGetDecoder(decoder);
   videoDecoder->addVideoStream(
-      stream_index.value_or(-1), videoStreamOptions, frame_index);
+      stream_index.value_or(-1), videoStreamOptions, custom_frame_mappings);
 }
 
 // Add a new video stream at `stream_index` using the provided options.
@@ -270,7 +270,7 @@ void add_video_stream(
     std::optional<std::string_view> dimension_order = std::nullopt,
     std::optional<int64_t> stream_index = std::nullopt,
     std::optional<std::string_view> device = std::nullopt,
-    std::optional<std::tuple<at::Tensor, at::Tensor, at::Tensor>> frame_index =
+    std::optional<std::tuple<at::Tensor, at::Tensor, at::Tensor>> custom_frame_mappings =
         std::nullopt) {
   _add_video_stream(
       decoder,
@@ -280,7 +280,7 @@ void add_video_stream(
       dimension_order,
       stream_index,
       device,
-      frame_index);
+      custom_frame_mappings);
 }
 
 void add_audio_stream(

--- a/src/torchcodec/_core/custom_ops.cpp
+++ b/src/torchcodec/_core/custom_ops.cpp
@@ -255,17 +255,9 @@ void _add_video_stream(
   if (device.has_value()) {
     videoStreamOptions.device = createTorchDevice(std::string(device.value()));
   }
-  std::optional<SingleStreamDecoder::CustomFrameMappings> converted_mappings =
-      custom_frame_mappings.has_value()
-      ? std::make_optional(SingleStreamDecoder::CustomFrameMappings{
-            std::get<0>(custom_frame_mappings.value()),
-            std::get<1>(custom_frame_mappings.value()),
-            std::get<2>(custom_frame_mappings.value())})
-      : std::nullopt;
-
   auto videoDecoder = unwrapTensorToGetDecoder(decoder);
   videoDecoder->addVideoStream(
-      stream_index.value_or(-1), videoStreamOptions, converted_mappings);
+      stream_index.value_or(-1), videoStreamOptions, custom_frame_mappings);
 }
 
 // Add a new video stream at `stream_index` using the provided options.

--- a/src/torchcodec/_core/custom_ops.cpp
+++ b/src/torchcodec/_core/custom_ops.cpp
@@ -36,9 +36,9 @@ TORCH_LIBRARY(torchcodec_ns, m) {
       "create_from_tensor(Tensor video_tensor, str? seek_mode=None) -> Tensor");
   m.def("_convert_to_tensor(int decoder_ptr) -> Tensor");
   m.def(
-      "_add_video_stream(Tensor(a!) decoder, *, int? width=None, int? height=None, int? num_threads=None, str? dimension_order=None, int? stream_index=None, str? device=None, str? color_conversion_library=None, (Tensor, Tensor, Tensor)? frame_index=None) -> ()");
+      "_add_video_stream(Tensor(a!) decoder, *, int? width=None, int? height=None, int? num_threads=None, str? dimension_order=None, int? stream_index=None, str? device=None, (Tensor, Tensor, Tensor)? frame_index=None, str? color_conversion_library=None) -> ()");
   m.def(
-      "add_video_stream(Tensor(a!) decoder, *, int? width=None, int? height=None, int? num_threads=None, str? dimension_order=None, int? stream_index=None, str? device=None, str? color_conversion_library=None, (Tensor, Tensor, Tensor)? frame_index=None) -> ()");
+      "add_video_stream(Tensor(a!) decoder, *, int? width=None, int? height=None, int? num_threads=None, str? dimension_order=None, int? stream_index=None, str? device=None, (Tensor, Tensor, Tensor)? frame_index=None) -> ()");
   m.def(
       "add_audio_stream(Tensor(a!) decoder, *, int? stream_index=None, int? sample_rate=None, int? num_channels=None) -> ()");
   m.def("seek_to_pts(Tensor(a!) decoder, float seconds) -> ()");
@@ -223,9 +223,9 @@ void _add_video_stream(
     std::optional<std::string_view> dimension_order = std::nullopt,
     std::optional<int64_t> stream_index = std::nullopt,
     std::optional<std::string_view> device = std::nullopt,
-    std::optional<std::string_view> color_conversion_library = std::nullopt,
     std::optional<std::tuple<at::Tensor, at::Tensor, at::Tensor>> frame_index =
-        std::nullopt) {
+        std::nullopt,
+    std::optional<std::string_view> color_conversion_library = std::nullopt) {
   VideoStreamOptions videoStreamOptions;
   videoStreamOptions.width = width;
   videoStreamOptions.height = height;
@@ -270,7 +270,6 @@ void add_video_stream(
     std::optional<std::string_view> dimension_order = std::nullopt,
     std::optional<int64_t> stream_index = std::nullopt,
     std::optional<std::string_view> device = std::nullopt,
-    std::optional<std::string_view> color_conversion_library = std::nullopt,
     std::optional<std::tuple<at::Tensor, at::Tensor, at::Tensor>> frame_index =
         std::nullopt) {
   _add_video_stream(
@@ -281,7 +280,6 @@ void add_video_stream(
       dimension_order,
       stream_index,
       device,
-      color_conversion_library,
       frame_index);
 }
 

--- a/src/torchcodec/_core/custom_ops.cpp
+++ b/src/torchcodec/_core/custom_ops.cpp
@@ -180,7 +180,7 @@ at::Tensor create_from_file(
   if (seek_mode.has_value()) {
     realSeek = seekModeFromString(seek_mode.value());
   }
-  
+
   std::unique_ptr<SingleStreamDecoder> uniqueDecoder =
       std::make_unique<SingleStreamDecoder>(filenameStr, realSeek);
 
@@ -224,7 +224,8 @@ void _add_video_stream(
     std::optional<int64_t> stream_index = std::nullopt,
     std::optional<std::string_view> device = std::nullopt,
     std::optional<std::string_view> color_conversion_library = std::nullopt,
-    std::optional<std::tuple<at::Tensor, at::Tensor, at::Tensor>> frame_index = std::nullopt) {
+    std::optional<std::tuple<at::Tensor, at::Tensor, at::Tensor>> frame_index =
+        std::nullopt) {
   VideoStreamOptions videoStreamOptions;
   videoStreamOptions.width = width;
   videoStreamOptions.height = height;
@@ -256,7 +257,8 @@ void _add_video_stream(
   }
 
   auto videoDecoder = unwrapTensorToGetDecoder(decoder);
-  videoDecoder->addVideoStream(stream_index.value_or(-1), videoStreamOptions, frame_index);
+  videoDecoder->addVideoStream(
+      stream_index.value_or(-1), videoStreamOptions, frame_index);
 }
 
 // Add a new video stream at `stream_index` using the provided options.
@@ -269,7 +271,8 @@ void add_video_stream(
     std::optional<int64_t> stream_index = std::nullopt,
     std::optional<std::string_view> device = std::nullopt,
     std::optional<std::string_view> color_conversion_library = std::nullopt,
-    std::optional<std::tuple<at::Tensor, at::Tensor, at::Tensor>> frame_index = std::nullopt) {
+    std::optional<std::tuple<at::Tensor, at::Tensor, at::Tensor>> frame_index =
+        std::nullopt) {
   _add_video_stream(
       decoder,
       width,

--- a/src/torchcodec/_core/custom_ops.cpp
+++ b/src/torchcodec/_core/custom_ops.cpp
@@ -105,9 +105,9 @@ OpsFrameOutput makeOpsFrameOutput(FrameOutput& frame) {
       torch::tensor(frame.durationSeconds, torch::dtype(torch::kFloat64)));
 }
 
-FrameMappings makeFrameMappings(
+SingleStreamDecoder::FrameMappings makeFrameMappings(
     std::tuple<at::Tensor, at::Tensor, at::Tensor> custom_frame_mappings) {
-  return FrameMappings{
+  return SingleStreamDecoder::FrameMappings{
       std::get<0>(custom_frame_mappings),
       std::get<1>(custom_frame_mappings),
       std::get<2>(custom_frame_mappings)};
@@ -263,7 +263,7 @@ void _add_video_stream(
   if (device.has_value()) {
     videoStreamOptions.device = createTorchDevice(std::string(device.value()));
   }
-  std::optional<FrameMappings> converted_mappings =
+  std::optional<SingleStreamDecoder::FrameMappings> converted_mappings =
       custom_frame_mappings.has_value()
       ? std::make_optional(makeFrameMappings(custom_frame_mappings.value()))
       : std::nullopt;

--- a/src/torchcodec/_core/ops.py
+++ b/src/torchcodec/_core/ops.py
@@ -206,6 +206,7 @@ def _add_video_stream_abstract(
     stream_index: Optional[int] = None,
     device: Optional[str] = None,
     color_conversion_library: Optional[str] = None,
+    frame_index: Optional[tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = None
 ) -> None:
     return
 
@@ -220,6 +221,8 @@ def add_video_stream_abstract(
     dimension_order: Optional[str] = None,
     stream_index: Optional[int] = None,
     device: Optional[str] = None,
+    color_conversion_library: Optional[str] = None,
+    frame_index: Optional[tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = None
 ) -> None:
     return
 

--- a/src/torchcodec/_core/ops.py
+++ b/src/torchcodec/_core/ops.py
@@ -206,7 +206,7 @@ def _add_video_stream_abstract(
     stream_index: Optional[int] = None,
     device: Optional[str] = None,
     color_conversion_library: Optional[str] = None,
-    frame_index: Optional[tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = None
+    frame_index: Optional[tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = None,
 ) -> None:
     return
 
@@ -222,7 +222,7 @@ def add_video_stream_abstract(
     stream_index: Optional[int] = None,
     device: Optional[str] = None,
     color_conversion_library: Optional[str] = None,
-    frame_index: Optional[tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = None
+    frame_index: Optional[tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = None,
 ) -> None:
     return
 

--- a/src/torchcodec/_core/ops.py
+++ b/src/torchcodec/_core/ops.py
@@ -205,7 +205,9 @@ def _add_video_stream_abstract(
     dimension_order: Optional[str] = None,
     stream_index: Optional[int] = None,
     device: Optional[str] = None,
-    custom_frame_mappings: Optional[tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = None,
+    custom_frame_mappings: Optional[
+        tuple[torch.Tensor, torch.Tensor, torch.Tensor]
+    ] = None,
     color_conversion_library: Optional[str] = None,
 ) -> None:
     return
@@ -221,7 +223,9 @@ def add_video_stream_abstract(
     dimension_order: Optional[str] = None,
     stream_index: Optional[int] = None,
     device: Optional[str] = None,
-    custom_frame_mappings: Optional[tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = None,
+    custom_frame_mappings: Optional[
+        tuple[torch.Tensor, torch.Tensor, torch.Tensor]
+    ] = None,
 ) -> None:
     return
 

--- a/src/torchcodec/_core/ops.py
+++ b/src/torchcodec/_core/ops.py
@@ -205,7 +205,7 @@ def _add_video_stream_abstract(
     dimension_order: Optional[str] = None,
     stream_index: Optional[int] = None,
     device: Optional[str] = None,
-    frame_index: Optional[tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = None,
+    custom_frame_mappings: Optional[tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = None,
     color_conversion_library: Optional[str] = None,
 ) -> None:
     return
@@ -221,7 +221,7 @@ def add_video_stream_abstract(
     dimension_order: Optional[str] = None,
     stream_index: Optional[int] = None,
     device: Optional[str] = None,
-    frame_index: Optional[tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = None,
+    custom_frame_mappings: Optional[tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = None,
 ) -> None:
     return
 

--- a/src/torchcodec/_core/ops.py
+++ b/src/torchcodec/_core/ops.py
@@ -205,8 +205,8 @@ def _add_video_stream_abstract(
     dimension_order: Optional[str] = None,
     stream_index: Optional[int] = None,
     device: Optional[str] = None,
-    color_conversion_library: Optional[str] = None,
     frame_index: Optional[tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = None,
+    color_conversion_library: Optional[str] = None,
 ) -> None:
     return
 
@@ -221,7 +221,6 @@ def add_video_stream_abstract(
     dimension_order: Optional[str] = None,
     stream_index: Optional[int] = None,
     device: Optional[str] = None,
-    color_conversion_library: Optional[str] = None,
     frame_index: Optional[tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = None,
 ) -> None:
     return

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -31,17 +31,17 @@ def _get_container_metadata(path, seek_mode):
     return get_container_metadata(decoder)
 
 
-@pytest.mark.parametrize(
-    "seek_mode",
-    ["approximate", "exact", "frame_index"]
-)
+@pytest.mark.parametrize("seek_mode", ["approximate", "exact", "frame_index"])
 def test_get_metadata(seek_mode):
     from torchcodec._core import add_video_stream
+
     decoder = create_from_file(str(NASA_VIDEO.path), seek_mode=seek_mode)
     # For frame_index seek mode, add a video stream to update metadata
     frame_index = NASA_VIDEO.frame_index if seek_mode == "frame_index" else None
     # Add the best video stream (index 3 for NASA_VIDEO)
-    add_video_stream(decoder, stream_index=NASA_VIDEO.default_stream_index, frame_index=frame_index)
+    add_video_stream(
+        decoder, stream_index=NASA_VIDEO.default_stream_index, frame_index=frame_index
+    )
     metadata = get_container_metadata(decoder)
 
     with_scan = seek_mode == "exact" or seek_mode == "frame_index"

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -20,7 +20,7 @@ from torchcodec._core import (
 )
 from torchcodec.decoders import AudioDecoder, VideoDecoder
 
-from .utils import NASA_AUDIO_MP3, NASA_VIDEO, get_ffmpeg_major_version
+from .utils import get_ffmpeg_major_version, NASA_AUDIO_MP3, NASA_VIDEO
 
 
 # TODO: Expected values in these tests should be based on the assets's

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -31,20 +31,20 @@ def _get_container_metadata(path, seek_mode):
     return get_container_metadata(decoder)
 
 
-@pytest.mark.parametrize("seek_mode", ["approximate", "exact", "frame_index"])
+@pytest.mark.parametrize("seek_mode", ["approximate", "exact", "custom_frame_mappings"])
 def test_get_metadata(seek_mode):
     from torchcodec._core import add_video_stream
 
     decoder = create_from_file(str(NASA_VIDEO.path), seek_mode=seek_mode)
-    # For frame_index seek mode, add a video stream to update metadata
-    frame_index = NASA_VIDEO.frame_index if seek_mode == "frame_index" else None
+    # For custom_frame_mappings seek mode, add a video stream to update metadata
+    custom_frame_mappings = NASA_VIDEO.custom_frame_mappings if seek_mode == "custom_frame_mappings" else None
     # Add the best video stream (index 3 for NASA_VIDEO)
     add_video_stream(
-        decoder, stream_index=NASA_VIDEO.default_stream_index, frame_index=frame_index
+        decoder, stream_index=NASA_VIDEO.default_stream_index, custom_frame_mappings=custom_frame_mappings
     )
     metadata = get_container_metadata(decoder)
 
-    with_scan = seek_mode == "exact" or seek_mode == "frame_index"
+    with_scan = seek_mode == "exact" or seek_mode == "custom_frame_mappings"
 
     assert len(metadata.streams) == 6
     assert metadata.best_video_stream_index == 3

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -10,6 +10,7 @@ from fractions import Fraction
 import pytest
 
 from torchcodec._core import (
+    add_video_stream,
     AudioStreamMetadata,
     create_from_file,
     get_container_metadata,
@@ -28,29 +29,43 @@ from .utils import NASA_AUDIO_MP3, NASA_VIDEO
 
 def _get_container_metadata(path, seek_mode):
     decoder = create_from_file(str(path), seek_mode=seek_mode)
+
+    # For custom_frame_mappings seek mode, add a video stream to update metadata
+    if seek_mode == "custom_frame_mappings":
+        custom_frame_mappings = NASA_VIDEO.get_custom_frame_mappings()
+
+        # Add the best video stream (index 3 for NASA_VIDEO)
+        add_video_stream(
+            decoder,
+            stream_index=NASA_VIDEO.default_stream_index,
+            custom_frame_mappings=custom_frame_mappings,
+        )
     return get_container_metadata(decoder)
 
 
-@pytest.mark.parametrize("seek_mode", ["approximate", "exact", "custom_frame_mappings"])
-def test_get_metadata(seek_mode):
-    from torchcodec._core import add_video_stream
-
-    decoder = create_from_file(str(NASA_VIDEO.path), seek_mode=seek_mode)
-    # For custom_frame_mappings seek mode, add a video stream to update metadata
-    custom_frame_mappings = (
-        NASA_VIDEO.get_custom_frame_mappings()
-        if seek_mode == "custom_frame_mappings"
+@pytest.mark.parametrize(
+    "metadata_getter",
+    (
+        get_container_metadata_from_header,
+        functools.partial(_get_container_metadata, seek_mode="approximate"),
+        functools.partial(_get_container_metadata, seek_mode="exact"),
+        functools.partial(_get_container_metadata, seek_mode="custom_frame_mappings"),
+    ),
+)
+def test_get_metadata(metadata_getter):
+    seek_mode = (
+        metadata_getter.keywords["seek_mode"]
+        if isinstance(metadata_getter, functools.partial)
         else None
     )
-    # Add the best video stream (index 3 for NASA_VIDEO)
-    add_video_stream(
-        decoder,
-        stream_index=NASA_VIDEO.default_stream_index,
-        custom_frame_mappings=custom_frame_mappings,
-    )
-    metadata = get_container_metadata(decoder)
+    with_added_video_stream = seek_mode == "custom_frame_mappings"
+    metadata = metadata_getter(NASA_VIDEO.path)
 
-    with_scan = seek_mode == "exact" or seek_mode == "custom_frame_mappings"
+    with_scan = (
+        (seek_mode == "exact" or seek_mode == "custom_frame_mappings")
+        if isinstance(metadata_getter, functools.partial)
+        else False
+    )
 
     assert len(metadata.streams) == 6
     assert metadata.best_video_stream_index == 3
@@ -85,7 +100,9 @@ def test_get_metadata(seek_mode):
     assert best_video_stream_metadata.begin_stream_seconds_from_header == 0
     assert best_video_stream_metadata.bit_rate == 128783
     assert best_video_stream_metadata.average_fps == pytest.approx(29.97, abs=0.001)
-    assert best_video_stream_metadata.pixel_aspect_ratio == Fraction(1, 1)
+    assert best_video_stream_metadata.pixel_aspect_ratio == (
+        Fraction(1, 1) if with_added_video_stream else None
+    )
     assert best_video_stream_metadata.codec == "h264"
     assert best_video_stream_metadata.num_frames_from_content == (
         390 if with_scan else None

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -20,7 +20,7 @@ from torchcodec._core import (
 )
 from torchcodec.decoders import AudioDecoder, VideoDecoder
 
-from .utils import NASA_AUDIO_MP3, NASA_VIDEO
+from .utils import NASA_AUDIO_MP3, NASA_VIDEO, get_ffmpeg_major_version
 
 
 # TODO: Expected values in these tests should be based on the assets's
@@ -58,6 +58,8 @@ def test_get_metadata(metadata_getter):
         if isinstance(metadata_getter, functools.partial)
         else None
     )
+    if (seek_mode == "custom_frame_mappings") and get_ffmpeg_major_version() in (4, 5):
+        pytest.skip(reason="ffprobe isn't accurate on ffmpeg 4 and 5")
     with_added_video_stream = seek_mode == "custom_frame_mappings"
     metadata = metadata_getter(NASA_VIDEO.path)
 

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -37,10 +37,16 @@ def test_get_metadata(seek_mode):
 
     decoder = create_from_file(str(NASA_VIDEO.path), seek_mode=seek_mode)
     # For custom_frame_mappings seek mode, add a video stream to update metadata
-    custom_frame_mappings = NASA_VIDEO.custom_frame_mappings if seek_mode == "custom_frame_mappings" else None
+    custom_frame_mappings = (
+        NASA_VIDEO.custom_frame_mappings
+        if seek_mode == "custom_frame_mappings"
+        else None
+    )
     # Add the best video stream (index 3 for NASA_VIDEO)
     add_video_stream(
-        decoder, stream_index=NASA_VIDEO.default_stream_index, custom_frame_mappings=custom_frame_mappings
+        decoder,
+        stream_index=NASA_VIDEO.default_stream_index,
+        custom_frame_mappings=custom_frame_mappings,
     )
     metadata = get_container_metadata(decoder)
 

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -38,7 +38,7 @@ def test_get_metadata(seek_mode):
     decoder = create_from_file(str(NASA_VIDEO.path), seek_mode=seek_mode)
     # For custom_frame_mappings seek mode, add a video stream to update metadata
     custom_frame_mappings = (
-        NASA_VIDEO.custom_frame_mappings
+        NASA_VIDEO.get_custom_frame_mappings()
         if seek_mode == "custom_frame_mappings"
         else None
     )

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -448,31 +448,31 @@ class TestVideoDecoderOps:
             )
             assert pts_is_equal
 
-    def test_seek_mode_frame_index_fails(self):
-        decoder = create_from_file(str(NASA_VIDEO.path), "frame_index")
+    def test_seek_mode_custom_frame_mappings_fails(self):
+        decoder = create_from_file(str(NASA_VIDEO.path), "custom_frame_mappings")
         with pytest.raises(
             RuntimeError,
-            match="Please provide a frame index when using frame_index seek mode.",
+            match="Please provide frame mappings when using custom_frame_mappings seek mode.",
         ):
-            add_video_stream(decoder, stream_index=0, frame_index=None)
+            add_video_stream(decoder, stream_index=0, custom_frame_mappings=None)
 
-        decoder = create_from_file(str(NASA_VIDEO.path), "frame_index")
+        decoder = create_from_file(str(NASA_VIDEO.path), "custom_frame_mappings")
         different_lengths = ((torch.tensor([1, 2, 3]), torch.tensor([1, 2]), torch.tensor([1, 2, 3])))
         with pytest.raises(
             RuntimeError,
             match="all_frames, is_key_frame, and duration from custom_frame_mappings were not same size.",
         ):
-            add_video_stream(decoder, stream_index=0, frame_index=different_lengths)
+            add_video_stream(decoder, stream_index=0, custom_frame_mappings=different_lengths)
 
     @pytest.mark.parametrize("device", cpu_and_cuda())
-    def test_seek_mode_frame_index(self, device):
+    def test_seek_mode_custom_frame_mappings(self, device):
         stream_index = 3  # frame index seek mode requires a stream index
-        decoder = create_from_file(str(NASA_VIDEO.path), "frame_index")
+        decoder = create_from_file(str(NASA_VIDEO.path), "custom_frame_mappings")
         add_video_stream(
             decoder,
             device=device,
             stream_index=stream_index,
-            frame_index=NASA_VIDEO.frame_index,
+            custom_frame_mappings=NASA_VIDEO.custom_frame_mappings,
         )
 
         frame0, _, _ = get_next_frame(decoder)

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -47,6 +47,7 @@ from .utils import (
     NASA_AUDIO,
     NASA_AUDIO_MP3,
     NASA_VIDEO,
+    get_ffmpeg_major_version,
     needs_cuda,
     SINE_MONO_S32,
     SINE_MONO_S32_44100,
@@ -474,6 +475,7 @@ class TestVideoDecoderOps:
                 decoder, stream_index=0, custom_frame_mappings=different_lengths
             )
 
+    @pytest.mark.skipif(get_ffmpeg_major_version() in (4, 5), reason="ffprobe isn't accurate on ffmpeg 4 and 5")
     @pytest.mark.parametrize("device", cpu_and_cuda())
     def test_seek_mode_custom_frame_mappings(self, device):
         stream_index = 3  # custom_frame_index seek mode requires a stream index

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -484,7 +484,9 @@ class TestVideoDecoderOps:
             decoder,
             device=device,
             stream_index=stream_index,
-            custom_frame_mappings=NASA_VIDEO.custom_frame_mappings,
+            custom_frame_mappings=NASA_VIDEO.get_custom_frame_mappings(
+                stream_index=stream_index
+            ),
         )
 
         frame0, _, _ = get_next_frame(decoder)

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -456,6 +456,14 @@ class TestVideoDecoderOps:
         ):
             add_video_stream(decoder, stream_index=0, frame_index=None)
 
+        decoder = create_from_file(str(NASA_VIDEO.path), "frame_index")
+        different_lengths = ((torch.tensor([1, 2, 3]), torch.tensor([1, 2]), torch.tensor([1, 2, 3])))
+        with pytest.raises(
+            RuntimeError,
+            match="all_frames, is_key_frame, and duration from custom_frame_mappings were not same size.",
+        ):
+            add_video_stream(decoder, stream_index=0, frame_index=different_lengths)
+
     @pytest.mark.parametrize("device", cpu_and_cuda())
     def test_seek_mode_frame_index(self, device):
         stream_index = 3  # frame index seek mode requires a stream index

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -449,14 +449,18 @@ class TestVideoDecoderOps:
             assert pts_is_equal
 
     def test_seek_mode_custom_frame_mappings_fails(self):
-        decoder = create_from_file(str(NASA_VIDEO.path), "custom_frame_mappings")
+        decoder = create_from_file(
+            str(NASA_VIDEO.path), seek_mode="custom_frame_mappings"
+        )
         with pytest.raises(
             RuntimeError,
             match="Please provide frame mappings when using custom_frame_mappings seek mode.",
         ):
             add_video_stream(decoder, stream_index=0, custom_frame_mappings=None)
 
-        decoder = create_from_file(str(NASA_VIDEO.path), "custom_frame_mappings")
+        decoder = create_from_file(
+            str(NASA_VIDEO.path), seek_mode="custom_frame_mappings"
+        )
         different_lengths = (
             torch.tensor([1, 2, 3]),
             torch.tensor([1, 2]),
@@ -473,7 +477,9 @@ class TestVideoDecoderOps:
     @pytest.mark.parametrize("device", cpu_and_cuda())
     def test_seek_mode_custom_frame_mappings(self, device):
         stream_index = 3  # frame index seek mode requires a stream index
-        decoder = create_from_file(str(NASA_VIDEO.path), "custom_frame_mappings")
+        decoder = create_from_file(
+            str(NASA_VIDEO.path), seek_mode="custom_frame_mappings"
+        )
         add_video_stream(
             decoder,
             device=device,

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -44,10 +44,10 @@ from torchcodec._core import (
 from .utils import (
     assert_frames_equal,
     cpu_and_cuda,
+    get_ffmpeg_major_version,
     NASA_AUDIO,
     NASA_AUDIO_MP3,
     NASA_VIDEO,
-    get_ffmpeg_major_version,
     needs_cuda,
     SINE_MONO_S32,
     SINE_MONO_S32_44100,
@@ -475,7 +475,10 @@ class TestVideoDecoderOps:
                 decoder, stream_index=0, custom_frame_mappings=different_lengths
             )
 
-    @pytest.mark.skipif(get_ffmpeg_major_version() in (4, 5), reason="ffprobe isn't accurate on ffmpeg 4 and 5")
+    @pytest.mark.skipif(
+        get_ffmpeg_major_version() in (4, 5),
+        reason="ffprobe isn't accurate on ffmpeg 4 and 5",
+    )
     @pytest.mark.parametrize("device", cpu_and_cuda())
     def test_seek_mode_custom_frame_mappings(self, device):
         stream_index = 3  # custom_frame_index seek mode requires a stream index

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -458,12 +458,19 @@ class TestVideoDecoderOps:
 
     @pytest.mark.parametrize("device", cpu_and_cuda())
     def test_seek_mode_frame_index(self, device):
-        stream_index = 3 # frame index seek mode requires a stream index
+        stream_index = 3  # frame index seek mode requires a stream index
         decoder = create_from_file(str(NASA_VIDEO.path), "frame_index")
-        add_video_stream(decoder, device=device, stream_index=stream_index, frame_index=NASA_VIDEO.frame_index)
-        
+        add_video_stream(
+            decoder,
+            device=device,
+            stream_index=stream_index,
+            frame_index=NASA_VIDEO.frame_index,
+        )
+
         frame0, _, _ = get_next_frame(decoder)
-        reference_frame0 = NASA_VIDEO.get_frame_data_by_index(0, stream_index=stream_index)
+        reference_frame0 = NASA_VIDEO.get_frame_data_by_index(
+            0, stream_index=stream_index
+        )
         assert_frames_equal(frame0, reference_frame0.to(device))
 
         frame6, _, _ = get_frame_at_pts(decoder, 6.006)
@@ -481,7 +488,7 @@ class TestVideoDecoderOps:
         ref_frames0_9 = NASA_VIDEO.get_frame_data_by_range(0, 9)
         bulk_frames0_9, *_ = get_frames_in_range(decoder, start=0, stop=9)
         assert_frames_equal(bulk_frames0_9, ref_frames0_9.to(device))
-        
+
     @pytest.mark.parametrize("color_conversion_library", ("filtergraph", "swscale"))
     def test_color_conversion_library(self, color_conversion_library):
         decoder = create_from_file(str(NASA_VIDEO.path))

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -476,7 +476,7 @@ class TestVideoDecoderOps:
 
     @pytest.mark.parametrize("device", cpu_and_cuda())
     def test_seek_mode_custom_frame_mappings(self, device):
-        stream_index = 3  # frame index seek mode requires a stream index
+        stream_index = 3  # custom_frame_index seek mode requires a stream index
         decoder = create_from_file(
             str(NASA_VIDEO.path), seek_mode="custom_frame_mappings"
         )

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -457,12 +457,18 @@ class TestVideoDecoderOps:
             add_video_stream(decoder, stream_index=0, custom_frame_mappings=None)
 
         decoder = create_from_file(str(NASA_VIDEO.path), "custom_frame_mappings")
-        different_lengths = ((torch.tensor([1, 2, 3]), torch.tensor([1, 2]), torch.tensor([1, 2, 3])))
+        different_lengths = (
+            torch.tensor([1, 2, 3]),
+            torch.tensor([1, 2]),
+            torch.tensor([1, 2, 3]),
+        )
         with pytest.raises(
             RuntimeError,
             match="all_frames, is_key_frame, and duration from custom_frame_mappings were not same size.",
         ):
-            add_video_stream(decoder, stream_index=0, custom_frame_mappings=different_lengths)
+            add_video_stream(
+                decoder, stream_index=0, custom_frame_mappings=different_lengths
+            )
 
     @pytest.mark.parametrize("device", cpu_and_cuda())
     def test_seek_mode_custom_frame_mappings(self, device):

--- a/test/utils.py
+++ b/test/utils.py
@@ -255,10 +255,18 @@ class TestContainerFile:
                 text=True,
             ).stdout
         )
-        all_frames = torch.tensor([float(frame["pts"]) for frame in result["frames"]])
-        is_key_frame = torch.tensor([frame["key_frame"] for frame in result["frames"]])
+        all_frames = torch.tensor(
+            [float(frame["pts"]) for frame in result["frames"] if "pts" in frame]
+        )
+        is_key_frame = torch.tensor(
+            [frame["key_frame"] for frame in result["frames"] if "key_frame" in frame]
+        )
         duration = torch.tensor(
-            [float(frame["duration"]) for frame in result["frames"]]
+            [
+                float(frame["duration"])
+                for frame in result["frames"]
+                if "duration" in frame
+            ]
         )
         assert (
             len(all_frames) == len(is_key_frame) == len(duration)

--- a/test/utils.py
+++ b/test/utils.py
@@ -255,20 +255,20 @@ class TestContainerFile:
                 text=True,
             ).stdout
         )
-        pts_list = [float(frame["pts"]) for frame in result["frames"]]
-        is_key_frame_list = [frame["key_frame"] for frame in result["frames"]]
-        duration_list = [float(frame["duration"]) for frame in result["frames"]]
-        # Zip the lists together, sort by pts, then unzip
+        pts_list = torch.tensor([float(frame["pts"]) for frame in result["frames"]])
+        is_key_frame_list = torch.tensor(
+            [frame["key_frame"] for frame in result["frames"]]
+        )
+        duration_list = torch.tensor(
+            [float(frame["duration"]) for frame in result["frames"]]
+        )
         assert (
             len(pts_list) == len(is_key_frame_list) == len(duration_list)
         ), "Mismatched lengths in frame index data"
-        combined = list(zip(pts_list, is_key_frame_list, duration_list))
-        combined.sort(key=lambda x: x[0])
-        pts_sorted, is_key_frame_sorted, duration_sorted = zip(*combined)
         self._custom_frame_mappings_data[stream_index] = (
-            torch.tensor(pts_sorted),
-            torch.tensor(is_key_frame_sorted),
-            torch.tensor(duration_sorted),
+            pts_list,
+            is_key_frame_list,
+            duration_list,
         )
 
     @property

--- a/test/utils.py
+++ b/test/utils.py
@@ -255,20 +255,18 @@ class TestContainerFile:
                 text=True,
             ).stdout
         )
-        pts_list = torch.tensor([float(frame["pts"]) for frame in result["frames"]])
-        is_key_frame_list = torch.tensor(
-            [frame["key_frame"] for frame in result["frames"]]
-        )
-        duration_list = torch.tensor(
+        all_frames = torch.tensor([float(frame["pts"]) for frame in result["frames"]])
+        is_key_frame = torch.tensor([frame["key_frame"] for frame in result["frames"]])
+        duration = torch.tensor(
             [float(frame["duration"]) for frame in result["frames"]]
         )
         assert (
-            len(pts_list) == len(is_key_frame_list) == len(duration_list)
+            len(all_frames) == len(is_key_frame) == len(duration)
         ), "Mismatched lengths in frame index data"
         self._custom_frame_mappings_data[stream_index] = (
-            pts_list,
-            is_key_frame_list,
-            duration_list,
+            all_frames,
+            is_key_frame,
+            duration,
         )
 
     @property

--- a/test/utils.py
+++ b/test/utils.py
@@ -2,6 +2,7 @@ import importlib
 import json
 import os
 import pathlib
+import subprocess
 import sys
 
 from dataclasses import dataclass, field
@@ -121,6 +122,7 @@ class TestContainerFile:
     default_stream_index: int
     stream_infos: Dict[int, Union[TestVideoStreamInfo, TestAudioStreamInfo]]
     frames: Dict[int, Dict[int, TestFrameInfo]]
+    frame_index_data: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = None
 
     def __post_init__(self):
         # We load the .frames attribute from the checked-in json files, if needed.
@@ -222,6 +224,37 @@ class TestContainerFile:
             stream_index = self.default_stream_index
 
         return self.frames[stream_index][idx]
+    
+    # This property is used to get the frame index metadata for the frame_index seek mode.
+    @property 
+    def frame_index(self, stream_index: Optional[int] = None) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        if stream_index is None:
+            stream_index = self.default_stream_index
+        if self.frame_index_data is None:
+            self.get_frame_index(stream_index)
+        return self.frame_index_data
+    
+    def get_frame_index(self, stream_index: int) -> None:
+        show_frames_result = json.loads(
+            subprocess.run(
+                ["ffprobe", "-i", f"{self.path}","-select_streams",f"{stream_index}","-show_frames","-of","json"],
+                check=True, capture_output=True, text=True,
+            ).stdout
+        )
+        frame_index_data = ([], [], [])
+        frames = show_frames_result["frames"]
+        for frame in frames:
+            frame_index_data[0].append(float(frame["pts"]))
+            frame_index_data[1].append(frame["key_frame"])
+            frame_index_data[2].append(float(frame["duration"]))
+
+        (pts_list, key_frame_list, duration_list) = frame_index_data
+        # Zip the lists together, sort by pts, then unzip
+        assert len(pts_list) == len(key_frame_list) == len(duration_list), "Mismatched lengths in frame index data"
+        combined = list(zip(pts_list, key_frame_list, duration_list))
+        combined.sort(key=lambda x: x[0])
+        pts_sorted, key_frame_sorted, duration_sorted = zip(*combined)
+        self.frame_index_data = (torch.tensor(pts_sorted), torch.tensor(key_frame_sorted), torch.tensor(duration_sorted))
 
     @property
     def empty_pts_seconds(self) -> torch.Tensor:

--- a/test/utils.py
+++ b/test/utils.py
@@ -122,7 +122,9 @@ class TestContainerFile:
     default_stream_index: int
     stream_infos: Dict[int, Union[TestVideoStreamInfo, TestAudioStreamInfo]]
     frames: Dict[int, Dict[int, TestFrameInfo]]
-    custom_frame_mappings_data: Optional[tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = None
+    custom_frame_mappings_data: Optional[
+        tuple[torch.Tensor, torch.Tensor, torch.Tensor]
+    ] = None
 
     def __post_init__(self):
         # We load the .frames attribute from the checked-in json files, if needed.

--- a/test/utils.py
+++ b/test/utils.py
@@ -246,6 +246,8 @@ class TestContainerFile:
                     f"{self.path}",
                     "-select_streams",
                     f"{stream_index}",
+                    "-show_entries",
+                    "frame=pts,duration,stream_index,key_frame",
                     "-show_frames",
                     "-of",
                     "json",

--- a/test/utils.py
+++ b/test/utils.py
@@ -122,7 +122,7 @@ class TestContainerFile:
     default_stream_index: int
     stream_infos: Dict[int, Union[TestVideoStreamInfo, TestAudioStreamInfo]]
     frames: Dict[int, Dict[int, TestFrameInfo]]
-    custom_frame_mappings_data: Dict[
+    _custom_frame_mappings_data: Dict[
         int, Optional[tuple[torch.Tensor, torch.Tensor, torch.Tensor]]
     ] = field(default_factory=dict)
 
@@ -233,9 +233,9 @@ class TestContainerFile:
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         if stream_index is None:
             stream_index = self.default_stream_index
-        if self.custom_frame_mappings_data.get(stream_index) is None:
+        if self._custom_frame_mappings_data.get(stream_index) is None:
             self.generate_custom_frame_mappings(stream_index)
-        return self.custom_frame_mappings_data[stream_index]
+        return self._custom_frame_mappings_data[stream_index]
 
     def generate_custom_frame_mappings(self, stream_index: int) -> None:
         result = json.loads(
@@ -265,7 +265,7 @@ class TestContainerFile:
         combined = list(zip(pts_list, is_key_frame_list, duration_list))
         combined.sort(key=lambda x: x[0])
         pts_sorted, is_key_frame_sorted, duration_sorted = zip(*combined)
-        self.custom_frame_mappings_data[stream_index] = (
+        self._custom_frame_mappings_data[stream_index] = (
             torch.tensor(pts_sorted),
             torch.tensor(is_key_frame_sorted),
             torch.tensor(duration_sorted),

--- a/test/utils.py
+++ b/test/utils.py
@@ -231,11 +231,6 @@ class TestContainerFile:
     def get_custom_frame_mappings(
         self, stream_index: Optional[int] = None
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        # Ensure all tests using this function are skipped if the FFmpeg version is 4 or 5
-        # FFprobe on FFmpeg 4 and 5 does not return complete metadata
-        if get_ffmpeg_major_version() == 4 or get_ffmpeg_major_version() == 5:
-            pytest.skip("FFprobe on FFmpeg 4 and 5 does not return complete metadata")
-
         if stream_index is None:
             stream_index = self.default_stream_index
         if self._custom_frame_mappings_data.get(stream_index) is None:

--- a/test/utils.py
+++ b/test/utils.py
@@ -122,9 +122,9 @@ class TestContainerFile:
     default_stream_index: int
     stream_infos: Dict[int, Union[TestVideoStreamInfo, TestAudioStreamInfo]]
     frames: Dict[int, Dict[int, TestFrameInfo]]
-    custom_frame_mappings_data: Optional[
-        tuple[torch.Tensor, torch.Tensor, torch.Tensor]
-    ] = None
+    custom_frame_mappings_data: Dict[
+        int, Optional[tuple[torch.Tensor, torch.Tensor, torch.Tensor]]
+    ] = field(default_factory=dict)
 
     def __post_init__(self):
         # We load the .frames attribute from the checked-in json files, if needed.
@@ -227,19 +227,18 @@ class TestContainerFile:
 
         return self.frames[stream_index][idx]
 
-    # This property is used to get the frame mappings for the custom_frame_mappings seek mode.
-    @property
-    def custom_frame_mappings(
+    # This function is used to get the frame mappings for the custom_frame_mappings seek mode.
+    def get_custom_frame_mappings(
         self, stream_index: Optional[int] = None
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         if stream_index is None:
             stream_index = self.default_stream_index
-        if self.custom_frame_mappings_data is None:
-            self.get_custom_frame_mappings(stream_index)
-        return self.custom_frame_mappings_data
+        if self.custom_frame_mappings_data.get(stream_index) is None:
+            self.generate_custom_frame_mappings(stream_index)
+        return self.custom_frame_mappings_data[stream_index]
 
-    def get_custom_frame_mappings(self, stream_index: int) -> None:
-        show_frames_result = json.loads(
+    def generate_custom_frame_mappings(self, stream_index: int) -> None:
+        result = json.loads(
             subprocess.run(
                 [
                     "ffprobe",
@@ -256,22 +255,17 @@ class TestContainerFile:
                 text=True,
             ).stdout
         )
-        custom_frame_mappings_data = ([], [], [])
-        frames = show_frames_result["frames"]
-        for frame in frames:
-            custom_frame_mappings_data[0].append(float(frame["pts"]))
-            custom_frame_mappings_data[1].append(frame["key_frame"])
-            custom_frame_mappings_data[2].append(float(frame["duration"]))
-
-        (pts_list, key_frame_list, duration_list) = custom_frame_mappings_data
+        pts_list = [float(frame["pts"]) for frame in result["frames"]]
+        is_key_frame_list = [frame["key_frame"] for frame in result["frames"]]
+        duration_list = [float(frame["duration"]) for frame in result["frames"]]
         # Zip the lists together, sort by pts, then unzip
         assert (
-            len(pts_list) == len(key_frame_list) == len(duration_list)
+            len(pts_list) == len(is_key_frame_list) == len(duration_list)
         ), "Mismatched lengths in frame index data"
-        combined = list(zip(pts_list, key_frame_list, duration_list))
+        combined = list(zip(pts_list, is_key_frame_list, duration_list))
         combined.sort(key=lambda x: x[0])
         pts_sorted, is_key_frame_sorted, duration_sorted = zip(*combined)
-        self.custom_frame_mappings_data = (
+        self.custom_frame_mappings_data[stream_index] = (
             torch.tensor(pts_sorted),
             torch.tensor(is_key_frame_sorted),
             torch.tensor(duration_sorted),

--- a/test/utils.py
+++ b/test/utils.py
@@ -122,7 +122,7 @@ class TestContainerFile:
     default_stream_index: int
     stream_infos: Dict[int, Union[TestVideoStreamInfo, TestAudioStreamInfo]]
     frames: Dict[int, Dict[int, TestFrameInfo]]
-    frame_index_data: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = None
+    frame_index_data: Optional[tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = None
 
     def __post_init__(self):
         # We load the .frames attribute from the checked-in json files, if needed.


### PR DESCRIPTION
This PR works towards enabling decoders to receive an external frame index, as described in #466. It is only enabled in the private C++ code, and not exposed in the Python yet. 


### The changes:
* The stream index is expected to be passed into `add_video_stream` in the format of 3 tensors in a tuple. 
  * The reason it is not passed into the SingleStreamDecoder constructor (as discussed in #466)  is that a `stream_index` needs to be specified to update the decoder's metadata from the ffprobe output, and that `stream_index` is explicitly available during the `add_video_stream`  call. 
* The metadata updates happen in the added function `readFrameIndexUpdateMetadataAndIndex`, which parallels the function used by exact mode, `scanFileAndUpdateMetadataAndIndex`. 
  * It assumes PTS ints are passed in, since that is the expected type used in `FrameInfo`.

### Testing:
* To create a frame index in the format needed, a new`frame_index` property is added to `TestContainerFile`, which runs, parses, and sorts the ffprobe output.
* I updated `test_get_metadata` to allow the new seek mode to work.
* I added `test_seek_mode_frame_index`, which tests a variety of frame grabbing functions in the new seek mode.