### PR TITLE
Fix skipif marker handling

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -38,8 +38,9 @@ def pytest_collection_modifyitems(items):
 
         # For skipif, the marker is always present regardless of whether the
         # condition is True or False, so we must check the actual condition.
-    skipif_condition_is_true = any(skipif_marker.args[0] for skipif_marker in item.iter_markers("skipif"))
-
+        skipif_condition_is_true = any(
+            skipif_marker.args[0] for skipif_marker in item.iter_markers("skipif")
+        )
 
         if in_fbcode():
             # fbcode doesn't like skipping tests, so instead we  just don't collect the test


### PR DESCRIPTION
Fixes a bug where tests with `@pytest.mark.skipif(cond, ...)` were being incorrectly excluded in internal CI even when `cond` was `False`.

The issue is that pytest markers are always present regardless of whether the condition is true or false. 