### PR TITLE
Correct `seek` signature to return `int` instead of `bytes`

### DIFF
--- a/examples/decoding/file_like.py
+++ b/examples/decoding/file_like.py
@@ -215,7 +215,7 @@ class FileOpCounter:
         self.num_reads += 1
         return self._file.read(size)
 
-    def seek(self, offset: int, whence: int) -> bytes:
+    def seek(self, offset: int, whence: int) -> int:
         self.num_seeks += 1
         return self._file.seek(offset, whence)
 

--- a/src/torchcodec/decoders/_audio_decoder.py
+++ b/src/torchcodec/decoders/_audio_decoder.py
@@ -35,7 +35,7 @@ class AudioDecoder:
             - If ``bytes`` object or ``torch.Tensor``: the raw encoded audio data.
             - If file-like object: we read video data from the object on demand. The object must
               expose the methods `read(self, size: int) -> bytes` and
-              `seek(self, offset: int, whence: int) -> bytes`. Read more in:
+              `seek(self, offset: int, whence: int) -> int`. Read more in:
               :ref:`sphx_glr_generated_examples_decoding_file_like.py`.
         stream_index (int, optional): Specifies which stream in the file to decode samples from.
             Note that this index is absolute across all media types. If left unspecified, then

--- a/src/torchcodec/decoders/_decoder_utils.py
+++ b/src/torchcodec/decoders/_decoder_utils.py
@@ -48,5 +48,5 @@ def create_decoder(
         f"Unknown source type: {type(source)}. "
         "Supported types are str, Path, bytes, Tensor and file-like objects with "
         "read(self, size: int) -> bytes and "
-        "seek(self, offset: int, whence: int) -> bytes methods."
+        "seek(self, offset: int, whence: int) -> int methods."
     )

--- a/src/torchcodec/decoders/_video_decoder.py
+++ b/src/torchcodec/decoders/_video_decoder.py
@@ -30,7 +30,7 @@ class VideoDecoder:
             - If ``bytes`` object or ``torch.Tensor``: the raw encoded video data.
             - If file-like object: we read video data from the object on demand. The object must
               expose the methods `read(self, size: int) -> bytes` and
-              `seek(self, offset: int, whence: int) -> bytes`. Read more in:
+              `seek(self, offset: int, whence: int) -> int`. Read more in:
               :ref:`sphx_glr_generated_examples_decoding_file_like.py`.
         stream_index (int, optional): Specifies which stream in the video to decode frames from.
             Note that this index is absolute across all media types. If left unspecified, then

--- a/test/test_decoders.py
+++ b/test/test_decoders.py
@@ -86,7 +86,7 @@ class TestDecoder:
                 def read(self, size: int) -> bytes:
                     return self._file.read(size)
 
-                def seek(self, offset: int, whence: int) -> bytes:
+                def seek(self, offset: int, whence: int) -> int:
                     return self._file.seek(offset, whence)
 
             source = CustomReader(open(asset.path, mode="rb", buffering=0))

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1038,7 +1038,7 @@ class TestAudioDecoderOps:
                 self.num_reads += 1
                 return self._file.read(size)
 
-            def seek(self, offset: int, whence: int) -> bytes:
+            def seek(self, offset: int, whence: int) -> int:
                 self.num_seeks += 1
                 return self._file.seek(offset, whence)
 
@@ -1086,8 +1086,8 @@ class TestAudioDecoderOps:
 
     def test_file_like_method_check_fails(self):
         class ReadMethodMissing:
-            def seek(self, offset: int, whence: int) -> bytes:
-                return bytes()
+            def seek(self, offset: int, whence: int) -> int:
+                return 0
 
         with pytest.raises(RuntimeError, match="must implement a read method"):
             create_from_file_like(ReadMethodMissing(), "approximate")
@@ -1107,7 +1107,7 @@ class TestAudioDecoderOps:
             def read(self) -> bytes:
                 return bytes()
 
-            def seek(self, offset: int, whence: int) -> bytes:
+            def seek(self, offset: int, whence: int) -> int:
                 return self._file.seeK(offset, whence)
 
         with pytest.raises(
@@ -1126,8 +1126,8 @@ class TestAudioDecoderOps:
                 return self._file.read(size)
 
             # io.RawIOBase says we should accept two ints; wrong signature on purpose
-            def seek(self, offset: int) -> bytes:
-                return bytes()
+            def seek(self, offset: int) -> int:
+                return 0
 
         with pytest.raises(
             TypeError, match="takes 2 positional arguments but 3 were given"
@@ -1147,7 +1147,7 @@ class TestAudioDecoderOps:
                 # We intentionally read more than requested.
                 return self._file.read(size + 10)
 
-            def seek(self, offset: int, whence: int) -> bytes:
+            def seek(self, offset: int, whence: int) -> int:
                 return self._file.seek(offset, whence)
 
         with pytest.raises(RuntimeError, match="does not conform to read protocol"):
@@ -1174,7 +1174,7 @@ class TestAudioDecoderOps:
 
                 return self._file.read(size)
 
-            def seek(self, offset: int, whence: int) -> bytes:
+            def seek(self, offset: int, whence: int) -> int:
                 return self._file.seek(offset, whence)
 
         decoder_file_like = create_from_file_like(


### PR DESCRIPTION
Current examples suggest `seek` api on file-like objects should return `bytes`, while actual usage always expects `int` instead.

For example: https://docs.python.org/3/library/io.html#io.IOBase.seek

```
seek(offset, whence=os.SEEK_SET, /)
Change the stream position to the given byte offset, interpreted relative to the position indicated by whence, and return the new absolute position.
```