### PR TITLE
Attempt at fixing contiguity test failures

### DIFF
--- a/test/test_encoders.py
+++ b/test/test_encoders.py
@@ -708,17 +708,20 @@ class TestVideoEncoder:
         )
 
         def encode_to_tensor(frames):
+            common_params = dict(crf=0, pixel_format="yuv444p")
             if method == "to_file":
                 dest = str(tmp_path / "output.mp4")
-                VideoEncoder(frames, frame_rate=30).to_file(dest=dest)
+                VideoEncoder(frames, frame_rate=30).to_file(dest=dest, **common_params)
                 with open(dest, "rb") as f:
                     return torch.frombuffer(f.read(), dtype=torch.uint8)
             elif method == "to_tensor":
-                return VideoEncoder(frames, frame_rate=30).to_tensor(format="mp4")
+                return VideoEncoder(frames, frame_rate=30).to_tensor(
+                    format="mp4", **common_params
+                )
             elif method == "to_file_like":
                 file_like = io.BytesIO()
                 VideoEncoder(frames, frame_rate=30).to_file_like(
-                    file_like, format="mp4"
+                    file_like, format="mp4", **common_params
                 )
                 return torch.frombuffer(file_like.getvalue(), dtype=torch.uint8)
             else:


### PR DESCRIPTION
Attempt to fix https://github.com/meta-pytorch/torchcodec/issues/1047

I can't reproduce the issue locally even after running the test thousands of times.

We now use `crf=0` and `pixel_format="yuv444p` so that no compression happens, which I hope may reduce randomness of the encoding process (if there is any, which I don't know). 

Let's merge that and see if we still observe the failures. If that still doesn't work the next attempt will be to enforce  no multi-threading (probably need the `codec_params` parameter for that)