### PR TITLE
Mark slow tests

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1384,8 +1384,9 @@ class TestVideoEncoderOps:
         frames, *_ = get_frames_in_range(decoder, start=0, stop=60)
         return frames
 
-    @pytest.mark.slow
-    @pytest.mark.parametrize("format", ("mov", "mp4", "mkv", "webm"))
+    @pytest.mark.parametrize(
+        "format", ("mov", "mp4", "mkv", pytest.param("webm", marks=pytest.mark.slow))
+    )
     def test_video_encoder_round_trip(self, tmp_path, format):
         # Test that decode(encode(decode(asset))) == decode(asset)
         ffmpeg_version = get_ffmpeg_major_version()
@@ -1423,10 +1424,18 @@ class TestVideoEncoderOps:
             assert psnr(s_frame, rt_frame) > 30
             assert_close(s_frame, rt_frame, atol=atol, rtol=0)
 
-    @pytest.mark.slow
     @pytest.mark.skipif(in_fbcode(), reason="ffmpeg CLI not available")
     @pytest.mark.parametrize(
-        "format", ("mov", "mp4", "avi", "mkv", "webm", "flv", "gif")
+        "format",
+        (
+            "mov",
+            "mp4",
+            "avi",
+            "mkv",
+            "flv",
+            "gif",
+            pytest.param("webm", marks=pytest.mark.slow),
+        ),
     )
     def test_video_encoder_against_ffmpeg_cli(self, tmp_path, format):
         ffmpeg_version = get_ffmpeg_major_version()


### PR DESCRIPTION
Both `test_video_encoder_round_trip()` and `test_video_encoder_against_ffmpeg_cli()` are taking around 30 seconds or more on my dev machine for webm. If we could _just_ say that the webm option is slow, that would be better, but I think this is okay for now.

This is relevant for when we just say `pytest test`, it will default to not running the slow tests. See our `pyproject.toml`: https://github.com/meta-pytorch/torchcodec/blob/b9cf8d10409f6e4adfa9c37fee40b6228b402f0d/pyproject.toml#L43-L51