### PR TITLE
Tests: fix tests if running with self-built ffmpeg

### DIFF
--- a/src/torchcodec/_core/custom_ops.cpp
+++ b/src/torchcodec/_core/custom_ops.cpp
@@ -656,6 +656,10 @@ std::string get_stream_json_metadata(
 
 // Returns version information about the various FFMPEG libraries that are
 // loaded in the program's address space.
+// TODO: ideally we'd have a more robust way of getting the ffmpeg version,
+// we're using av_version_info() which is not standardized and shouldn't be
+// parsed by code (which we do!). See
+// https://github.com/pytorch/torchcodec/issues/100
 std::string _get_json_ffmpeg_library_versions() {
   std::stringstream ss;
   ss << "{\n";

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -78,9 +78,7 @@ def test_get_metadata(metadata_getter):
     with pytest.raises(NotImplementedError, match="Decide on logic"):
         metadata.bit_rate
 
-    ffmpeg_major_version = int(
-        get_ffmpeg_library_versions()["ffmpeg_version"].split(".")[0]
-    )
+    ffmpeg_major_version = get_ffmpeg_major_version()
     if ffmpeg_major_version <= 5:
         expected_duration_seconds_from_header = 16.57
         expected_bit_rate_from_header = 324915

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -15,7 +15,6 @@ from torchcodec._core import (
     create_from_file,
     get_container_metadata,
     get_container_metadata_from_header,
-    get_ffmpeg_library_versions,
     VideoStreamMetadata,
 )
 from torchcodec.decoders import AudioDecoder, VideoDecoder

--- a/test/utils.py
+++ b/test/utils.py
@@ -29,6 +29,9 @@ def cpu_and_cuda():
 
 def get_ffmpeg_major_version():
     ffmpeg_version = get_ffmpeg_library_versions()["ffmpeg_version"]
+    # When building FFmpeg from source there can be a `n` prefix in the version
+    # string.  This is quite brittle as we're using av_version_info(), which has
+    # no stable format. See https://github.com/pytorch/torchcodec/issues/100
     if ffmpeg_version.startswith("n"):
         ffmpeg_version = ffmpeg_version.removeprefix("n")
     return int(ffmpeg_version.split(".")[0])

--- a/test/utils.py
+++ b/test/utils.py
@@ -28,7 +28,10 @@ def cpu_and_cuda():
 
 
 def get_ffmpeg_major_version():
-    return int(get_ffmpeg_library_versions()["ffmpeg_version"].split(".")[0])
+    ffmpeg_version = get_ffmpeg_library_versions()["ffmpeg_version"]
+    if ffmpeg_version.startswith("n"):
+        ffmpeg_version = ffmpeg_version.removeprefix("n")
+    return int(ffmpeg_version.split(".")[0])
 
 
 # For use with decoded data frames. On CPU Linux, we expect exact, bit-for-bit


### PR DESCRIPTION
If self-building ffmpeg from the tag for development reasons, it's version is set as `n6.1.2` (with n-prefix). This causes failures in the torchcodec tests. This patch handles such a case accounting for the `n6.1.2` ffmpeg version format.

CC: @scotts, @NicolasHug, @dvrogozh