### PR TITLE
[torchcodec] Fix runtime library loading for portable Python wheels

### DIFF
--- a/src/torchcodec/_core/CMakeLists.txt
+++ b/src/torchcodec/_core/CMakeLists.txt
@@ -53,6 +53,21 @@ function(make_torchcodec_sublibrary
     # Avoid adding the "lib" prefix which we already add explicitly.
     set_target_properties(${library_name} PROPERTIES PREFIX "")
 
+    # Set RPATH to find sibling libraries and PyTorch libs at runtime.
+    # $ORIGIN refers to the directory containing this library (site-packages/torchcodec/)
+    # $ORIGIN/../torch/lib points to PyTorch's lib directory (site-packages/torch/lib/)
+    if(LINUX)
+        set_target_properties(${library_name} PROPERTIES
+            INSTALL_RPATH "$ORIGIN:$ORIGIN/../torch/lib"
+            BUILD_WITH_INSTALL_RPATH TRUE
+        )
+    elseif(APPLE)
+        set_target_properties(${library_name} PROPERTIES
+            INSTALL_RPATH "@loader_path:@loader_path/../torch/lib"
+            BUILD_WITH_INSTALL_RPATH TRUE
+        )
+    endif()
+
     target_link_libraries(
         ${library_name}
         PUBLIC
@@ -128,16 +143,31 @@ function(make_torchcodec_libraries
         AVIOTensorContext.cpp
         custom_ops.cpp
     )
-    set(custom_ops_dependencies
-        ${core_library_name}
-        ${Python3_LIBRARIES}
-    )
+    # On Linux, we avoid linking directly against libpython because:
+    # 1. It couples the wheel to a specific Python installation path (e.g., conda)
+    # 2. The library is always loaded from within Python, so libpython symbols
+    #    are already available at runtime
+    # On Mac and Windows, we need the explicit link.
+    if(LINUX)
+        set(custom_ops_dependencies
+            ${core_library_name}
+        )
+    else()
+        set(custom_ops_dependencies
+            ${core_library_name}
+            ${Python3_LIBRARIES}
+        )
+    endif()
     make_torchcodec_sublibrary(
         "${custom_ops_library_name}"
         SHARED
         "${custom_ops_sources}"
         "${custom_ops_dependencies}"
     )
+    # On Linux, allow undefined symbols (Python symbols resolved at runtime)
+    if(LINUX)
+        target_link_options(${custom_ops_library_name} PRIVATE "-Wl,--allow-shlib-undefined")
+    endif()
 
     # 3. Create libtorchcodec_pybind_opsN.so.
     set(pybind_ops_library_name "libtorchcodec_pybind_ops${ffmpeg_major_version}")


### PR DESCRIPTION
Summary:
This change addresses runtime library loading issues when building torchcodec Python wheels for distribution across different environments (e.g., conda vs system Python).

The changes include:

1. **RPATH configuration**: Set RPATH on Linux ($ORIGIN) and macOS (loader_path) to find sibling libraries and PyTorch dependencies at runtime, without hardcoding absolute paths.

2. **Avoid libpython coupling on Linux**: Remove direct linking against libpython on Linux to prevent coupling wheels to specific Python installation paths. Python symbols are already available when the library is loaded from within Python, so they resolve at runtime. Explicit linking is retained for macOS and Windows where it's needed.

3. **Allow undefined symbols on Linux**: Use `-Wl,--allow-shlib-undefined` for the custom ops library on Linux to permit Python symbols to resolve at runtime rather than link time.

These changes make the built wheels more portable and usable across different Python installations without requiring rebuilds for each environment.

This is to resolve issues we were observing when building the wheel in the new docker builder environment.

Issue looks like:

```
>>> import torchcodec
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/.venv/lib/python3.12/site-packages/torchcodec/__init__.py", line 12, in <module>
    from . import decoders, encoders, samplers, transforms  # noqa
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/.venv/lib/python3.12/site-packages/torchcodec/decoders/__init__.py", line 7, in <module>
    from .._core import AudioStreamMetadata, VideoStreamMetadata
  File "/.venv/lib/python3.12/site-packages/torchcodec/_core/__init__.py", line 8, in <module>
    from ._metadata import (
  File "/.venv/lib/python3.12/site-packages/torchcodec/_core/_metadata.py", line 16, in <module>
    from torchcodec._core.ops import (
  File "/.venv/lib/python3.12/site-packages/torchcodec/_core/ops.py", line 105, in <module>
    ffmpeg_major_version, core_library_path = load_torchcodec_shared_libraries()
                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/.venv/lib/python3.12/site-packages/torchcodec/_core/ops.py", line 75, in load_torchcodec_shared_libraries
    raise RuntimeError(
RuntimeError: Could not load libtorchcodec. Likely causes:
          1. FFmpeg is not properly installed in your environment. We support
             versions 4, 5, 6, 7, and 8. On Windows, ensure you've installed
             the "full-shared" version which ships DLLs.
          2. The PyTorch version (2.10.0a0+gitdc8fe8f) is not compatible with
             this version of TorchCodec. Refer to the version compatibility
             table:
             https://github.com/pytorch/torchcodec?tab=readme-ov-file#installing-torchcodec.
          3. Another runtime dependency; see exceptions below.
        The following exceptions were raised as we tried to load libtorchcodec:

[start of libtorchcodec loading traceback]
FFmpeg version 8: Could not load this library: /.venv/lib/python3.12/site-packages/torchcodec/libtorchcodec_core8.so
FFmpeg version 7: Could not load this library: /.venv/lib/python3.12/site-packages/torchcodec/libtorchcodec_core7.so
FFmpeg version 6: Could not load this library: /.venv/lib/python3.12/site-packages/torchcodec/libtorchcodec_core6.so
FFmpeg version 5: Could not load this library: /.venv/lib/python3.12/site-packages/torchcodec/libtorchcodec_core5.so
FFmpeg version 4: Could not load this library: /.venv/lib/python3.12/site-packages/torchcodec/libtorchcodec_core4.so
[end of libtorchcodec loading traceback].
```

Differential Revision: D88802808


