### PR TITLE
Clarify that `num_ffmpeg_threads` is only for CPU

### DIFF
--- a/benchmarks/encoders/benchmark_encoders.py
+++ b/benchmarks/encoders/benchmark_encoders.py
@@ -71,7 +71,7 @@ def report_stats(times, num_frames, nvenc_metrics=None, prefix="", unit="ms"):
             f"GPU memory used:      med = {mem_used_median:.1f} MB, max = {mem_used_max:.1f} MB"
         )
         print(
-            f"NVENC utilization:    med = {nvenc_metrics["utilization"].median():.1f}%,     max = {util_max:.1f}%"
+            f"NVENC utilization:    med = {nvenc_metrics['utilization'].median():.1f}%,     max = {util_max:.1f}%"
         )
 
 

--- a/src/torchcodec/decoders/_video_decoder.py
+++ b/src/torchcodec/decoders/_video_decoder.py
@@ -104,7 +104,8 @@ class VideoDecoder:
                 cheap no-copy operation that allows these frames to be
                 transformed using the `torchvision transforms
                 <https://pytorch.org/vision/stable/transforms.html>`_.
-        num_ffmpeg_threads (int, optional): The number of threads to use for decoding.
+        num_ffmpeg_threads (int, optional): The number of threads to use for CPU decoding.
+            This has no effect when using GPU decoding.
             Use 1 for single-threaded decoding which may be best if you are running multiple
             instances of ``VideoDecoder`` in parallel. Use a higher number for multi-threaded
             decoding which is best if you are running a single instance of ``VideoDecoder``.


### PR DESCRIPTION
Closes https://github.com/meta-pytorch/torchcodec/issues/353

The `num_ffmpeg_threads` parameter of `VideoDecoder` only affects CPU decoding. It doesn't affect GPU decoding.

To verify this I looked for uses of  `thread_count` in the FFmpeg code-base: it's only used for decoding, never for demuxing, and it's never used in the nvdec codec:

```bash
~/dev/FFmpeg (master) » git grep thread_count libavformat/ | wc   # not used for demuxing
      0       0       0
```

```bash
~/dev/FFmpeg (master) » git grep -C 1 thread_count libavcodec/*nvdec*  # not used in nvdec codec. Weirdly there's one hit for logging.
libavcodec/nvdec.c-            av_log(avctx, AV_LOG_WARNING, "Try lowering the amount of threads. Using %d right now.\n",
libavcodec/nvdec.c:                   avctx->thread_count);
libavcodec/nvdec.c-        }


```





And to be extra sure, I ran benchmark showing no difference between calls:

```py
from torchcodec.decoders import VideoDecoder


import torch
from time import perf_counter_ns


def bench(f, *args, num_exp=100, warmup=0, **kwargs):

    for _ in range(warmup):
        f(*args, **kwargs)

    times = []
    for _ in range(num_exp):
        start = perf_counter_ns()
        f(*args, **kwargs)
        end = perf_counter_ns()
        times.append(end - start)
    return torch.tensor(times).float()

def report_stats(times, unit="ms"):
    mul = {
        "ns": 1,
        "µs": 1e-3,
        "ms": 1e-6,
        "s": 1e-9,
    }[unit]
    times = times * mul
    std = times.std().item()
    med = times.median().item()
    print(f"{med = :.2f}{unit} +- {std:.2f}")
    return med


def f(num_ffmpeg_threads):
    decoder = VideoDecoder("test/resources/testsrc2.mp4", device="cuda", num_ffmpeg_threads=num_ffmpeg_threads)
    decoder[:]

report_stats(bench(f, warmup=1, num_exp=20, num_ffmpeg_threads=0))
report_stats(bench(f, warmup=1, num_exp=20, num_ffmpeg_threads=1))
report_stats(bench(f, warmup=1, num_exp=20, num_ffmpeg_threads=4))
report_stats(bench(f, warmup=1, num_exp=20, num_ffmpeg_threads=16))
```

```
~/dev/torchcodec-cuda (main*) » python bench_ffmpeg_threads.py                   nicolashug@nicolashug-fedora-PW0H326Y
med = 274.31ms +- 3.57
med = 281.61ms +- 5.24
med = 275.53ms +- 4.08
med = 280.13ms +- 5.53
```