### PR TITLE
Fix format in VideoEncoder tutorial

### DIFF
--- a/examples/encoding/video_encoding.py
+++ b/examples/encoding/video_encoding.py
@@ -208,6 +208,7 @@ high_quality_output = encoder.to_tensor(format="mp4", codec="libx264", crf=0)
 play_video(high_quality_output)
 
 # %%
+
 # Low quality (high CRF)
 low_quality_output = encoder.to_tensor(format="mp4", codec="libx264", crf=50)
 play_video(low_quality_output)


### PR DESCRIPTION
This PR resolves a small formatting error in the [CRF section](https://meta-pytorch.org/torchcodec/stable/generated_examples/encoding/video_encoding.html#crf-constant-rate-factor):
<img width="719" height="336" alt="Screenshot 2025-12-04 at 6 12 20 PM" src="https://github.com/user-attachments/assets/4b7971d3-c07b-4635-86fb-ea2a2677528a" />

Fixed in built docs:
<img width="719" height="336" alt="Screenshot 2025-12-04 at 6 13 25 PM" src="https://github.com/user-attachments/assets/667ac67c-f6f8-4e9f-a99d-bb4526eb663b" />
