### PR TITLE
Add encoders to top-level import list

### DIFF
--- a/src/torchcodec/__init__.py
+++ b/src/torchcodec/__init__.py
@@ -7,7 +7,7 @@
 # Note: usort wants to put Frame and FrameBatch after decoders and samplers,
 # but that results in circular import.
 from ._frame import AudioSamples, Frame, FrameBatch  # usort:skip # noqa
-from . import decoders, samplers  # noqa
+from . import decoders, encoders, samplers  # noqa
 
 try:
     # Note that version.py is generated during install.


### PR DESCRIPTION
Fixes #1017

Curiously, I tried writing a unit test for this, but it passed without making any changes. :/ So there's something with how we're importing things during test that is making `torchcodec.encoders` available even though it's not exposed in the top-level `__init__.py`.

However, when I loaded up an interactive `python` shell without this change, I got:
```python
>>> import torchcodec
>>> import torch
>>> encoder = torchcodec.encoders.AudioEncoder(samples=torch.rand(1), sample_rate=16_000)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'torchcodec' has no attribute 'encoders'. Did you mean: 'decoders'?
```
Same as the user. And then with this change:
```python
>>> import torchcodec
>>> import torch
>>> encoder = torchcodec.encoders.AudioEncoder(samples=torch.rand(1), sample_rate=16_000)
>>> 
```