### PR TITLE
Use CUDA 13.0 on CI

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -55,7 +55,7 @@ jobs:
           # the wheel unless the label cliflow/binaries/all is present in the
           # PR.
         python-version: ['3.10']
-        cuda-version: ['12.6']
+        cuda-version: ['12.8']
         ffmpeg-version-for-tests: ['7']
     container:
       image: "pytorch/manylinux2_28-builder:cuda${{ matrix.cuda-version }}"

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -67,9 +67,9 @@ jobs:
           # For the actual release we should add that label and change this to
           # include more python versions.
         python-version: ['3.10']
-        # We test against 12.6 and 12.9 to avoid having too big of a CI matrix,
+        # We test against 12.6 and 13.0 to avoid having too big of a CI matrix,
         # but for releases we should add 12.8.
-        cuda-version: ['12.6', '12.9']
+        cuda-version: ['12.6', '13.0']
         # TODO: put back ffmpeg 5 https://github.com/pytorch/torchcodec/issues/325
         ffmpeg-version-for-tests: ['4.4.2', '6', '7']
 


### PR DESCRIPTION
It seems from https://github.com/pytorch/torchcodec/actions/runs/17402821403/job/49401670135?pr=831 that test-infra stopped support 12.9 and is generating jobs for 13.0 instead, so we need to change our jobs to reflect that.