### PR TITLE
Skip tests that require ffmpeg built with libvpx support also on Win with ffmpeg 8

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1169,7 +1169,7 @@ class TestVideoEncoderOps:
                 f"FFmpeg6 defaults to lossy encoding for {format}, skipping round-trip test."
             )
         if format == "webm" and (
-            ffmpeg_version == 4 or (IS_WINDOWS and ffmpeg_version in (6, 7))
+            ffmpeg_version == 4 or (IS_WINDOWS and ffmpeg_version in (6, 7, 8))
         ):
             pytest.skip("Codec for webm is not available in this FFmpeg installation.")
         source_frames = self.decode(TEST_SRC_2_720P.path).data
@@ -1234,7 +1234,7 @@ class TestVideoEncoderOps:
         # Test that to_file, to_tensor, and to_file_like produce the same results
         ffmpeg_version = get_ffmpeg_major_version()
         if format == "webm" and (
-            ffmpeg_version == 4 or (IS_WINDOWS and ffmpeg_version in (6, 7))
+            ffmpeg_version == 4 or (IS_WINDOWS and ffmpeg_version in (6, 7, 8))
         ):
             pytest.skip("Codec for webm is not available in this FFmpeg installation.")
 
@@ -1281,7 +1281,7 @@ class TestVideoEncoderOps:
     def test_video_encoder_against_ffmpeg_cli(self, tmp_path, format):
         ffmpeg_version = get_ffmpeg_major_version()
         if format == "webm" and (
-            ffmpeg_version == 4 or (IS_WINDOWS and ffmpeg_version in (6, 7))
+            ffmpeg_version == 4 or (IS_WINDOWS and ffmpeg_version in (6, 7, 8))
         ):
             pytest.skip("Codec for webm is not available in this FFmpeg installation.")
 


### PR DESCRIPTION
I was obtaining some test failures in https://github.com/conda-forge/torchcodec-feedstock/pull/39, and it seems that some tests required ffmpeg built with libvpx support, to have a vp8 encoder, that is currently not available on Windows due to https://github.com/conda-forge/libvpx-feedstock/issues/6 .

Indeed, it seems that for some reason the related tests were disabled for ffmpeg 6 and 7, while not for ffmpeg 8, even if also ffmpeg 8 on Windows does not have a vp8 encoder. I am not sure why upstream CI is passing, but this patch fixes the tests on conda-forge.