### PR TITLE
Explicitly import importlib.util to resolve mypy error

### DIFF
--- a/src/torchcodec/_internally_replaced_utils.py
+++ b/src/torchcodec/_internally_replaced_utils.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import importlib
+import importlib.util
 import sys
 from pathlib import Path
 from types import ModuleType


### PR DESCRIPTION
Recent CI have an error during the mypy job ([example](https://github.com/meta-pytorch/torchcodec/actions/runs/19870399125/job/56944341482?pr=1085)). 

The error indicates that functions from `importlib.util` are missing, such as `spec_from_file_location` and `module_from_spec`. This PR resolves this by directly importing `importlib.util` as suggested in [other sources](https://discuss.python.org/t/python3-11-importlib-no-longer-exposes-util/25641).