### PR TITLE
Shorter frame-mapping test name

### DIFF
--- a/test/test_decoders.py
+++ b/test/test_decoders.py
@@ -1342,7 +1342,11 @@ class TestVideoDecoder:
     @pytest.mark.parametrize(
         "custom_frame_mappings,expected_match",
         [
-            (NASA_VIDEO.generate_custom_frame_mappings(0), "seek_mode"),
+            pytest.param(
+                NASA_VIDEO.generate_custom_frame_mappings(0),
+                "seek_mode",
+                id="valid_content_approximate",
+            ),
             ("{}", "The input is empty or missing the required 'frames' key."),
             (
                 '{"valid": "json"}',


### PR DESCRIPTION
The test currently has a really long name as it contains the entire file content. See e.g. https://github.com/pytorch/torchcodec/actions/runs/17242892367/job/48925287759#step:11:215


This PR fixes this by hard-coding the test name, which can be done through `pytes.param(..., id=NAME)`.

I think this is what's causing the failures on  https://github.com/pytorch/torchcodec/actions/runs/17242927437/job/48927121120?pr=806
