### PR TITLE
Speed-up CMake builds by allowing a persistent Cmake build dir

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,10 @@ git clone git@github.com:pytorch/torchcodec.git
 # Or, using https instead of ssh: git clone https://github.com/pytorch/torchcodec.git
 cd torchcodec
 
+# Optional, but recommended: define a persistent build directory which speeds-up
+# subsequent builds.
+export TORCHCODEC_CMAKE_BUILD_DIR="${PWD}/build"
+
 pip install -e ".[dev]" --no-build-isolation -vv
 # Or, for cuda support: ENABLE_CUDA=1 pip install -e ".[dev]" --no-build-isolation -vv
 ```

--- a/setup.py
+++ b/setup.py
@@ -126,12 +126,17 @@ class CMakeBuild(build_ext):
             f"-DTORCHCODEC_DISABLE_COMPILE_WARNING_AS_ERROR={torchcodec_disable_compile_warning_as_error}",
         ]
 
+        self.build_temp = os.getenv("TORCHCODEC_CMAKE_BUILD_DIR", self.build_temp)
+        print(f"Using {self.build_temp = }", flush=True)
         Path(self.build_temp).mkdir(parents=True, exist_ok=True)
 
+        print("Calling cmake (configure)", flush=True)
         subprocess.check_call(
             ["cmake", str(_ROOT_DIR)] + cmake_args, cwd=self.build_temp
         )
+        print("Calling cmake --build", flush=True)
         subprocess.check_call(["cmake", "--build", "."], cwd=self.build_temp)
+        print("Calling cmake --install", flush=True)
         subprocess.check_call(["cmake", "--install", "."], cwd=self.build_temp)
 
     def copy_extensions_to_source(self):


### PR DESCRIPTION
When we build with `pip install -e . --no-build-isolation`, `cmake` currently always relies on `self.build_temp`:

https://github.com/pytorch/torchcodec/blob/de517c51f10f39d7d5e9a34714ecd00fece7ad36/setup.py#L129-L135

`self.build_temp` is automatically created at some point - not sure by what, whether it's `pip` or `setuptools` or something else. It doesn't matter. What matters is that it's a temporary directory that changes for each invocation of `pip install -e . --no-build-isolation`. And because it changes each time, it means the cmake configuration step is re-done each time as well. And that takes time.

This PR adds a `TORCHCODEC_CMAKE_BUILD_DIR` that can be optionally specified to indicate a persistent build dir for cmake. This should greatly speed-up subsequent builds by avoiding the config step, and by avoiding re-compiling most files (but you should be using ccache anyway!!)


I recommend doing something like `conda env config vars set TORCHCODEC_CMAKE_BUILD_DIR=${PWD}/build` where PWD is the torchcodec dir, so that this variable is set automatically when you activate your conda env.

----

Here's a diff of the first and second `TORCHCODEC_CMAKE_BUILD_DIR=./build pip install -e . --no-build-isolation` invocations. Note the configuration step, and the lack of recompilation.

```diff

