### PR TITLE
Add an upper bound to the ffmpeg version installed in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Start by installing the **nightly** build of PyTorch following the
 Then, the easiest way to install the rest of the dependencies is to run:
 
 ```bash
-conda install cmake pkg-config pybind11 ffmpeg -c conda-forge
+conda install cmake pkg-config pybind11 "ffmpeg<8" -c conda-forge
 ```
 
 ### Clone and build

--- a/README.md
+++ b/README.md
@@ -114,9 +114,9 @@ ffmpeg -f lavfi -i \
    easy way to install it is to use `conda`:
 
    ```bash
-   conda install ffmpeg
+   conda install "ffmpeg<8"
    # or
-   conda install ffmpeg -c conda-forge
+   conda install "ffmpeg<8" -c conda-forge
    ```
 
 3. Install TorchCodec:
@@ -157,9 +157,9 @@ format you want. Refer to Nvidia's GPU support matrix for more details
    easy way to install it is to use `conda`:
 
    ```bash
-   conda install ffmpeg
+   conda install "ffmpeg<8"
    # or
-   conda install ffmpeg -c conda-forge
+   conda install "ffmpeg<8" -c conda-forge
    ```
 
    If you are building FFmpeg from source you can follow Nvidia's guide to


### PR DESCRIPTION
On the `conda-forge` side, ffmpeg was updated to 8 in https://github.com/conda-forge/ffmpeg-feedstock/pull/335, so by default `conda install ffmpeg` will install a ffmpeg incompatible with torchcodec. To ensure that a ffmpeg compatible with torchcodec is installed, we can add a `<8` upper bound to the ffmpeg specification.

Once torchcodec is compatible with ffmpeg 8 (https://github.com/pytorch/torchcodec/issues/839) probably it make sense to keep this upper bound, but bump it to 9, to avoid regression once ffmpeg 9 will come out.