### PR TITLE
Fix `NVDEC -> NPP` CUDA stream sync issue

### DIFF
--- a/src/torchcodec/_core/CudaDeviceInterface.cpp
+++ b/src/torchcodec/_core/CudaDeviceInterface.cpp
@@ -275,7 +275,32 @@ void CudaDeviceInterface::convertAVFrameToFrameOutput(
   }
 
   torch::DeviceIndex deviceIndex = getNonNegativeDeviceIndex(device_);
-  nppCtx_->hStream = at::cuda::getCurrentCUDAStream(deviceIndex).stream();
+
+  // Create a CUDA event and attach it to the AVFrame's CUDA stream. That's the
+  // NVDEC stream, i.e. the CUDA stream that the frame was decoded on.
+  // We will be waiting for this event to complete before calling the NPP
+  // functions, to ensure NVDEC has finished decoding the frame before running
+  // the NPP color-conversion.
+  // Note that our code is generic and assumes that the NVDEC's stream can be
+  // arbitrary, but unfortunately we know it's hardcoded to be the default
+  // stream by FFmpeg:
+  // https://github.com/FFmpeg/FFmpeg/blob/66e40840d15b514f275ce3ce2a4bf72ec68c7311/libavutil/hwcontext_cuda.c#L387-L388
+  TORCH_CHECK(
+      hwFramesCtx->device_ctx != nullptr,
+      "The AVFrame's hw_frames_ctx does not have a device_ctx. ");
+  auto cudaDeviceCtx =
+      static_cast<AVCUDADeviceContext*>(hwFramesCtx->device_ctx->hwctx);
+  at::cuda::CUDAEvent nvdecDoneEvent;
+  at::cuda::CUDAStream nvdecStream = // That's always the default stream. Sad.
+      c10::cuda::getStreamFromExternal(cudaDeviceCtx->stream, deviceIndex);
+  nvdecDoneEvent.record(nvdecStream);
+
+  // Don't start NPP work before NVDEC is done decoding the frame!
+  at::cuda::CUDAStream nppStream = at::cuda::getCurrentCUDAStream(deviceIndex);
+  nvdecDoneEvent.block(nppStream);
+
+  // Create the NPP context if we haven't yet.
+  nppCtx_->hStream = nppStream.stream();
   cudaError_t err =
       cudaStreamGetFlags(nppCtx_->hStream, &nppCtx_->nStreamFlags);
   TORCH_CHECK(


### PR DESCRIPTION
This PR fixes a CUDA stream synchronization bug between NVDEC (the decoder) and NPP (the color-conversion).

I hope this is a also *the* fix for an issue that was originally discovered by @ronghanghu with https://fburl.com/oay62aq2.

For context:

- A frame is first decoded by NVDEC as YUV, and we then use NPP to convert the frame from YUV to RGB
- CUDA streams are... too complex for me to properly explain, so let's ask ChatGPT for [a primer](https://chatgpt.com/share/68b8441f-5410-8008-b72f-41d5d5931286). The important points for us are:
  - NVDEC has a stream, and NPP has a stream
  - In most cases, and unless you explicitly request otherwise, the NVDEC's stream is the same as the NPP stream. There's no problem in this case.
  - But that's not always the case. In general the NVDEC stream may be different from the NPP stream. Because streams execute in parallel, that means that we may be sometimes launching the NPP kernel while the NVDEC stream hasn't actually finished decoding the frame. That's obviously a problem, and that's the bug this PR is fixing: we now force the NPP stream to wait for the NVDEC stream to finish.


The bug can be reproduced with this snippet:

```py
#%%
import torch

path = "/home/nicolashug/Downloads/break/video.mp4"


DECODE_WITH_DEFAULT_STREAM = True
DECODE_WITH_DEFAULT_STREAM = False  # Leads to bug in main

with torch.cuda.stream(None if DECODE_WITH_DEFAULT_STREAM else torch.cuda.Stream()):
    from torchcodec.decoders import VideoDecoder
    # This will set stream 0 for NVDEC no matter what, because it's hardcoded in
    # FFmpeg.
    dec = VideoDecoder(path, device="cuda")

    prev_frame = None
    for index in range(len(dec)):
        # This will use the default stream for NVDEC (hardcoded) and the current
        # stream for NPP, as set above in the context manager.
        frame = dec.get_frame_at(index)

        if prev_frame is not None:
            abs_diff = (frame.data.cpu().float() - prev_frame.data.cpu().float()).abs()
            if abs_diff.max() <= 3:
                raise ValueError(f"Frame {index} is too similar to previous frame")

        prev_frame = frame
```

What we're observing is that sometimes, the decoded frame `i` is actually the same as `i - 1`. That's a side-effect of the original stream sync bug. How? I'm not entirely sure, it may be related to how the pytorch CUDA caching allocator works, but  IDK. What I do know is that this snippet consistently fails on `main` and consistently succeeds with this PR.


-----

While working on this, I discovered an interesting (and sad) piece of trivia: the NVDEC stream is [**hardcoded** by FFmpeg](https://github.com/FFmpeg/FFmpeg/blob/66e40840d15b514f275ce3ce2a4bf72ec68c7311/libavutil/hwcontext_cuda.c#L387-L388) to always be the default stream. This means that doing something like this:

```py
with torch.cuda.stream(torch.cuda.Stream()):
    dec = VideoDecoder(path, device="cuda")
    dec.get_frame_at(...)
```

will always use the default stream for the decoding. That's sad. That's not really expected. But there's nothing we can do about it. Only NPP will be relying on the newly created stream.

This is orthogonal to the bug: the bug still exists regardless of this fact.