### PR TITLE
Remove discard check when scanning file

### DIFF
--- a/src/torchcodec/_core/SingleStreamDecoder.cpp
+++ b/src/torchcodec/_core/SingleStreamDecoder.cpp
@@ -243,13 +243,6 @@ void SingleStreamDecoder::scanFileAndUpdateMetadataAndIndex() {
     return;
   }
 
-  for (unsigned int i = 0; i < formatContext_->nb_streams; ++i) {
-    // We want to scan and update the metadata of all streams.
-    TORCH_CHECK(
-        formatContext_->streams[i]->discard != AVDISCARD_ALL,
-        "Did you add a stream before you called for a scan?");
-  }
-
   AutoAVPacket autoAVPacket;
   while (true) {
     ReferenceAVPacket packet(autoAVPacket);


### PR DESCRIPTION
This check was added in PR #503. We're keeping setting all inactive streams to `AVDISCARD_ALL`, but removing the check in `scanFileAndUpdateMetadataAndIndex()`. The reasoning behind the check was, I believe: let's make sure we're scanning the packets for all streams. And since we're only setting `AVDISCARD_ALL` in `addVideoStreamDecoder()`, then if we encounter it when scanning, something out-of-order must have happened.

However, I don't think we're the only ones setting the discard value. I've encountered a video that `ffprobe` reports has an unsupported codec for stream 1. Stream 0 seems fine. I suspect that FFmpeg is then setting `AVDISCARD_ALL` for us on stream 1 in `avformat_open_input()` or `avformat_find_stream_info()`. We should be able to decode stream 0 just fine.