### PR TITLE
Update runner type to macos-14 in workflow

### DIFF
--- a/.github/workflows/macos_wheel.yaml
+++ b/.github/workflows/macos_wheel.yaml
@@ -52,7 +52,7 @@ jobs:
       pre-script: packaging/pre_build_script.sh
       post-script: packaging/post_build_script.sh
       smoke-test-script: packaging/fake_smoke_test.py
-      runner-type: macos-m1-stable
+      runner-type: macos-14
       package-name: torchcodec
       trigger-event: ${{ github.event_name }}
       build-platform: "python-build-package"


### PR DESCRIPTION
Removing dependency on self-hosted macOS runners, in prep for migration to meta-pytorch org