### PR TITLE
Fix build

### DIFF
--- a/src/torchcodec/_core/custom_ops.cpp
+++ b/src/torchcodec/_core/custom_ops.cpp
@@ -84,7 +84,9 @@ at::Tensor wrapDecoderPointerToTensor(
 }
 
 SingleStreamDecoder* unwrapTensorToGetDecoder(at::Tensor& tensor) {
-  TORCH_INTERNAL_ASSERT(tensor.is_contiguous());
+  TORCH_CHECK(
+      tensor.is_contiguous(),
+      "fake decoder tensor must be contiguous! This is an internal error, please report on the torchcodec issue tracker.");
   void* buffer = tensor.mutable_data_ptr();
   SingleStreamDecoder* decoder = static_cast<SingleStreamDecoder*>(buffer);
   return decoder;


### PR DESCRIPTION
All builds started [failing](https://github.com/pytorch/torchcodec/actions/runs/17239919864/job/48914006197?pr=846) with:


```
/Users/ec2-user/runner/_work/torchcodec/torchcodec/pytorch/torchcodec/src/torchcodec/_core/custom_ops.cpp:87:47: error: must specify at least one argument for '...' parameter of variadic macro [-Werror,-Wgnu-zero-variadic-macro-arguments]
  TORCH_INTERNAL_ASSERT(tensor.is_contiguous());
                                              ^
```

Probably a BC-breaking change from torch? Anyway, we should probably rely on `TORCH_CHECK` rather than `TORCH_INTERNAL_ASSERT` regardless.