### PR TITLE
Prevent 3.13t Windows builds

### DIFF
--- a/.github/workflows/windows_wheel.yaml
+++ b/.github/workflows/windows_wheel.yaml
@@ -36,6 +36,8 @@ jobs:
       with-rocm: disable
       with-cuda: disable
       build-python-only: "disable"
+      python-versions: '["3.10", "3.11", "3.12", "3.13"]'
+
 
   build:
     needs: generate-matrix


### PR DESCRIPTION
Windows 3.13t builds don't work, which causes failures on our `main` branch (not on PRs): https://github.com/pytorch/torchcodec/actions/runs/17288016442/job/49068864699

This PR prevents those 3.13t jobs from being started. That's OK, we can do without 3.13t it for now. 3.13 is supported.