### PR TITLE
Add color handling to VideoEncoder GPU

### DIFF
--- a/src/torchcodec/_core/CudaDeviceInterface.cpp
+++ b/src/torchcodec/_core/CudaDeviceInterface.cpp
@@ -542,7 +542,7 @@ UniqueAVFrame CudaDeviceInterface::convertCUDATensorToAVFrameForEncoding(
 
   NppiSize oSizeROI = {width, height};
   NppStatus status;
-  // Convert to NV12, as CUDA_PIXEL_FORMAT is always NV12 currently
+  // Convert to NV12, as CUDA_ENCODING_PIXEL_FORMAT is always NV12 currently
   status = nppiRGBToNV12_8u_ColorTwist32f_C3P2R_Ctx(
       static_cast<const Npp8u*>(hwcFrame.data_ptr()),
       hwcFrame.stride(0) * hwcFrame.element_size(),
@@ -555,7 +555,7 @@ UniqueAVFrame CudaDeviceInterface::convertCUDATensorToAVFrameForEncoding(
   TORCH_CHECK(
       status == NPP_SUCCESS,
       "Failed to convert RGB to ",
-      av_get_pix_fmt_name(CUDA_PIXEL_FORMAT),
+      av_get_pix_fmt_name(DeviceInterface::CUDA_ENCODING_PIXEL_FORMAT),
       ": NPP error code ",
       status);
 
@@ -578,7 +578,7 @@ void CudaDeviceInterface::setupHardwareFrameContextForEncoding(
       hwFramesCtxRef != nullptr,
       "Failed to allocate hardware frames context for codec");
 
-  codecContext->sw_pix_fmt = CUDA_PIXEL_FORMAT;
+  codecContext->sw_pix_fmt = DeviceInterface::CUDA_ENCODING_PIXEL_FORMAT;
   // Always set pixel format to support CUDA encoding.
   codecContext->pix_fmt = AV_PIX_FMT_CUDA;
 

--- a/src/torchcodec/_core/CudaDeviceInterface.h
+++ b/src/torchcodec/_core/CudaDeviceInterface.h
@@ -43,7 +43,6 @@ class CudaDeviceInterface : public DeviceInterface {
 
   std::string getDetails() override;
 
-  constexpr static AVPixelFormat CUDA_PIXEL_FORMAT = AV_PIX_FMT_NV12;
   UniqueAVFrame convertCUDATensorToAVFrameForEncoding(
       const torch::Tensor& tensor,
       int frameIndex,

--- a/src/torchcodec/_core/DeviceInterface.h
+++ b/src/torchcodec/_core/DeviceInterface.h
@@ -139,6 +139,9 @@ class DeviceInterface {
     return "";
   }
 
+  // Pixel format used for encoding on CUDA devices
+  static constexpr AVPixelFormat CUDA_ENCODING_PIXEL_FORMAT = AV_PIX_FMT_NV12;
+
   // Function used for video encoding, only implemented in CudaDeviceInterface.
   // It is here to isolate CUDA dependencies from CPU builds
   // TODO Video-Encoder: Reconsider using video encoding functions in device

--- a/src/torchcodec/_core/Encoder.cpp
+++ b/src/torchcodec/_core/Encoder.cpp
@@ -795,7 +795,7 @@ void VideoEncoder::initializeEncoder(
   } else {
     if (frames_.device().is_cuda()) {
       // Default to nv12 pixel format when encoding on GPU.
-      outPixelFormat_ = AV_PIX_FMT_NV12;
+      outPixelFormat_ = DeviceInterface::CUDA_ENCODING_PIXEL_FORMAT;
     } else {
       const AVPixelFormat* formats = getSupportedPixelFormats(*avCodec);
       // Use first listed pixel format as default (often yuv420p).


### PR DESCRIPTION
This PR resolves this TODO:
`// TODO-VideoEncoder: Enable configuration of color properties, similar to FFmpeg.`

Support is added for the following parameters:
* Color spaces: `BT.601`, `BT.709`, `BT.2020`
* Color ranges: `tv` (limited), `pc` (full)

As a result, 6 `ColorConversionMatrices` are stored and utilized for NPP color conversion functions. To my understanding, these are the most commonly used or newer color spaces parameters ([docs for AVColorSpace](https://www.ffmpeg.org/doxygen/3.1/pixfmt_8h.html#aff71a069509a1ad3ff54d53a1c894c85))


The testing caveats:
* FFmpeg 4 and 6 fails frame equal assertions in `test_nvenc_against_ffmpeg_cli`. It only passes when using non-default color range and colorspace (specifically, not limited range and BT601). Since these tests pass on FFmpeg 7 and 8, I suspect there is some issue in FFmpeg 4 and 6. I've opened #1140 to track this issue.
* The `av1_nvenc` test is disabled on FFmpeg4, as the codec is not implemented.