### PR TITLE
Fix typing error

### DIFF
--- a/src/torchcodec/_core/ops.py
+++ b/src/torchcodec/_core/ops.py
@@ -28,9 +28,6 @@ def load_torchcodec_shared_libraries():
     # ffmpeg major version. This should cover all potential ffmpeg versions
     # installed on the user's machine.
     #
-    # On fbcode, _get_extension_path() is overridden and directly points to the
-    # correct .so file, so this for-loop succeeds on the first iteration.
-    #
     # Note that we use two different methods for loading shared libraries:
     #
     #   1. torch.ops.load_library(): For PyTorch custom ops and the C++ only

--- a/src/torchcodec/_core/ops.py
+++ b/src/torchcodec/_core/ops.py
@@ -23,10 +23,10 @@ _pybind_ops: Optional[ModuleType] = None
 
 
 def load_torchcodec_shared_libraries():
-    # Successively try to load libtorchcodec_*7.so, libtorchcodec_*6.so,
-    # libtorchcodec_*5.so, and libtorchcodec_*4.so. Each of these correspond to an
-    # ffmpeg major version. This should cover all potential ffmpeg versions
-    # installed on the user's machine.
+    # Successively try to load the shared libraries for each version of FFmpeg
+    # that we support. We always start with the highest version, working our way
+    # down to the lowest version. Once we can load ALL shared libraries for a
+    # version of FFmpeg, we have succeeded and we stop.
     #
     # Note that we use two different methods for loading shared libraries:
     #

--- a/src/torchcodec/_internally_replaced_utils.py
+++ b/src/torchcodec/_internally_replaced_utils.py
@@ -53,12 +53,12 @@ def _load_pybind11_module(module_name: str, library_path: str) -> ModuleType:
     return importlib.util.module_from_spec(spec)
 
 
+# Note that the return value from this function must match the value used as
+# PYBIND_OPS_MODULE_NAME when we compile _core/pybind_ops.cpp. If the values
+# do not match, we will not be able to import the C++ shared library as a
+# Python module at runtime.
+#
+# The parameter ffmpeg_major_version is unused externally, but used
+# internally.
 def _get_pybind_ops_module_name(ffmpeg_major_version: int) -> str:
-    # Note that this value must match the value used as PYBIND_OPS_MODULE_NAME
-    # when we compile _core/pybind_ops.cpp. If the values do not match, we will
-    # not be able to import the C++ shared library as a Python module at
-    # runtime.
-    #
-    # The parameter ffmpeg_major_version is unused externally, but used
-    # internally.
     return "core_pybind_ops"

--- a/src/torchcodec/_internally_replaced_utils.py
+++ b/src/torchcodec/_internally_replaced_utils.py
@@ -53,7 +53,7 @@ def _load_pybind11_module(module_name: str, library_path: str) -> ModuleType:
     return importlib.util.module_from_spec(spec)
 
 
-def _get_pybind_ops_module_name(ffmpeg_major_version: str) -> str:
+def _get_pybind_ops_module_name(ffmpeg_major_version: int) -> str:
     # Note that this value must match the value used as PYBIND_OPS_MODULE_NAME
     # when we compile _core/pybind_ops.cpp. If the values do not match, we will
     # not be able to import the C++ shared library as a Python module at


### PR DESCRIPTION
We had a trivial typing error where the function was declared as taking strings, but we were passing in ints. I am surprised this passed the type-checking lint. Maybe because we never actually use the value externally?