### PR TITLE
Call spec.loader.exec_module in _load_pybind11_module utility

### DIFF
--- a/src/torchcodec/_internally_replaced_utils.py
+++ b/src/torchcodec/_internally_replaced_utils.py
@@ -52,7 +52,7 @@ def _load_pybind11_module(module_name: str, library_path: str) -> ModuleType:
 
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
-    
+
     return mod
 
 

--- a/src/torchcodec/_internally_replaced_utils.py
+++ b/src/torchcodec/_internally_replaced_utils.py
@@ -50,7 +50,10 @@ def _load_pybind11_module(module_name: str, library_path: str) -> ModuleType:
             f"Unable to load spec for module {module_name} from path {library_path}"
         )
 
-    return importlib.util.module_from_spec(spec)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    
+    return mod
 
 
 # Note that the return value from this function must match the value used as


### PR DESCRIPTION
I am not 100% sure about this change, but without this change the torchcodec build of conda-forge fails after the upgrade from pybind11 2.* to pybind11 3.* during tests with error like:

~~~
 │ =========================== short test summary info ============================
 │ FAILED test/test_decoders.py::TestDecoder::test_create[file_like_rawio-VideoDecoder-asset0] - AttributeError: module 'core_pybind_ops' has no attribute 'create_from_file_like'
 │ FAILED test/test_decoders.py::TestDecoder::test_create[file_like_rawio-AudioDecoder-asset1] - AttributeError: module 'core_pybind_ops' has no attribute 'create_from_file_like'
 │ FAILED test/test_decoders.py::TestDecoder::test_create[file_like_rawio-AudioDecoder-asset2] - AttributeError: module 'core_pybind_ops' has no attribute 'create_from_file_like'
 │ FAILED test/test_decoders.py::TestDecoder::test_create[file_like_bufferedio-VideoDecoder-asset0] - AttributeError: module 'core_pybind_ops' has no attribute 'create_from_file_like'
 │ FAILED test/test_decoders.py::TestDecoder::test_create[file_like_bufferedio-AudioDecoder-asset1] - AttributeError: module 'core_pybind_ops' has no attribute 'create_from_file_like'
 │ FAILED test/test_decoders.py::TestDecoder::test_create[file_like_bufferedio-AudioDecoder-asset2] - AttributeError: module 'core_pybind_ops' has no attribute 'create_from_file_like'
 │ FAILED test/test_decoders.py::TestDecoder::test_create[file_like_custom-VideoDecoder-asset0] - AttributeError: module 'core_pybind_ops' has no attribute 'create_from_file_like'
 │ FAILED test/test_decoders.py::TestDecoder::test_create[file_like_custom-AudioDecoder-asset1] - AttributeError: module 'core_pybind_ops' has no attribute 'create_from_file_like'
 │ FAILED test/test_decoders.py::TestDecoder::test_create[file_like_custom-AudioDecoder-asset2] - AttributeError: module 'core_pybind_ops' has no attribute 'create_from_file_like'
 │ FAILED test/test_ops.py::TestVideoDecoderOps::test_create_decoder[file_like_rawio-cpu] - AttributeError: module 'core_pybind_ops' has no attribute 'create_from_file_like'
 │ FAILED test/test_ops.py::TestVideoDecoderOps::test_create_decoder[file_like_bufferedio-cpu] - AttributeError: module 'core_pybind_ops' has no attribute 'create_from_file_like'
 │ FAILED test/test_ops.py::TestAudioDecoderOps::test_file_like_decoding[cpu-0] - AttributeError: module 'core_pybind_ops' has no attribute 'create_from_file_like'
 │ FAILED test/test_ops.py::TestAudioDecoderOps::test_file_like_decoding[cpu-1024] - AttributeError: module 'core_pybind_ops' has no attribute 'create_from_file_like'
 │ FAILED test/test_ops.py::TestAudioDecoderOps::test_file_like_method_check_fails - AttributeError: module 'core_pybind_ops' has no attribute 'create_from_file_like'
 │ FAILED test/test_ops.py::TestAudioDecoderOps::test_file_like_read_fails - AttributeError: module 'core_pybind_ops' has no attribute 'create_from_file_like'
 │ FAILED test/test_ops.py::TestAudioDecoderOps::test_file_like_read_less_than_requested[half] - AttributeError: module 'core_pybind_ops' has no attribute 'create_from_file_like'
 │ FAILED test/test_ops.py::TestAudioDecoderOps::test_file_like_read_less_than_requested[minus_10] - AttributeError: module 'core_pybind_ops' has no attribute 'create_from_file_like'
 │ ============ 17 failed, 702 passed, 98 skipped in 109.81s (0:01:49) ============
~~~

to be honest, I do not know enough about Python module loading to understand why this happens in conda-forge CI, and not in torchcodec CI that also uses pybind11 `3.*` . However, the problem goes away if after loading the module, we also execute `spec.loader.exec_module` . Looking around it seems that this may be related to multi-phase init (for example https://github.com/pybind/pybind11/pull/5574), but to be honest I do not know enough about that to understand if that is the case.
