### PR TITLE
Close avio object *before* encode destruction. And flush, too.

### DIFF
--- a/src/torchcodec/_core/Encoder.cpp
+++ b/src/torchcodec/_core/Encoder.cpp
@@ -109,7 +109,7 @@ void AudioEncoder::close_avio() {
     if (!avioContextHolder_) {
       avio_close(avFormatContext_->pb);
       // avoids closing again in destructor, which would segfault.
-      avFormatContext_->pb = nullptr; 
+      avFormatContext_->pb = nullptr;
     }
   }
 }

--- a/src/torchcodec/_core/Encoder.cpp
+++ b/src/torchcodec/_core/Encoder.cpp
@@ -99,8 +99,18 @@ AVSampleFormat findBestOutputSampleFormat(const AVCodec& avCodec) {
 } // namespace
 
 AudioEncoder::~AudioEncoder() {
-  if (avFormatContext_ && avFormatContext_->pb && !avioContextHolder_) {
-    avio_close(avFormatContext_->pb);
+  close_avio();
+}
+
+void AudioEncoder::close_avio() {
+  if (avFormatContext_ && avFormatContext_->pb) {
+    avio_flush(avFormatContext_->pb);
+
+    if (!avioContextHolder_) {
+      avio_close(avFormatContext_->pb);
+      // avoids closing again in destructor, which would segfault.
+      avFormatContext_->pb = nullptr; 
+    }
   }
 }
 
@@ -308,6 +318,8 @@ void AudioEncoder::encode() {
       status == AVSUCCESS,
       "Error in: av_write_trailer",
       getFFMPEGErrorStringFromErrorCode(status));
+
+  close_avio();
 }
 
 UniqueAVFrame AudioEncoder::maybeConvertAVFrame(const UniqueAVFrame& avFrame) {

--- a/src/torchcodec/_core/Encoder.h
+++ b/src/torchcodec/_core/Encoder.h
@@ -33,6 +33,7 @@ class AudioEncoder {
   void encodeFrame(AutoAVPacket& autoAVPacket, const UniqueAVFrame& avFrame);
   void maybeFlushSwrBuffers(AutoAVPacket& autoAVPacket);
   void flushBuffers();
+  void close_avio();
 
   UniqueEncodingAVFormatContext avFormatContext_;
   UniqueAVCodecContext avCodecContext_;


### PR DESCRIPTION
The `Failed to open input buffer` aren't resolved as they were visible in https://github.com/pytorch/torchcodec/actions/runs/16238309871/job/45851804069?pr=757.


So https://github.com/pytorch/torchcodec/issues/724 is still a problem, and https://github.com/pytorch/torchcodec/pull/755 wasn't a proper fix.

I hope this one is the one. It does 2 things:

- We now call `avio_close()` at the end of `encode()`. Not just when the encoder is destructed. That makes sense.
- We also now call `avio_flush()`, which was potentially needed. I'm not entirely sure, but it's probably needed. Or at least it's fairly clear that calling `avio_close()` isn't enough anyway, because we are seeing the error not just when relying on FFmpeg's default avio object, but also when using `to_tensor()`: https://github.com/pytorch/torchcodec/actions/runs/16238309871/job/45851804069?pr=757.