### PR TITLE
Add frame rate to VideoEncoder API

### DIFF
--- a/src/torchcodec/_core/Encoder.cpp
+++ b/src/torchcodec/_core/Encoder.cpp
@@ -644,7 +644,11 @@ void sortCodecOptions(
 }
 
 void validateFrameRate(int frameRate) {
-  TORCH_CHECK(frameRate > 0, "frame_rate=", frameRate, " must be > 0.");
+  TORCH_CHECK(
+      frameRate > 0,
+      "Invalid frame_rate: ",
+      frameRate,
+      ". Frame rate must be a positive integer.");
 }
 } // namespace
 
@@ -796,7 +800,6 @@ void VideoEncoder::initializeEncoder(
   avCodecContext_->width = outWidth_;
   avCodecContext_->height = outHeight_;
   avCodecContext_->pix_fmt = outPixelFormat_;
-  // TODO-VideoEncoder: Verify that frame_rate and time_base are correct
   avCodecContext_->time_base = {1, outFrameRate_};
   avCodecContext_->framerate = {outFrameRate_, 1};
 

--- a/src/torchcodec/_core/Encoder.h
+++ b/src/torchcodec/_core/Encoder.h
@@ -173,6 +173,7 @@ class VideoEncoder {
 
   const torch::Tensor frames_;
   int inFrameRate_;
+  int outFrameRate_ = -1;
 
   int inWidth_ = -1;
   int inHeight_ = -1;

--- a/src/torchcodec/_core/StreamOptions.h
+++ b/src/torchcodec/_core/StreamOptions.h
@@ -53,6 +53,7 @@ struct VideoStreamOptions {
   std::optional<double> crf;
   std::optional<std::string> preset;
   std::optional<std::map<std::string, std::string>> extraOptions;
+  std::optional<int> frameRate;
 };
 
 struct AudioStreamOptions {

--- a/src/torchcodec/_core/ops.py
+++ b/src/torchcodec/_core/ops.py
@@ -218,12 +218,13 @@ def encode_video_to_file_like(
     crf: Optional[Union[int, float]] = None,
     preset: Optional[str] = None,
     extra_options: Optional[list[str]] = None,
+    desired_frame_rate: Optional[int] = None,
 ) -> None:
     """Encode video frames to a file-like object.
 
     Args:
         frames: Video frames tensor
-        frame_rate: Frame rate in frames per second
+        frame_rate: Frame rate in frames per second (input frame rate)
         format: Video format (e.g., "mp4", "mov", "mkv")
         file_like: File-like object that supports write() and seek() methods
         codec: Optional codec name (e.g., "libx264", "h264")
@@ -231,6 +232,8 @@ def encode_video_to_file_like(
         crf: Optional constant rate factor for encoding quality
         preset: Optional encoder preset as string (e.g., "ultrafast", "medium")
         extra_options: Optional list of extra options as flattened key-value pairs
+        desired_frame_rate: Optional desired output frame rate. If not specified,
+            uses the input frame_rate.
     """
     assert _pybind_ops is not None
 
@@ -244,6 +247,7 @@ def encode_video_to_file_like(
         crf,
         preset,
         extra_options,
+        desired_frame_rate,
     )
 
 
@@ -336,6 +340,7 @@ def encode_video_to_file_abstract(
     preset: Optional[str] = None,
     crf: Optional[Union[int, float]] = None,
     extra_options: Optional[list[str]] = None,
+    desired_frame_rate: Optional[int] = None,
 ) -> None:
     return
 
@@ -350,6 +355,7 @@ def encode_video_to_tensor_abstract(
     preset: Optional[str] = None,
     crf: Optional[Union[int, float]] = None,
     extra_options: Optional[list[str]] = None,
+    desired_frame_rate: Optional[int] = None,
 ) -> torch.Tensor:
     return torch.empty([], dtype=torch.long)
 
@@ -365,6 +371,7 @@ def _encode_video_to_file_like_abstract(
     preset: Optional[str] = None,
     crf: Optional[Union[int, float]] = None,
     extra_options: Optional[list[str]] = None,
+    desired_frame_rate: Optional[int] = None,
 ) -> None:
     return
 

--- a/src/torchcodec/encoders/_video_encoder.py
+++ b/src/torchcodec/encoders/_video_encoder.py
@@ -15,7 +15,9 @@ class VideoEncoder:
             tensor of shape ``(N, C, H, W)`` where N is the number of frames,
             C is 3 channels (RGB), H is height, and W is width.
             Values must be uint8 in the range ``[0, 255]``.
-        frame_rate (int): The frame rate of the **input** ``frames``. Also defines the encoded **output** frame rate.
+        frame_rate (int): The frame rate of the **input** ``frames``. The
+            frame rate of the encoded output can be specified using the
+            encoding methods (``to_file``, etc.).
     """
 
     def __init__(self, frames: Tensor, *, frame_rate: int):
@@ -41,6 +43,7 @@ class VideoEncoder:
         pixel_format: Optional[str] = None,
         crf: Optional[Union[int, float]] = None,
         preset: Optional[Union[str, int]] = None,
+        frame_rate: Optional[int] = None,
     ) -> None:
         """Encode frames into a file.
 
@@ -63,6 +66,8 @@ class VideoEncoder:
             extra_options (dict[str, Any], optional): A dictionary of additional
                 encoder options to pass, e.g. ``{"qp": 5, "tune": "film"}``.
                 Values will be converted to strings before passing to the encoder.
+            frame_rate (int, optional): The frame rate of the output video. If not specified,
+                uses the frame rate provided to the VideoEncoder constructor.
         """
         preset = str(preset) if isinstance(preset, int) else preset
         _core.encode_video_to_file(
@@ -76,6 +81,7 @@ class VideoEncoder:
             extra_options=[
                 str(x) for k, v in (extra_options or {}).items() for x in (k, v)
             ],
+            desired_frame_rate=frame_rate,
         )
 
     def to_tensor(
@@ -87,6 +93,7 @@ class VideoEncoder:
         crf: Optional[Union[int, float]] = None,
         preset: Optional[Union[str, int]] = None,
         extra_options: Optional[Dict[str, Any]] = None,
+        frame_rate: Optional[int] = None,
     ) -> Tensor:
         """Encode frames into raw bytes, as a 1D uint8 Tensor.
 
@@ -108,6 +115,8 @@ class VideoEncoder:
             extra_options (dict[str, Any], optional): A dictionary of additional
                 encoder options to pass, e.g. ``{"qp": 5, "tune": "film"}``.
                 Values will be converted to strings before passing to the encoder.
+            frame_rate (int, optional): The frame rate of the output video. If not specified,
+                uses the frame rate provided to the VideoEncoder constructor.
 
         Returns:
             Tensor: The raw encoded bytes as 1D uint8 Tensor.
@@ -124,6 +133,7 @@ class VideoEncoder:
             extra_options=[
                 str(x) for k, v in (extra_options or {}).items() for x in (k, v)
             ],
+            desired_frame_rate=frame_rate,
         )
 
     def to_file_like(
@@ -136,6 +146,7 @@ class VideoEncoder:
         crf: Optional[Union[int, float]] = None,
         preset: Optional[Union[str, int]] = None,
         extra_options: Optional[Dict[str, Any]] = None,
+        frame_rate: Optional[int] = None,
     ) -> None:
         """Encode frames into a file-like object.
 
@@ -162,6 +173,8 @@ class VideoEncoder:
             extra_options (dict[str, Any], optional): A dictionary of additional
                 encoder options to pass, e.g. ``{"qp": 5, "tune": "film"}``.
                 Values will be converted to strings before passing to the encoder.
+            frame_rate (int, optional): The frame rate of the output video. If not specified,
+                uses the frame rate provided to the VideoEncoder constructor.
         """
         preset = str(preset) if isinstance(preset, int) else preset
         _core.encode_video_to_file_like(
@@ -176,4 +189,5 @@ class VideoEncoder:
             extra_options=[
                 str(x) for k, v in (extra_options or {}).items() for x in (k, v)
             ],
+            desired_frame_rate=frame_rate,
         )

--- a/src/torchcodec/encoders/_video_encoder.py
+++ b/src/torchcodec/encoders/_video_encoder.py
@@ -67,7 +67,7 @@ class VideoEncoder:
                 encoder options to pass, e.g. ``{"qp": 5, "tune": "film"}``.
                 Values will be converted to strings before passing to the encoder.
             frame_rate (int, optional): The frame rate of the output video. If not specified,
-                uses the frame rate provided to the VideoEncoder constructor.
+                uses the frame rate of the input ``frames``.
         """
         preset = str(preset) if isinstance(preset, int) else preset
         _core.encode_video_to_file(
@@ -116,7 +116,7 @@ class VideoEncoder:
                 encoder options to pass, e.g. ``{"qp": 5, "tune": "film"}``.
                 Values will be converted to strings before passing to the encoder.
             frame_rate (int, optional): The frame rate of the output video. If not specified,
-                uses the frame rate provided to the VideoEncoder constructor.
+                uses the frame rate of the input ``frames``.
 
         Returns:
             Tensor: The raw encoded bytes as 1D uint8 Tensor.
@@ -174,7 +174,7 @@ class VideoEncoder:
                 encoder options to pass, e.g. ``{"qp": 5, "tune": "film"}``.
                 Values will be converted to strings before passing to the encoder.
             frame_rate (int, optional): The frame rate of the output video. If not specified,
-                uses the frame rate provided to the VideoEncoder constructor.
+                uses the frame rate of the input ``frames``.
         """
         preset = str(preset) if isinstance(preset, int) else preset
         _core.encode_video_to_file_like(

--- a/test/test_encoders.py
+++ b/test/test_encoders.py
@@ -659,6 +659,13 @@ class TestVideoEncoder:
         ):
             encoder.to_tensor(format="mp4", preset="fake_preset")
 
+        with pytest.raises(RuntimeError, match=r"frame_rate"):
+            encoder = VideoEncoder(
+                frames=torch.zeros((5, 3, 64, 64), dtype=torch.uint8),
+                frame_rate=30,
+            )
+            getattr(encoder, method)(**valid_params, frame_rate=0)
+
     @pytest.mark.parametrize("method", ["to_file", "to_tensor", "to_file_like"])
     @pytest.mark.parametrize("crf", [23, 23.5, -0.9])
     def test_crf_valid_values(self, method, crf, tmp_path):
@@ -1175,3 +1182,71 @@ class TestVideoEncoder:
         assert metadata["profile"].lower() == expected_profile
         assert metadata["color_space"] == colorspace
         assert metadata["color_range"] == color_range
+
+    @pytest.mark.skipif(
+        in_fbcode(),
+        reason="ffprobe not available internally",
+    )
+    @pytest.mark.parametrize("method", ["to_file", "to_tensor", "to_file_like"])
+    @pytest.mark.parametrize("output_frame_rate", [10, 60, None])
+    def test_frame_rate_parameter(self, tmp_path, method, output_frame_rate):
+
+        # Use ffprobe to get frame rate
+        def get_frame_rate(file_path):
+            result = subprocess.run(
+                [
+                    "ffprobe",
+                    "-v",
+                    "error",
+                    "-select_streams",
+                    "v:0",
+                    "-show_entries",
+                    "stream=r_frame_rate",
+                    "-of",
+                    "default=noprint_wrappers=1:nokey=1",
+                    str(file_path),
+                ],
+                capture_output=True,
+                check=True,
+                text=True,
+            )
+            # Frame rate is returned as a fraction like "60/1"
+            numerator, denominator = result.stdout.strip().split("/")
+            return int(numerator) / int(denominator)
+
+        frames = (
+            VideoDecoder(TEST_SRC_2_720P.path)
+            .get_frames_in_range(start=0, stop=60)
+            .data
+        )
+        input_frame_rate = 30
+        encoder = VideoEncoder(frames=frames, frame_rate=input_frame_rate)
+
+        if method == "to_file":
+            output_path = str(tmp_path / "output.mp4")
+            encoder.to_file(dest=output_path, frame_rate=output_frame_rate)
+        elif method == "to_tensor":
+            encoded_tensor = encoder.to_tensor(
+                format="mp4", frame_rate=output_frame_rate
+            )
+            # Write tensor to file to check with ffprobe
+            output_path = str(tmp_path / "output_from_tensor.mp4")
+            with open(output_path, "wb") as f:
+                f.write(encoded_tensor.numpy().tobytes())
+        elif method == "to_file_like":
+            file_like = io.BytesIO()
+            encoder.to_file_like(
+                file_like=file_like, format="mp4", frame_rate=output_frame_rate
+            )
+            # Write file_like to file to check with ffprobe
+            output_path = str(tmp_path / "output_from_file_like.mp4")
+            with open(output_path, "wb") as f:
+                f.write(file_like.getvalue())
+        else:
+            raise ValueError(f"Unknown method: {method}")
+
+        actual_frame_rate = get_frame_rate(output_path)
+        # Ensure frame_rate=None uses the input_frame_rate
+        if output_frame_rate is None:
+            output_frame_rate = input_frame_rate
+        assert actual_frame_rate == output_frame_rate


### PR DESCRIPTION
This PR adds output `frame_rate` to the API. 

Previously, we always encoded videos using the same `frame_rate` as the input `frames`. 

Now, we can set the output `frame_rate` when calling `to_file`/`to_tensor`/`to_filelike` (as in `AudioEncoder`), to adjusts the encoded video's frame durations. If no output `frame_rate` is specified, fallback to reusing the input `frame_rate`.

#### Testing: 
To test, I added `test_frame_rate_parameter` which slows and speeds up a test video and ensures the video metadata is updated correctly. I also observed the video plays back slower or faster.

#### API after changes:
The complete API now looks as follows:
```
  encoder = VideoEncoder(frames=frames, frame_rate=25)
  encoder.to_file(
      dest="video.mp4",
      codec="libx264",
      pixel_format="yuv420p",
      crf=20,
      preset="medium",
      extra_options={
		"tune": "fastdecode",		
		"x264-params": "deblock=-1,-1:aq-mode=2
	  },
      frame_rate=25,
  )
```