### PR TITLE
Skip compile tests

### DIFF
--- a/test/test_decoders.py
+++ b/test/test_decoders.py
@@ -1147,7 +1147,7 @@ class TestVideoDecoder:
         )
 
     # TODO investigate why this is failing from the nightlies of Dec 09 2025.
-    @pytest.skip(reason="TODO investigate")
+    @pytest.mark.skip(reason="TODO investigate")
     # TODO investigate why this fails internally.
     @pytest.mark.skipif(in_fbcode(), reason="Compile test fails internally.")
     @pytest.mark.skipif(


### PR DESCRIPTION
Related to https://github.com/meta-pytorch/torchcodec/issues/1112

This is either a regression in core, or something we've always been doing wrong here within TC. This PR temporarily disables the test to keep our CI green.