### PR TITLE
Use MSVC toolchain when building FFmpeg on Windows

### DIFF
--- a/packaging/build_ffmpeg.sh
+++ b/packaging/build_ffmpeg.sh
@@ -20,6 +20,10 @@
 set -eux
 
 prefix="${FFMPEG_ROOT}"
+args=""
+if [[ "$OSTYPE" == "msys" ]]; then
+   args="--toolchain=msvc"
+fi
 archive="https://github.com/FFmpeg/FFmpeg/archive/refs/tags/n${FFMPEG_VERSION}.tar.gz"
 
 build_dir=$(mktemp -d -t ffmpeg-build.XXXXXXXXXX)
@@ -62,7 +66,7 @@ tar -xf ffmpeg.tar.gz --strip-components 1
     --enable-avformat \
     --enable-avutil \
     --enable-swscale \
-    --enable-swresample
+    --enable-swresample ${args}
 
 make -j install
 ls ${prefix}/*


### PR DESCRIPTION
As done in torchaudio: https://github.com/pytorch/audio/blob/6fbc710b617f79b992ef2ebc7f95e818aa390293/.github/scripts/ffmpeg/build.sh#L20-L22