### PR TITLE
Remove outdated comment

### DIFF
--- a/src/torchcodec/_core/DeviceInterface.h
+++ b/src/torchcodec/_core/DeviceInterface.h
@@ -17,14 +17,6 @@
 
 namespace facebook::torchcodec {
 
-// Note that all these device functions should only be called if the device is
-// not a CPU device. CPU device functions are already implemented in the
-// SingleStreamDecoder implementation.
-// These functions should only be called from within an if block like this:
-// if (device.type() != torch::kCPU) {
-//   deviceFunction(device, ...);
-// }
-
 class DeviceInterface {
  public:
   DeviceInterface(const torch::Device& device) : device_(device) {}


### PR DESCRIPTION
This comment is left over from before the `DeviceInterface` was a proper abstraction. At the time, the CPU logic was in `SingleStreamDecoder`, and we always conditionally called `DeviceInterface`. Now, we treat the CPU as another device and `SingleStreamDecoder` always calls its `DeviceInterface` for work that can happen on the CPU or another device.