### PR TITLE
Suport device=None

### DIFF
--- a/src/torchcodec/decoders/_video_decoder.py
+++ b/src/torchcodec/decoders/_video_decoder.py
@@ -144,7 +144,6 @@ class VideoDecoder:
         if num_ffmpeg_threads is None:
             raise ValueError(f"{num_ffmpeg_threads = } should be an int.")
 
-        # Handle device=None by using the current default device
         if device is None:
             device = str(torch.get_default_device())
         elif isinstance(device, torch_device):

--- a/test/test_decoders.py
+++ b/test/test_decoders.py
@@ -396,8 +396,8 @@ class TestVideoDecoder:
         ],
     )
     def test_device_none_default_device(self, device_str):
-        # device=None should respect both torch.device() context manager
-        # and torch.set_default_device()
+        # VideoDecoder defaults to device=None, which should respect both
+        # torch.device() context manager and torch.set_default_device().
 
         # Test with context manager
         with torch.device(device_str):


### PR DESCRIPTION
Support `device=None` in VideoDecoder
-----------------------------------------------

Fixes #993

### Summary

This PR implements support for `device=None` in `VideoDecoder`, allowing it to use PyTorch's "current device" as determined by context managers and global settings. `device=None` is now the default parameter value.

### Backward Compatibility

*   Existing code with explicit `device="cpu"` or `device="cuda"` works exactly as before
*   **Only change**: The default device will no longer be `cpu` but rather PyTorch's device context if set.
  
