### PR TITLE
Remove TORCH_CHECKS on avcodec_get_supported_config output

### DIFF
--- a/src/torchcodec/_core/FFMPEGCommon.cpp
+++ b/src/torchcodec/_core/FFMPEGCommon.cpp
@@ -58,7 +58,7 @@ int64_t getDuration(const UniqueAVFrame& avFrame) {
 
 const int* getSupportedSampleRates(const AVCodec& avCodec) {
   const int* supportedSampleRates = nullptr;
-#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(61, 13, 100)
+#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(61, 13, 100) // FFmpeg >= 7.1
   int numSampleRates = 0;
   int ret = avcodec_get_supported_config(
       nullptr,
@@ -154,26 +154,26 @@ void setDefaultChannelLayout(UniqueAVFrame& avFrame, int numChannels) {
 void validateNumChannels(const AVCodec& avCodec, int numChannels) {
 #if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(61, 13, 100) // FFmpeg >= 7
   std::stringstream supportedNumChannels;
-  const AVChannelLayout* supported_layouts = nullptr;
-  int num_layouts = 0;
+  const AVChannelLayout* supportedLayouts = nullptr;
+  int numLayouts = 0;
   int ret = avcodec_get_supported_config(
       nullptr,
       &avCodec,
       AV_CODEC_CONFIG_CHANNEL_LAYOUT,
       0,
-      reinterpret_cast<const void**>(&supported_layouts),
-      &num_layouts);
-  if (ret < 0 || supported_layouts == nullptr) {
+      reinterpret_cast<const void**>(&supportedLayouts),
+      &numLayouts);
+  if (ret < 0 || supportedLayouts == nullptr) {
     // If we can't validate, we must assume it'll be fine. If not, FFmpeg will
     // eventually raise.
     return;
   }
-  for (int i = 0; i < num_layouts; ++i) {
+  for (int i = 0; i < numLayouts; ++i) {
     if (i > 0) {
       supportedNumChannels << ", ";
     }
-    supportedNumChannels << supported_layouts[i].nb_channels;
-    if (numChannels == supported_layouts[i].nb_channels) {
+    supportedNumChannels << supportedLayouts[i].nb_channels;
+    if (numChannels == supportedLayouts[i].nb_channels) {
       return;
     }
   }

--- a/src/torchcodec/_core/FFMPEGCommon.cpp
+++ b/src/torchcodec/_core/FFMPEGCommon.cpp
@@ -79,7 +79,7 @@ const int* getSupportedSampleRates(const AVCodec& avCodec) {
 
 const AVSampleFormat* getSupportedOutputSampleFormats(const AVCodec& avCodec) {
   const AVSampleFormat* supportedSampleFormats = nullptr;
-#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(61, 13, 100) // FFmpeg >= 7
+#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(61, 13, 100) // FFmpeg >= 7.1
   int numSampleFormats = 0;
   int ret = avcodec_get_supported_config(
       nullptr,
@@ -152,7 +152,7 @@ void setDefaultChannelLayout(UniqueAVFrame& avFrame, int numChannels) {
 }
 
 void validateNumChannels(const AVCodec& avCodec, int numChannels) {
-#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(61, 13, 100) // FFmpeg >= 7
+#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(61, 13, 100) // FFmpeg >= 7.1
   std::stringstream supportedNumChannels;
   const AVChannelLayout* supportedLayouts = nullptr;
   int numLayouts = 0;


### PR DESCRIPTION
In some environments `avcodec_get_supported_config` will not return the expected config. Rather than error out, we should continue execution and allow FFmpeg to handle it, or raise an error later. 