### PR TITLE
Let `get_frames_at` and `get_frames_played_at` accept tensor indices

### DIFF
--- a/src/torchcodec/decoders/_video_decoder.py
+++ b/src/torchcodec/decoders/_video_decoder.py
@@ -247,6 +247,12 @@ class VideoDecoder:
         Returns:
             FrameBatch: The frames at the given indices.
         """
+        if isinstance(indices, torch.Tensor):
+            # TODO we should avoid converting tensors to lists and just let the
+            # core ops and C++ code natively accept tensors.  See
+            # https://github.com/pytorch/torchcodec/issues/879
+            indices = indices.to(torch.int).tolist()
+
         data, pts_seconds, duration_seconds = core.get_frames_at_indices(
             self._decoder, frame_indices=indices
         )
@@ -322,6 +328,12 @@ class VideoDecoder:
         Returns:
             FrameBatch: The frames that are played at ``seconds``.
         """
+        if isinstance(seconds, torch.Tensor):
+            # TODO we should avoid converting tensors to lists and just let the
+            # core ops and C++ code natively accept tensors.  See
+            # https://github.com/pytorch/torchcodec/issues/879
+            seconds = seconds.to(torch.float).tolist()
+
         data, pts_seconds, duration_seconds = core.get_frames_by_pts(
             self._decoder, timestamps=seconds
         )

--- a/test/test_decoders.py
+++ b/test/test_decoders.py
@@ -1390,6 +1390,17 @@ class TestVideoDecoder:
                         custom_frame_mappings=custom_frame_mappings,
                     )
 
+    def test_get_frames_at_tensor_indices(self):
+        # Non-regression test for tensor support in get_frames_at() and
+        # get_frames_played_at()
+        decoder = VideoDecoder(NASA_VIDEO.path)
+
+        decoder.get_frames_at(torch.tensor([0, 10], dtype=torch.int))
+        decoder.get_frames_at(torch.tensor([0, 10], dtype=torch.float))
+
+        decoder.get_frames_played_at(torch.tensor([0, 1], dtype=torch.int))
+        decoder.get_frames_played_at(torch.tensor([0, 1], dtype=torch.float))
+
 
 class TestAudioDecoder:
     @pytest.mark.parametrize("asset", (NASA_AUDIO, NASA_AUDIO_MP3, SINE_MONO_S32))


### PR DESCRIPTION
Closes https://github.com/pytorch/torchcodec/issues/877

`decoder.get_frames_at(indices)` was **implicitly** accepting tensor `indices` before https://github.com/pytorch/torchcodec/pull/746/files#diff-4f95b28922233b6ec6f41a7264a5518af7ea7dfb11329b133d378f9701e3cad0L224-L227 . 

The type annotation clearly mentions `list[int]` but passing a tensor was previously working, and some users are already depending on this behavior: the nightlies are currently breaking `transformers` as reported in https://github.com/pytorch/torchcodec/issues/877.

To avoid breaking users in our next release, this PR re-enables tensor support in a non-optimal way. I am opening https://github.com/pytorch/torchcodec/issues/879 to follow-up on this so we can officially and properly support tensors.