<   creating /tmp/pip-modern-metadata-9kordydh/torchcodec.egg-info
<   writing /tmp/pip-modern-metadata-9kordydh/torchcodec.egg-info/PKG-INFO
<   writing dependency_links to /tmp/pip-modern-metadata-9kordydh/torchcodec.egg-info/dependency_links.txt
<   writing requirements to /tmp/pip-modern-metadata-9kordydh/torchcodec.egg-info/requires.txt
<   writing top-level names to /tmp/pip-modern-metadata-9kordydh/torchcodec.egg-info/top_level.txt
<   writing manifest file '/tmp/pip-modern-metadata-9kordydh/torchcodec.egg-info/SOURCES.txt'
<   reading manifest file '/tmp/pip-modern-metadata-9kordydh/torchcodec.egg-info/SOURCES.txt'
---
>   creating /tmp/pip-modern-metadata-1lw54qjm/torchcodec.egg-info
>   writing /tmp/pip-modern-metadata-1lw54qjm/torchcodec.egg-info/PKG-INFO
>   writing dependency_links to /tmp/pip-modern-metadata-1lw54qjm/torchcodec.egg-info/dependency_links.txt
>   writing requirements to /tmp/pip-modern-metadata-1lw54qjm/torchcodec.egg-info/requires.txt
>   writing top-level names to /tmp/pip-modern-metadata-1lw54qjm/torchcodec.egg-info/top_level.txt
>   writing manifest file '/tmp/pip-modern-metadata-1lw54qjm/torchcodec.egg-info/SOURCES.txt'
>   reading manifest file '/tmp/pip-modern-metadata-1lw54qjm/torchcodec.egg-info/SOURCES.txt'
28,29c28,29
<   writing manifest file '/tmp/pip-modern-metadata-9kordydh/torchcodec.egg-info/SOURCES.txt'
<   creating '/tmp/pip-modern-metadata-9kordydh/torchcodec-0.5.0a0.dist-info'
---
>   writing manifest file '/tmp/pip-modern-metadata-1lw54qjm/torchcodec.egg-info/SOURCES.txt'
>   creating '/tmp/pip-modern-metadata-1lw54qjm/torchcodec-0.5.0a0.dist-info'
46,52c46,52
<   creating /tmp/pip-wheel-1z6z4rvy/.tmp-0gs6lpwo/torchcodec.egg-info
<   writing /tmp/pip-wheel-1z6z4rvy/.tmp-0gs6lpwo/torchcodec.egg-info/PKG-INFO
<   writing dependency_links to /tmp/pip-wheel-1z6z4rvy/.tmp-0gs6lpwo/torchcodec.egg-info/dependency_links.txt
<   writing requirements to /tmp/pip-wheel-1z6z4rvy/.tmp-0gs6lpwo/torchcodec.egg-info/requires.txt
<   writing top-level names to /tmp/pip-wheel-1z6z4rvy/.tmp-0gs6lpwo/torchcodec.egg-info/top_level.txt
<   writing manifest file '/tmp/pip-wheel-1z6z4rvy/.tmp-0gs6lpwo/torchcodec.egg-info/SOURCES.txt'
<   reading manifest file '/tmp/pip-wheel-1z6z4rvy/.tmp-0gs6lpwo/torchcodec.egg-info/SOURCES.txt'
---
>   creating /tmp/pip-wheel-ovhhyoqq/.tmp-sje2lbbo/torchcodec.egg-info
>   writing /tmp/pip-wheel-ovhhyoqq/.tmp-sje2lbbo/torchcodec.egg-info/PKG-INFO
>   writing dependency_links to /tmp/pip-wheel-ovhhyoqq/.tmp-sje2lbbo/torchcodec.egg-info/dependency_links.txt
>   writing requirements to /tmp/pip-wheel-ovhhyoqq/.tmp-sje2lbbo/torchcodec.egg-info/requires.txt
>   writing top-level names to /tmp/pip-wheel-ovhhyoqq/.tmp-sje2lbbo/torchcodec.egg-info/top_level.txt
>   writing manifest file '/tmp/pip-wheel-ovhhyoqq/.tmp-sje2lbbo/torchcodec.egg-info/SOURCES.txt'
>   reading manifest file '/tmp/pip-wheel-ovhhyoqq/.tmp-sje2lbbo/torchcodec.egg-info/SOURCES.txt'
56,58c56,58
<   writing manifest file '/tmp/pip-wheel-1z6z4rvy/.tmp-0gs6lpwo/torchcodec.egg-info/SOURCES.txt'
<   creating '/tmp/pip-wheel-1z6z4rvy/.tmp-0gs6lpwo/torchcodec-0.5.0a0.dist-info'
<   creating /tmp/pip-wheel-1z6z4rvy/.tmp-0gs6lpwo/torchcodec-0.5.0a0.dist-info/WHEEL
---
>   writing manifest file '/tmp/pip-wheel-ovhhyoqq/.tmp-sje2lbbo/torchcodec.egg-info/SOURCES.txt'
>   creating '/tmp/pip-wheel-ovhhyoqq/.tmp-sje2lbbo/torchcodec-0.5.0a0.dist-info'
>   creating /tmp/pip-wheel-ovhhyoqq/.tmp-sje2lbbo/torchcodec-0.5.0a0.dist-info/WHEEL
63,77d62
<   -- The C compiler identification is GNU 14.2.1
<   -- The CXX compiler identification is GNU 15.1.1
<   -- Detecting C compiler ABI info
<   -- Detecting C compiler ABI info - done
<   -- Check for working C compiler: /usr/lib64/ccache/cc - skipped
<   -- Detecting C compile features
<   -- Detecting C compile features - done
<   -- Detecting CXX compiler ABI info
<   -- Detecting CXX compiler ABI info - done
<   -- Check for working CXX compiler: /usr/lib64/ccache/c++ - skipped
<   -- Detecting CXX compile features
<   -- Detecting CXX compile features - done
<   -- Found Python: /home/nicolashug/.opt/miniconda3/envs/codec/bin/python3.11 (found suitable version "3.11.13", minimum required is "3.8") found components: Interpreter Development.Module Development.Embed
<   -- Performing Test HAS_FLTO
<   -- Performing Test HAS_FLTO - Success
86,87d70
<   -- Found Torch: /home/nicolashug/.opt/miniconda3/envs/codec/lib/python3.11/site-packages/torch/lib/libtorch.so
<   -- Found Python3: /home/nicolashug/.opt/miniconda3/envs/codec/include/python3.11 (found suitable exact version "3.11.13") found components: Development Development.Module Development.Embed
92,101c75
<   -- Found PkgConfig: /home/nicolashug/.opt/miniconda3/envs/codec/bin/pkg-config (found version "0.29.2")
<   -- Checking for modules 'libavdevice;libavfilter;libavformat;libavcodec;libavutil;libswresample;libswscale'
<   --   Found libavdevice, version 60.3.100
<   --   Found libavfilter, version 9.12.100
<   --   Found libavformat, version 60.16.100
<   --   Found libavcodec, version 60.31.102
<   --   Found libavutil, version 58.29.100
<   --   Found libswresample, version 4.12.100
<   --   Found libswscale, version 7.5.100
<   -- Configuring done (1.9s)
---
>   -- Configuring done (0.2s)
114a89,98
>   Dependencies file "src/torchcodec/_core/CMakeFiles/libtorchcodec_core6.dir/AVIOContextHolder.cpp.o.d" is newer than depends file "/home/nicolashug/dev/torchcodec/build_try/src/torchcodec/_core/CMakeFiles/libtorchcodec_core6.dir/compiler_depend.internal".
>   Dependencies file "src/torchcodec/_core/CMakeFiles/libtorchcodec_core6.dir/AVIOTensorContext.cpp.o.d" is newer than depends file "/home/nicolashug/dev/torchcodec/build_try/src/torchcodec/_core/CMakeFiles/libtorchcodec_core6.dir/compiler_depend.internal".
>   Dependencies file "src/torchcodec/_core/CMakeFiles/libtorchcodec_core6.dir/CpuDeviceInterface.cpp.o.d" is newer than depends file "/home/nicolashug/dev/torchcodec/build_try/src/torchcodec/_core/CMakeFiles/libtorchcodec_core6.dir/compiler_depend.internal".
>   Dependencies file "src/torchcodec/_core/CMakeFiles/libtorchcodec_core6.dir/DeviceInterface.cpp.o.d" is newer than depends file "/home/nicolashug/dev/torchcodec/build_try/src/torchcodec/_core/CMakeFiles/libtorchcodec_core6.dir/compiler_depend.internal".
>   Dependencies file "src/torchcodec/_core/CMakeFiles/libtorchcodec_core6.dir/Encoder.cpp.o.d" is newer than depends file "/home/nicolashug/dev/torchcodec/build_try/src/torchcodec/_core/CMakeFiles/libtorchcodec_core6.dir/compiler_depend.internal".
>   Dependencies file "src/torchcodec/_core/CMakeFiles/libtorchcodec_core6.dir/FFMPEGCommon.cpp.o.d" is newer than depends file "/home/nicolashug/dev/torchcodec/build_try/src/torchcodec/_core/CMakeFiles/libtorchcodec_core6.dir/compiler_depend.internal".
>   Dependencies file "src/torchcodec/_core/CMakeFiles/libtorchcodec_core6.dir/Frame.cpp.o.d" is newer than depends file "/home/nicolashug/dev/torchcodec/build_try/src/torchcodec/_core/CMakeFiles/libtorchcodec_core6.dir/compiler_depend.internal".
>   Dependencies file "src/torchcodec/_core/CMakeFiles/libtorchcodec_core6.dir/SingleStreamDecoder.cpp.o.d" is newer than depends file "/home/nicolashug/dev/torchcodec/build_try/src/torchcodec/_core/CMakeFiles/libtorchcodec_core6.dir/compiler_depend.internal".
>   Dependencies file "src/torchcodec/_core/CMakeFiles/libtorchcodec_core6.dir/link.d" is newer than depends file "/home/nicolashug/dev/torchcodec/build_try/src/torchcodec/_core/CMakeFiles/libtorchcodec_core6.dir/compiler_depend.internal".
>   Consolidate compiler generated dependencies of target libtorchcodec_core6
118,136c102
<   [  6%] Building CXX object src/torchcodec/_core/CMakeFiles/libtorchcodec_core6.dir/AVIOTensorContext.cpp.o
<   cd /home/nicolashug/dev/torchcodec/build_try/src/torchcodec/_core && /usr/lib64/ccache/c++ -DUSE_C10D_GLOO -DUSE_DISTRIBUTED -DUSE_RPC -DUSE_TENSORPIPE -Dlibtorchcodec_core6_EXPORTS -I/home/nicolashug/dev/torchcodec/src/torchcodec/_core/./../../.. -I/home/nicolashug/.opt/miniconda3/envs/codec/include/python3.11 -isystem /home/nicolashug/.opt/miniconda3/envs/codec/lib/python3.11/site-packages/torch/include -isystem /home/nicolashug/.opt/miniconda3/envs/codec/include -isystem /home/nicolashug/.opt/miniconda3/envs/codec/lib/python3.11/site-packages/torch/include/torch/csrc/api/include -Wall -Wextra -pedantic -Werror  -O3 -DNDEBUG -std=gnu++17 -fPIC -MD -MT src/torchcodec/_core/CMakeFiles/libtorchcodec_core6.dir/AVIOTensorContext.cpp.o -MF CMakeFiles/libtorchcodec_core6.dir/AVIOTensorContext.cpp.o.d -o CMakeFiles/libtorchcodec_core6.dir/AVIOTensorContext.cpp.o -c /home/nicolashug/dev/torchcodec/src/torchcodec/_core/AVIOTensorContext.cpp
<   [ 26%] Building CXX object src/torchcodec/_core/CMakeFiles/libtorchcodec_core6.dir/SingleStreamDecoder.cpp.o
<   [ 26%] Building CXX object src/torchcodec/_core/CMakeFiles/libtorchcodec_core6.dir/FFMPEGCommon.cpp.o
<   [ 13%] Building CXX object src/torchcodec/_core/CMakeFiles/libtorchcodec_core6.dir/AVIOContextHolder.cpp.o
<   [ 33%] Building CXX object src/torchcodec/_core/CMakeFiles/libtorchcodec_core6.dir/CpuDeviceInterface.cpp.o
<   [ 40%] Building CXX object src/torchcodec/_core/CMakeFiles/libtorchcodec_core6.dir/Encoder.cpp.o
<   cd /home/nicolashug/dev/torchcodec/build_try/src/torchcodec/_core && /usr/lib64/ccache/c++ -DUSE_C10D_GLOO -DUSE_DISTRIBUTED -DUSE_RPC -DUSE_TENSORPIPE -Dlibtorchcodec_core6_EXPORTS -I/home/nicolashug/dev/torchcodec/src/torchcodec/_core/./../../.. -I/home/nicolashug/.opt/miniconda3/envs/codec/include/python3.11 -isystem /home/nicolashug/.opt/miniconda3/envs/codec/lib/python3.11/site-packages/torch/include -isystem /home/nicolashug/.opt/miniconda3/envs/codec/include -isystem /home/nicolashug/.opt/miniconda3/envs/codec/lib/python3.11/site-packages/torch/include/torch/csrc/api/include -Wall -Wextra -pedantic -Werror  -O3 -DNDEBUG -std=gnu++17 -fPIC -MD -MT src/torchcodec/_core/CMakeFiles/libtorchcodec_core6.dir/SingleStreamDecoder.cpp.o -MF CMakeFiles/libtorchcodec_core6.dir/SingleStreamDecoder.cpp.o.d -o CMakeFiles/libtorchcodec_core6.dir/SingleStreamDecoder.cpp.o -c /home/nicolashug/dev/torchcodec/src/torchcodec/_core/SingleStreamDecoder.cpp
<   cd /home/nicolashug/dev/torchcodec/build_try/src/torchcodec/_core && /usr/lib64/ccache/c++ -DUSE_C10D_GLOO -DUSE_DISTRIBUTED -DUSE_RPC -DUSE_TENSORPIPE -Dlibtorchcodec_core6_EXPORTS -I/home/nicolashug/dev/torchcodec/src/torchcodec/_core/./../../.. -I/home/nicolashug/.opt/miniconda3/envs/codec/include/python3.11 -isystem /home/nicolashug/.opt/miniconda3/envs/codec/lib/python3.11/site-packages/torch/include -isystem /home/nicolashug/.opt/miniconda3/envs/codec/include -isystem /home/nicolashug/.opt/miniconda3/envs/codec/lib/python3.11/site-packages/torch/include/torch/csrc/api/include -Wall -Wextra -pedantic -Werror  -O3 -DNDEBUG -std=gnu++17 -fPIC -MD -MT src/torchcodec/_core/CMakeFiles/libtorchcodec_core6.dir/FFMPEGCommon.cpp.o -MF CMakeFiles/libtorchcodec_core6.dir/FFMPEGCommon.cpp.o.d -o CMakeFiles/libtorchcodec_core6.dir/FFMPEGCommon.cpp.o -c /home/nicolashug/dev/torchcodec/src/torchcodec/_core/FFMPEGCommon.cpp
<   cd /home/nicolashug/dev/torchcodec/build_try/src/torchcodec/_core && /usr/lib64/ccache/c++ -DUSE_C10D_GLOO -DUSE_DISTRIBUTED -DUSE_RPC -DUSE_TENSORPIPE -Dlibtorchcodec_core6_EXPORTS -I/home/nicolashug/dev/torchcodec/src/torchcodec/_core/./../../.. -I/home/nicolashug/.opt/miniconda3/envs/codec/include/python3.11 -isystem /home/nicolashug/.opt/miniconda3/envs/codec/lib/python3.11/site-packages/torch/include -isystem /home/nicolashug/.opt/miniconda3/envs/codec/include -isystem /home/nicolashug/.opt/miniconda3/envs/codec/lib/python3.11/site-packages/torch/include/torch/csrc/api/include -Wall -Wextra -pedantic -Werror  -O3 -DNDEBUG -std=gnu++17 -fPIC -MD -MT src/torchcodec/_core/CMakeFiles/libtorchcodec_core6.dir/AVIOContextHolder.cpp.o -MF CMakeFiles/libtorchcodec_core6.dir/AVIOContextHolder.cpp.o.d -o CMakeFiles/libtorchcodec_core6.dir/AVIOContextHolder.cpp.o -c /home/nicolashug/dev/torchcodec/src/torchcodec/_core/AVIOContextHolder.cpp
<   [ 46%] Building CXX object src/torchcodec/_core/CMakeFiles/libtorchcodec_core6.dir/Frame.cpp.o
<   cd /home/nicolashug/dev/torchcodec/build_try/src/torchcodec/_core && /usr/lib64/ccache/c++ -DUSE_C10D_GLOO -DUSE_DISTRIBUTED -DUSE_RPC -DUSE_TENSORPIPE -Dlibtorchcodec_core6_EXPORTS -I/home/nicolashug/dev/torchcodec/src/torchcodec/_core/./../../.. -I/home/nicolashug/.opt/miniconda3/envs/codec/include/python3.11 -isystem /home/nicolashug/.opt/miniconda3/envs/codec/lib/python3.11/site-packages/torch/include -isystem /home/nicolashug/.opt/miniconda3/envs/codec/include -isystem /home/nicolashug/.opt/miniconda3/envs/codec/lib/python3.11/site-packages/torch/include/torch/csrc/api/include -Wall -Wextra -pedantic -Werror  -O3 -DNDEBUG -std=gnu++17 -fPIC -MD -MT src/torchcodec/_core/CMakeFiles/libtorchcodec_core6.dir/CpuDeviceInterface.cpp.o -MF CMakeFiles/libtorchcodec_core6.dir/CpuDeviceInterface.cpp.o.d -o CMakeFiles/libtorchcodec_core6.dir/CpuDeviceInterface.cpp.o -c /home/nicolashug/dev/torchcodec/src/torchcodec/_core/CpuDeviceInterface.cpp
<   [ 53%] Building CXX object src/torchcodec/_core/CMakeFiles/libtorchcodec_core6.dir/DeviceInterface.cpp.o
<   cd /home/nicolashug/dev/torchcodec/build_try/src/torchcodec/_core && /usr/lib64/ccache/c++ -DUSE_C10D_GLOO -DUSE_DISTRIBUTED -DUSE_RPC -DUSE_TENSORPIPE -Dlibtorchcodec_core6_EXPORTS -I/home/nicolashug/dev/torchcodec/src/torchcodec/_core/./../../.. -I/home/nicolashug/.opt/miniconda3/envs/codec/include/python3.11 -isystem /home/nicolashug/.opt/miniconda3/envs/codec/lib/python3.11/site-packages/torch/include -isystem /home/nicolashug/.opt/miniconda3/envs/codec/include -isystem /home/nicolashug/.opt/miniconda3/envs/codec/lib/python3.11/site-packages/torch/include/torch/csrc/api/include -Wall -Wextra -pedantic -Werror  -O3 -DNDEBUG -std=gnu++17 -fPIC -MD -MT src/torchcodec/_core/CMakeFiles/libtorchcodec_core6.dir/Encoder.cpp.o -MF CMakeFiles/libtorchcodec_core6.dir/Encoder.cpp.o.d -o CMakeFiles/libtorchcodec_core6.dir/Encoder.cpp.o -c /home/nicolashug/dev/torchcodec/src/torchcodec/_core/Encoder.cpp
<   cd /home/nicolashug/dev/torchcodec/build_try/src/torchcodec/_core && /usr/lib64/ccache/c++ -DUSE_C10D_GLOO -DUSE_DISTRIBUTED -DUSE_RPC -DUSE_TENSORPIPE -Dlibtorchcodec_core6_EXPORTS -I/home/nicolashug/dev/torchcodec/src/torchcodec/_core/./../../.. -I/home/nicolashug/.opt/miniconda3/envs/codec/include/python3.11 -isystem /home/nicolashug/.opt/miniconda3/envs/codec/lib/python3.11/site-packages/torch/include -isystem /home/nicolashug/.opt/miniconda3/envs/codec/include -isystem /home/nicolashug/.opt/miniconda3/envs/codec/lib/python3.11/site-packages/torch/include/torch/csrc/api/include -Wall -Wextra -pedantic -Werror  -O3 -DNDEBUG -std=gnu++17 -fPIC -MD -MT src/torchcodec/_core/CMakeFiles/libtorchcodec_core6.dir/Frame.cpp.o -MF CMakeFiles/libtorchcodec_core6.dir/Frame.cpp.o.d -o CMakeFiles/libtorchcodec_core6.dir/Frame.cpp.o -c /home/nicolashug/dev/torchcodec/src/torchcodec/_core/Frame.cpp
<   cd /home/nicolashug/dev/torchcodec/build_try/src/torchcodec/_core && /usr/lib64/ccache/c++ -DUSE_C10D_GLOO -DUSE_DISTRIBUTED -DUSE_RPC -DUSE_TENSORPIPE -Dlibtorchcodec_core6_EXPORTS -I/home/nicolashug/dev/torchcodec/src/torchcodec/_core/./../../.. -I/home/nicolashug/.opt/miniconda3/envs/codec/include/python3.11 -isystem /home/nicolashug/.opt/miniconda3/envs/codec/lib/python3.11/site-packages/torch/include -isystem /home/nicolashug/.opt/miniconda3/envs/codec/include -isystem /home/nicolashug/.opt/miniconda3/envs/codec/lib/python3.11/site-packages/torch/include/torch/csrc/api/include -Wall -Wextra -pedantic -Werror  -O3 -DNDEBUG -std=gnu++17 -fPIC -MD -MT src/torchcodec/_core/CMakeFiles/libtorchcodec_core6.dir/DeviceInterface.cpp.o -MF CMakeFiles/libtorchcodec_core6.dir/DeviceInterface.cpp.o.d -o CMakeFiles/libtorchcodec_core6.dir/DeviceInterface.cpp.o -c /home/nicolashug/dev/torchcodec/src/torchcodec/_core/DeviceInterface.cpp
<   [ 60%] Linking CXX shared library libtorchcodec_core6.so
<   cd /home/nicolashug/dev/torchcodec/build_try/src/torchcodec/_core && /home/nicolashug/.opt/miniconda3/envs/codec/lib/python3.11/site-packages/cmake/data/bin/cmake -E cmake_link_script CMakeFiles/libtorchcodec_core6.dir/link.txt --verbose=1
<   /usr/lib64/ccache/c++ -fPIC  -Wall -Wextra -pedantic -Werror  -O3 -DNDEBUG -Wl,--dependency-file=CMakeFiles/libtorchcodec_core6.dir/link.d -shared -Wl,-soname,libtorchcodec_core6.so -o libtorchcodec_core6.so CMakeFiles/libtorchcodec_core6.dir/AVIOContextHolder.cpp.o CMakeFiles/libtorchcodec_core6.dir/AVIOTensorContext.cpp.o CMakeFiles/libtorchcodec_core6.dir/FFMPEGCommon.cpp.o CMakeFiles/libtorchcodec_core6.dir/Frame.cpp.o CMakeFiles/libtorchcodec_core6.dir/DeviceInterface.cpp.o CMakeFiles/libtorchcodec_core6.dir/CpuDeviceInterface.cpp.o CMakeFiles/libtorchcodec_core6.dir/SingleStreamDecoder.cpp.o CMakeFiles/libtorchcodec_core6.dir/Encoder.cpp.o   -L/lib/intel64  -L/lib/intel64_win  -L/lib/win-x64  -Wl,-rpath,/lib/intel64:/lib/intel64_win:/lib/win-x64:/home/nicolashug/.opt/miniconda3/envs/codec/lib/python3.11/site-packages/torch/lib:/home/nicolashug/.opt/miniconda3/envs/codec/lib: /home/nicolashug/.opt/miniconda3/envs/codec/lib/python3.11/site-packages/torch/lib/libtorch.so /home/nicolashug/.opt/miniconda3/envs/codec/lib/python3.11/site-packages/torch/lib/libc10.so /home/nicolashug/.opt/miniconda3/envs/codec/lib/libavdevice.so /home/nicolashug/.opt/miniconda3/envs/codec/lib/libavfilter.so /home/nicolashug/.opt/miniconda3/envs/codec/lib/libavformat.so /home/nicolashug/.opt/miniconda3/envs/codec/lib/libavcodec.so /home/nicolashug/.opt/miniconda3/envs/codec/lib/libavutil.so /home/nicolashug/.opt/miniconda3/envs/codec/lib/libswresample.so /home/nicolashug/.opt/miniconda3/envs/codec/lib/libswscale.so -Wl,--no-as-needed,"/home/nicolashug/.opt/miniconda3/envs/codec/lib/python3.11/site-packages/torch/lib/libtorch_cpu.so" -Wl,--as-needed /home/nicolashug/.opt/miniconda3/envs/codec/lib/python3.11/site-packages/torch/lib/libc10.so -Wl,--no-as-needed,"/home/nicolashug/.opt/miniconda3/envs/codec/lib/python3.11/site-packages/torch/lib/libtorch.so" -Wl,--as-needed
---
>   gmake[2]: Nothing to be done for 'src/torchcodec/_core/CMakeFiles/libtorchcodec_core6.dir/build'.
144a111,117
>   Dependencies file "src/torchcodec/_core/CMakeFiles/libtorchcodec_custom_ops6.dir/AVIOTensorContext.cpp.o.d" is newer than depends file "/home/nicolashug/dev/torchcodec/build_try/src/torchcodec/_core/CMakeFiles/libtorchcodec_custom_ops6.dir/compiler_depend.internal".
>   Dependencies file "src/torchcodec/_core/CMakeFiles/libtorchcodec_pybind_ops6.dir/AVIOFileLikeContext.cpp.o.d" is newer than depends file "/home/nicolashug/dev/torchcodec/build_try/src/torchcodec/_core/CMakeFiles/libtorchcodec_pybind_ops6.dir/compiler_depend.internal".
>   Dependencies file "src/torchcodec/_core/CMakeFiles/libtorchcodec_custom_ops6.dir/custom_ops.cpp.o.d" is newer than depends file "/home/nicolashug/dev/torchcodec/build_try/src/torchcodec/_core/CMakeFiles/libtorchcodec_custom_ops6.dir/compiler_depend.internal".
>   Dependencies file "src/torchcodec/_core/CMakeFiles/libtorchcodec_pybind_ops6.dir/pybind_ops.cpp.o.d" is newer than depends file "/home/nicolashug/dev/torchcodec/build_try/src/torchcodec/_core/CMakeFiles/libtorchcodec_pybind_ops6.dir/compiler_depend.internal".
>   Dependencies file "src/torchcodec/_core/CMakeFiles/libtorchcodec_custom_ops6.dir/link.d" is newer than depends file "/home/nicolashug/dev/torchcodec/build_try/src/torchcodec/_core/CMakeFiles/libtorchcodec_custom_ops6.dir/compiler_depend.internal".
>   Dependencies file "src/torchcodec/_core/CMakeFiles/libtorchcodec_pybind_ops6.dir/link.d" is newer than depends file "/home/nicolashug/dev/torchcodec/build_try/src/torchcodec/_core/CMakeFiles/libtorchcodec_pybind_ops6.dir/compiler_depend.internal".
>   Consolidate compiler generated dependencies of target libtorchcodec_custom_ops6
147c120
<   gmake[2]: Entering directory '/home/nicolashug/dev/torchcodec/build_try'
---
>   Consolidate compiler generated dependencies of target libtorchcodec_pybind_ops6
151,163c124
<   [ 73%] Building CXX object src/torchcodec/_core/CMakeFiles/libtorchcodec_custom_ops6.dir/AVIOTensorContext.cpp.o
<   [ 73%] Building CXX object src/torchcodec/_core/CMakeFiles/libtorchcodec_custom_ops6.dir/custom_ops.cpp.o
<   cd /home/nicolashug/dev/torchcodec/build_try/src/torchcodec/_core && /usr/lib64/ccache/c++ -DUSE_C10D_GLOO -DUSE_DISTRIBUTED -DUSE_RPC -DUSE_TENSORPIPE -Dlibtorchcodec_custom_ops6_EXPORTS -I/home/nicolashug/dev/torchcodec/src/torchcodec/_core/./../../.. -I/home/nicolashug/.opt/miniconda3/envs/codec/include/python3.11 -isystem /home/nicolashug/.opt/miniconda3/envs/codec/lib/python3.11/site-packages/torch/include -isystem /home/nicolashug/.opt/miniconda3/envs/codec/include -isystem /home/nicolashug/.opt/miniconda3/envs/codec/lib/python3.11/site-packages/torch/include/torch/csrc/api/include -Wall -Wextra -pedantic -Werror  -O3 -DNDEBUG -std=gnu++17 -fPIC -MD -MT src/torchcodec/_core/CMakeFiles/libtorchcodec_custom_ops6.dir/AVIOTensorContext.cpp.o -MF CMakeFiles/libtorchcodec_custom_ops6.dir/AVIOTensorContext.cpp.o.d -o CMakeFiles/libtorchcodec_custom_ops6.dir/AVIOTensorContext.cpp.o -c /home/nicolashug/dev/torchcodec/src/torchcodec/_core/AVIOTensorContext.cpp
<   cd /home/nicolashug/dev/torchcodec/build_try/src/torchcodec/_core && /usr/lib64/ccache/c++ -DUSE_C10D_GLOO -DUSE_DISTRIBUTED -DUSE_RPC -DUSE_TENSORPIPE -Dlibtorchcodec_custom_ops6_EXPORTS -I/home/nicolashug/dev/torchcodec/src/torchcodec/_core/./../../.. -I/home/nicolashug/.opt/miniconda3/envs/codec/include/python3.11 -isystem /home/nicolashug/.opt/miniconda3/envs/codec/lib/python3.11/site-packages/torch/include -isystem /home/nicolashug/.opt/miniconda3/envs/codec/include -isystem /home/nicolashug/.opt/miniconda3/envs/codec/lib/python3.11/site-packages/torch/include/torch/csrc/api/include -Wall -Wextra -pedantic -Werror  -O3 -DNDEBUG -std=gnu++17 -fPIC -MD -MT src/torchcodec/_core/CMakeFiles/libtorchcodec_custom_ops6.dir/custom_ops.cpp.o -MF CMakeFiles/libtorchcodec_custom_ops6.dir/custom_ops.cpp.o.d -o CMakeFiles/libtorchcodec_custom_ops6.dir/custom_ops.cpp.o -c /home/nicolashug/dev/torchcodec/src/torchcodec/_core/custom_ops.cpp
<   [ 80%] Building CXX object src/torchcodec/_core/CMakeFiles/libtorchcodec_pybind_ops6.dir/AVIOFileLikeContext.cpp.o
<   cd /home/nicolashug/dev/torchcodec/build_try/src/torchcodec/_core && /usr/lib64/ccache/c++ -DPYBIND_OPS_MODULE_NAME=core_pybind_ops -DUSE_C10D_GLOO -DUSE_DISTRIBUTED -DUSE_RPC -DUSE_TENSORPIPE -Dlibtorchcodec_pybind_ops6_EXPORTS -I/home/nicolashug/dev/torchcodec/src/torchcodec/_core/./../../.. -isystem /home/nicolashug/.opt/miniconda3/envs/codec/lib/python3.11/site-packages/torch/include -isystem /home/nicolashug/.opt/miniconda3/envs/codec/include/python3.11 -isystem /home/nicolashug/.opt/miniconda3/envs/codec/include -isystem /home/nicolashug/.opt/miniconda3/envs/codec/lib/python3.11/site-packages/torch/include/torch/csrc/api/include -Wall -Wextra -pedantic -Werror  -O3 -DNDEBUG -std=gnu++17 -fPIC -fvisibility=hidden -MD -MT src/torchcodec/_core/CMakeFiles/libtorchcodec_pybind_ops6.dir/AVIOFileLikeContext.cpp.o -MF CMakeFiles/libtorchcodec_pybind_ops6.dir/AVIOFileLikeContext.cpp.o.d -o CMakeFiles/libtorchcodec_pybind_ops6.dir/AVIOFileLikeContext.cpp.o -c /home/nicolashug/dev/torchcodec/src/torchcodec/_core/AVIOFileLikeContext.cpp
<   [ 86%] Building CXX object src/torchcodec/_core/CMakeFiles/libtorchcodec_pybind_ops6.dir/pybind_ops.cpp.o
<   cd /home/nicolashug/dev/torchcodec/build_try/src/torchcodec/_core && /usr/lib64/ccache/c++ -DPYBIND_OPS_MODULE_NAME=core_pybind_ops -DUSE_C10D_GLOO -DUSE_DISTRIBUTED -DUSE_RPC -DUSE_TENSORPIPE -Dlibtorchcodec_pybind_ops6_EXPORTS -I/home/nicolashug/dev/torchcodec/src/torchcodec/_core/./../../.. -isystem /home/nicolashug/.opt/miniconda3/envs/codec/lib/python3.11/site-packages/torch/include -isystem /home/nicolashug/.opt/miniconda3/envs/codec/include/python3.11 -isystem /home/nicolashug/.opt/miniconda3/envs/codec/include -isystem /home/nicolashug/.opt/miniconda3/envs/codec/lib/python3.11/site-packages/torch/include/torch/csrc/api/include -Wall -Wextra -pedantic -Werror  -O3 -DNDEBUG -std=gnu++17 -fPIC -fvisibility=hidden -MD -MT src/torchcodec/_core/CMakeFiles/libtorchcodec_pybind_ops6.dir/pybind_ops.cpp.o -MF CMakeFiles/libtorchcodec_pybind_ops6.dir/pybind_ops.cpp.o.d -o CMakeFiles/libtorchcodec_pybind_ops6.dir/pybind_ops.cpp.o -c /home/nicolashug/dev/torchcodec/src/torchcodec/_core/pybind_ops.cpp
<   [ 93%] Linking CXX shared library libtorchcodec_custom_ops6.so
<   cd /home/nicolashug/dev/torchcodec/build_try/src/torchcodec/_core && /home/nicolashug/.opt/miniconda3/envs/codec/lib/python3.11/site-packages/cmake/data/bin/cmake -E cmake_link_script CMakeFiles/libtorchcodec_custom_ops6.dir/link.txt --verbose=1
<   [100%] Linking CXX shared module libtorchcodec_pybind_ops6.so
<   cd /home/nicolashug/dev/torchcodec/build_try/src/torchcodec/_core && /home/nicolashug/.opt/miniconda3/envs/codec/lib/python3.11/site-packages/cmake/data/bin/cmake -E cmake_link_script CMakeFiles/libtorchcodec_pybind_ops6.dir/link.txt --verbose=1
<   /usr/lib64/ccache/c++ -fPIC  -Wall -Wextra -pedantic -Werror  -O3 -DNDEBUG -Wl,-undefined,dynamic_lookup -Wl,--dependency-file=CMakeFiles/libtorchcodec_pybind_ops6.dir/link.d -shared  -o libtorchcodec_pybind_ops6.so CMakeFiles/libtorchcodec_pybind_ops6.dir/AVIOFileLikeContext.cpp.o CMakeFiles/libtorchcodec_pybind_ops6.dir/pybind_ops.cpp.o   -L/lib/intel64  -L/lib/intel64_win  -L/lib/win-x64  -Wl,-rpath,/lib/intel64:/lib/intel64_win:/lib/win-x64:/home/nicolashug/dev/torchcodec/build_try/src/torchcodec/_core:/home/nicolashug/.opt/miniconda3/envs/codec/lib:/home/nicolashug/.opt/miniconda3/envs/codec/lib/python3.11/site-packages/torch/lib: libtorchcodec_core6.so /home/nicolashug/.opt/miniconda3/envs/codec/lib/libavdevice.so /home/nicolashug/.opt/miniconda3/envs/codec/lib/libavfilter.so /home/nicolashug/.opt/miniconda3/envs/codec/lib/libavformat.so /home/nicolashug/.opt/miniconda3/envs/codec/lib/libavcodec.so /home/nicolashug/.opt/miniconda3/envs/codec/lib/libavutil.so /home/nicolashug/.opt/miniconda3/envs/codec/lib/libswresample.so /home/nicolashug/.opt/miniconda3/envs/codec/lib/libswscale.so /home/nicolashug/.opt/miniconda3/envs/codec/lib/python3.11/site-packages/torch/lib/libtorch.so -Wl,--no-as-needed,"/home/nicolashug/.opt/miniconda3/envs/codec/lib/python3.11/site-packages/torch/lib/libtorch_cpu.so" -Wl,--as-needed /home/nicolashug/.opt/miniconda3/envs/codec/lib/python3.11/site-packages/torch/lib/libc10.so -Wl,--no-as-needed,"/home/nicolashug/.opt/miniconda3/envs/codec/lib/python3.11/site-packages/torch/lib/libtorch.so" -Wl,--as-needed /home/nicolashug/.opt/miniconda3/envs/codec/lib/python3.11/site-packages/torch/lib/libc10.so
---
>   gmake[2]: Nothing to be done for 'src/torchcodec/_core/CMakeFiles/libtorchcodec_custom_ops6.dir/build'.
165,166c126,128
<   /usr/lib64/ccache/c++ -fPIC  -Wall -Wextra -pedantic -Werror  -O3 -DNDEBUG -Wl,--dependency-file=CMakeFiles/libtorchcodec_custom_ops6.dir/link.d -shared -Wl,-soname,libtorchcodec_custom_ops6.so -o libtorchcodec_custom_ops6.so CMakeFiles/libtorchcodec_custom_ops6.dir/AVIOTensorContext.cpp.o CMakeFiles/libtorchcodec_custom_ops6.dir/custom_ops.cpp.o   -L/lib/intel64  -L/lib/intel64_win  -L/lib/win-x64  -Wl,-rpath,/lib/intel64:/lib/intel64_win:/lib/win-x64:/home/nicolashug/dev/torchcodec/build_try/src/torchcodec/_core:/home/nicolashug/.opt/miniconda3/envs/codec/lib:/home/nicolashug/.opt/miniconda3/envs/codec/lib/python3.11/site-packages/torch/lib: libtorchcodec_core6.so /home/nicolashug/.opt/miniconda3/envs/codec/lib/libpython3.11.so /home/nicolashug/.opt/miniconda3/envs/codec/lib/libavdevice.so /home/nicolashug/.opt/miniconda3/envs/codec/lib/libavfilter.so /home/nicolashug/.opt/miniconda3/envs/codec/lib/libavformat.so /home/nicolashug/.opt/miniconda3/envs/codec/lib/libavcodec.so /home/nicolashug/.opt/miniconda3/envs/codec/lib/libavutil.so /home/nicolashug/.opt/miniconda3/envs/codec/lib/libswresample.so /home/nicolashug/.opt/miniconda3/envs/codec/lib/libswscale.so /home/nicolashug/.opt/miniconda3/envs/codec/lib/python3.11/site-packages/torch/lib/libtorch.so -Wl,--no-as-needed,"/home/nicolashug/.opt/miniconda3/envs/codec/lib/python3.11/site-packages/torch/lib/libtorch_cpu.so" -Wl,--as-needed /home/nicolashug/.opt/miniconda3/envs/codec/lib/python3.11/site-packages/torch/lib/libc10.so -Wl,--no-as-needed,"/home/nicolashug/.opt/miniconda3/envs/codec/lib/python3.11/site-packages/torch/lib/libtorch.so" -Wl,--as-needed /home/nicolashug/.opt/miniconda3/envs/codec/lib/python3.11/site-packages/torch/lib/libc10.so
<   [100%] Built target libtorchcodec_pybind_ops6
---
>   [ 80%] Built target libtorchcodec_custom_ops6
>   gmake[2]: Entering directory '/home/nicolashug/dev/torchcodec/build_try'
>   gmake[2]: Nothing to be done for 'src/torchcodec/_core/CMakeFiles/libtorchcodec_pybind_ops6.dir/build'.
168c130
<   [100%] Built target libtorchcodec_custom_ops6
---
>   [100%] Built target libtorchcodec_pybind_ops6
174,185c136,144
<   -- Installing: /tmp/tmpexb7uxbx.build-lib/torchcodec/libtorchcodec_core6.so
<   -- Set non-toolchain portion of runtime path of "/tmp/tmpexb7uxbx.build-lib/torchcodec/libtorchcodec_core6.so" to ""
<   -- Installing: /tmp/tmpexb7uxbx.build-lib/torchcodec/libtorchcodec_custom_ops6.so
<   -- Set non-toolchain portion of runtime path of "/tmp/tmpexb7uxbx.build-lib/torchcodec/libtorchcodec_custom_ops6.so" to ""
<   -- Installing: /tmp/tmpexb7uxbx.build-lib/torchcodec/libtorchcodec_pybind_ops6.so
<   -- Set non-toolchain portion of runtime path of "/tmp/tmpexb7uxbx.build-lib/torchcodec/libtorchcodec_pybind_ops6.so" to ""
<   Copying /tmp/tmpexb7uxbx.build-lib/torchcodec/libtorchcodec_pybind_ops6.so to src/torchcodec/libtorchcodec_pybind_ops6.so
<   copying /tmp/tmpexb7uxbx.build-lib/torchcodec/libtorchcodec_pybind_ops6.so -> src/torchcodec
<   Copying /tmp/tmpexb7uxbx.build-lib/torchcodec/libtorchcodec_custom_ops6.so to src/torchcodec/libtorchcodec_custom_ops6.so
<   copying /tmp/tmpexb7uxbx.build-lib/torchcodec/libtorchcodec_custom_ops6.so -> src/torchcodec
<   Copying /tmp/tmpexb7uxbx.build-lib/torchcodec/libtorchcodec_core6.so to src/torchcodec/libtorchcodec_core6.so
<   copying /tmp/tmpexb7uxbx.build-lib/torchcodec/libtorchcodec_core6.so -> src/torchcodec
---
>   -- Installing: /tmp/tmpy6_z360m.build-lib/torchcodec/libtorchcodec_core6.so
>   -- Set non-toolchain portion of runtime path of "/tmp/tmpy6_z360m.build-lib/torchcodec/libtorchcodec_core6.so" to ""
>   -- Installing: /tmp/tmpy6_z360m.build-lib/torchcodec/libtorchcodec_custom_ops6.so
>   -- Set non-toolchain portion of runtime path of "/tmp/tmpy6_z360m.build-lib/torchcodec/libtorchcodec_custom_ops6.so" to ""
>   -- Installing: /tmp/tmpy6_z360m.build-lib/torchcodec/libtorchcodec_pybind_ops6.so
>   -- Set non-toolchain portion of runtime path of "/tmp/tmpy6_z360m.build-lib/torchcodec/libtorchcodec_pybind_ops6.so" to ""
>   Copying /tmp/tmpy6_z360m.build-lib/torchcodec/libtorchcodec_pybind_ops6.so to src/torchcodec/libtorchcodec_pybind_ops6.so
>   Copying /tmp/tmpy6_z360m.build-lib/torchcodec/libtorchcodec_custom_ops6.so to src/torchcodec/libtorchcodec_custom_ops6.so
>   Copying /tmp/tmpy6_z360m.build-lib/torchcodec/libtorchcodec_core6.so to src/torchcodec/libtorchcodec_core6.so
187,193c146,152
<   creating /tmp/tmp_csiij00.build-temp/torchcodec.egg-info
<   writing /tmp/tmp_csiij00.build-temp/torchcodec.egg-info/PKG-INFO
<   writing dependency_links to /tmp/tmp_csiij00.build-temp/torchcodec.egg-info/dependency_links.txt
<   writing requirements to /tmp/tmp_csiij00.build-temp/torchcodec.egg-info/requires.txt
<   writing top-level names to /tmp/tmp_csiij00.build-temp/torchcodec.egg-info/top_level.txt
<   writing manifest file '/tmp/tmp_csiij00.build-temp/torchcodec.egg-info/SOURCES.txt'
<   reading manifest file '/tmp/tmp_csiij00.build-temp/torchcodec.egg-info/SOURCES.txt'
---
>   creating /tmp/tmpljqs86xa.build-temp/torchcodec.egg-info
>   writing /tmp/tmpljqs86xa.build-temp/torchcodec.egg-info/PKG-INFO
>   writing dependency_links to /tmp/tmpljqs86xa.build-temp/torchcodec.egg-info/dependency_links.txt
>   writing requirements to /tmp/tmpljqs86xa.build-temp/torchcodec.egg-info/requires.txt
>   writing top-level names to /tmp/tmpljqs86xa.build-temp/torchcodec.egg-info/top_level.txt
>   writing manifest file '/tmp/tmpljqs86xa.build-temp/torchcodec.egg-info/SOURCES.txt'
>   reading manifest file '/tmp/tmpljqs86xa.build-temp/torchcodec.egg-info/SOURCES.txt'
197c156
<   writing manifest file '/tmp/tmp_csiij00.build-temp/torchcodec.egg-info/SOURCES.txt'
---
>   writing manifest file '/tmp/tmpljqs86xa.build-temp/torchcodec.egg-info/SOURCES.txt'
206c165
<   creating '/tmp/pip-wheel-1z6z4rvy/.tmp-0gs6lpwo/torchcodec-0.5.0a0-0.editable-cp311-cp311-linux_x86_64.whl' and adding '/tmp/tmpmzxynqm4torchcodec-0.5.0a0-0.editable-cp311-cp311-linux_x86_64.whl' to it
---
>   creating '/tmp/pip-wheel-ovhhyoqq/.tmp-sje2lbbo/torchcodec-0.5.0a0-0.editable-cp311-cp311-linux_x86_64.whl' and adding '/tmp/tmp_ppfpb53torchcodec-0.5.0a0-0.editable-cp311-cp311-linux_x86_64.whl' to it

```