### PR TITLE
Fix formatting in performance tips tutorial

### DIFF
--- a/examples/decoding/performance_tips.py
+++ b/examples/decoding/performance_tips.py
@@ -52,7 +52,6 @@ to increase performance.
 # - :meth:`~torchcodec.decoders.VideoDecoder.get_frames_played_at` for timestamps
 # - :meth:`~torchcodec.decoders.VideoDecoder.get_frames_played_in_range` for time ranges
 #
-# %%
 # **When to use:**
 #
 # - Decoding multiple frames
@@ -136,9 +135,8 @@ to increase performance.
 # (NVDEC) on supported hardware. This keeps decoded tensors in GPU memory,
 # avoiding expensive CPU-GPU transfers for downstream GPU operations.
 #
-# %%
-# **Recommended:  use the Beta Interface!!**
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# **Recommended: use the Beta Interface!!**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
 # We recommend you use the new "beta" CUDA interface which is significantly faster than the previous one, and supports the same features:
 #
@@ -147,7 +145,6 @@ to increase performance.
 #     with set_cuda_backend("beta"):
 #         decoder = VideoDecoder("file.mp4", device="cuda")
 #
-# %%
 # **When to use:**
 #
 # - Decoding large resolution videos


### PR DESCRIPTION
This PR makes slight adjustments to the Performance Tips tutorial to hide formatting characters.
Before:
<img width="775" height="340" alt="Screenshot 2026-01-21 at 2 05 34 PM" src="https://github.com/user-attachments/assets/0584dfa4-844e-4918-a968-c9f7985d0574" />
After:
<img width="775" height="393" alt="Screenshot 2026-01-21 at 2 05 52 PM" src="https://github.com/user-attachments/assets/2dd76027-9c44-4aea-99dd-144c38dd2645" />
