### PR TITLE
Skip `test_num_channels`

### DIFF
--- a/test/test_encoders.py
+++ b/test/test_encoders.py
@@ -403,6 +403,9 @@ class TestAudioEncoder:
             encoded_from_contiguous, encoded_from_non_contiguous, rtol=0, atol=0
         )
 
+    @pytest.mark.skip(
+        reason="Flaky test, see https://github.com/pytorch/torchcodec/issues/724"
+    )
     @pytest.mark.parametrize("num_channels_input", (1, 2))
     @pytest.mark.parametrize("num_channels_output", (1, 2, None))
     @pytest.mark.parametrize("method", ("to_file", "to_tensor", "to_file_like"))


### PR DESCRIPTION
This test has been very flaky and failing often. Let's skip it to preserve CI health, until we find a proper way to resolve https://github.com/pytorch/torchcodec/issues/724 . It's not a super super critical test and a lost of what it's testing is tested in other tests already.