### PR TITLE
Set 3.10 as minimum supported version

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -51,10 +51,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-          # 3.9 corresponds to the minimum python version for which we build
+          # 3.10 corresponds to the minimum python version for which we build
           # the wheel unless the label cliflow/binaries/all is present in the
           # PR.
-        python-version: ['3.9']
+        python-version: ['3.10']
         cuda-version: ['12.6']
         ffmpeg-version-for-tests: ['7']
     container:

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -61,12 +61,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-          # 3.9 corresponds to the minimum python version for which we build
+          # 3.10 corresponds to the minimum python version for which we build
           # the wheel unless the label cliflow/binaries/all is present in the
           # PR.
           # For the actual release we should add that label and change this to
           # include more python versions.
-        python-version: ['3.9']
+        python-version: ['3.10']
         # We test against 12.6 and 12.9 to avoid having too big of a CI matrix,
         # but for releases we should add 12.8.
         cuda-version: ['12.6', '12.9']

--- a/.github/workflows/linux_wheel.yaml
+++ b/.github/workflows/linux_wheel.yaml
@@ -62,7 +62,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9']
+        python-version: ['3.10']
         ffmpeg-version-for-tests: ['4.4.2', '5.1.2', '6.1.1', '7.0.1']
     needs: build
     steps:

--- a/.github/workflows/macos_wheel.yaml
+++ b/.github/workflows/macos_wheel.yaml
@@ -63,7 +63,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9']
+        python-version: ['3.10']
         ffmpeg-version-for-tests: ['4.4.2', '5.1.2', '6.1.1', '7.0.1']
     needs: build
     steps:

--- a/.github/workflows/reference_resources.yaml
+++ b/.github/workflows/reference_resources.yaml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9']
+        python-version: ['3.10']
         ffmpeg-version-for-tests: ['4.4.2', '5.1.2', '6.1.1', '7.0.1']
     steps:
       - name: Setup conda env

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ The following table indicates the compatibility between versions of
 
 | `torchcodec`       | `torch`            | Python              |
 | ------------------ | ------------------ | ------------------- |
-| `main` / `nightly` | `main` / `nightly` | `>=3.9`, `<=3.13`   |
+| `main` / `nightly` | `main` / `nightly` | `>=3.10`, `<=3.13`   |
 | `0.6`              | `2.8`              | `>=3.9`, `<=3.13`   |
 | `0.5`              | `2.7`              | `>=3.9`, `<=3.13`   |
 | `0.4`              | `2.7`              | `>=3.9`, `<=3.13`   |


### PR DESCRIPTION
`torch` doesn't support 3.9 anymore, so we can't either. This PR moves our jobs to test on 3.10 instead of 3.9

Closes https://github.com/pytorch/torchcodec/issues/841