### PR TITLE
Remove 12.9 CUDA test jobs

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -55,7 +55,7 @@ jobs:
           # the wheel unless the label cliflow/binaries/all is present in the
           # PR.
         python-version: ['3.10']
-        cuda-version: ['12.8']
+        cuda-version: ['12.6']
         ffmpeg-version-for-tests: ['7']
     container:
       image: "pytorch/manylinux2_28-builder:cuda${{ matrix.cuda-version }}"


### PR DESCRIPTION
PyTorch stopped supported 12.9 so our CI is [red](https://github.com/pytorch/torchcodec/actions/runs/17411240832/job/49430026435?pr=865). We should replace it by 13.0. I'm trying to add 13.0 jobs in https://github.com/pytorch/torchcodec/pull/862, but it's failing when installing dependencies. We should follow-up ASAP on it.