### PR TITLE
BETA CUDA interface: Fix CUDA context initialization

### DIFF
--- a/src/torchcodec/_core/BetaCudaDeviceInterface.cpp
+++ b/src/torchcodec/_core/BetaCudaDeviceInterface.cpp
@@ -203,10 +203,7 @@ BetaCudaDeviceInterface::BetaCudaDeviceInterface(const torch::Device& device)
   TORCH_CHECK(
       device_.type() == torch::kCUDA, "Unsupported device: ", device_.str());
 
-  // Initialize CUDA context with a dummy tensor
-  torch::Tensor dummyTensorForCudaInitialization = torch::empty(
-      {1}, torch::TensorOptions().dtype(torch::kUInt8).device(device_));
-
+  initializeCudaContextWithPytorch(device_);
   nppCtx_ = getNppStreamContext(device_);
 }
 

--- a/src/torchcodec/_core/CUDACommon.cpp
+++ b/src/torchcodec/_core/CUDACommon.cpp
@@ -23,6 +23,14 @@ PerGpuCache<NppStreamContext> g_cached_npp_ctxs(
 
 } // namespace
 
+void initializeCudaContextWithPytorch(const torch::Device& device) {
+  // It is important for pytorch itself to create the cuda context. If ffmpeg
+  // creates the context it may not be compatible with pytorch.
+  // This is a dummy tensor to initialize the cuda context.
+  torch::Tensor dummyTensorForCudaInitialization = torch::zeros(
+      {1}, torch::TensorOptions().dtype(torch::kUInt8).device(device));
+}
+
 /* clang-format off */
 // Note: [YUV -> RGB Color Conversion, color space and color range]
 //

--- a/src/torchcodec/_core/CUDACommon.h
+++ b/src/torchcodec/_core/CUDACommon.h
@@ -22,6 +22,8 @@ extern "C" {
 
 namespace facebook::torchcodec {
 
+void initializeCudaContextWithPytorch(const torch::Device& device);
+
 // Unique pointer type for NPP stream context
 using UniqueNppContext = std::unique_ptr<NppStreamContext>;
 

--- a/src/torchcodec/_core/CudaDeviceInterface.cpp
+++ b/src/torchcodec/_core/CudaDeviceInterface.cpp
@@ -129,11 +129,10 @@ CudaDeviceInterface::CudaDeviceInterface(const torch::Device& device)
   TORCH_CHECK(
       device_.type() == torch::kCUDA, "Unsupported device: ", device_.str());
 
-  // It is important for pytorch itself to create the cuda context. If ffmpeg
-  // creates the context it may not be compatible with pytorch.
-  // This is a dummy tensor to initialize the cuda context.
-  torch::Tensor dummyTensorForCudaInitialization = torch::empty(
-      {1}, torch::TensorOptions().dtype(torch::kUInt8).device(device_));
+  initializeCudaContextWithPytorch(device_);
+
+  // TODO rename this, this is a hardware device context, not a CUDA context!
+  // See https://github.com/meta-pytorch/torchcodec/issues/924
   ctx_ = getCudaContext(device_);
   nppCtx_ = getNppStreamContext(device_);
 }


### PR DESCRIPTION
On `main`, this fails:

```py

from torchcodec.decoders import VideoDecoder
from joblib import Parallel, delayed

video_path = "/home/nicolashug/videos_h264/vid.mp4"

import torch

def decode_one_video():
    decoder = VideoDecoder(video_path, device="cuda:0:beta", seek_mode="approximate")
    decoder.get_frame_at(-1)

Parallel(n_jobs=8, prefer="threads")(delayed(decode_one_video)() for _ in range(100))
```

with

```
RuntimeError: Failed to get decoder caps: 201
```


That is, spawning one `VideoDecoder` per thread fails with CUDA error 201 which is CUDA_INVALID_CONTEXT.


Uh?

I'm confused as well. This seems to indicate that our CUDA context initialization hack, where we create a dummy tensor to force context creation, doesn't work as expected:

https://github.com/meta-pytorch/torchcodec/blob/9c5da208f2ddc2c039c5af3541e3d18ca779af96/src/torchcodec/_core/BetaCudaDeviceInterface.cpp#L206-L208


After a lot of trial and error, it seems that using `torch::zeros` instead of `torch::empty` resolves the problem. Why? I have no idea. Maybe `torch::empty` was optimized out? Maybe, but that doesn't explain why the default CUDA interface works fine with teh snippet above... Anyway, now they both use `torch::zeros`, and they both work when running my multithreaded benchmarks.