### PR TITLE
Make ffmpeg directory path absolute

### DIFF
--- a/src/torchcodec/_core/ops.py
+++ b/src/torchcodec/_core/ops.py
@@ -101,7 +101,7 @@ if sys.platform == "win32" and hasattr(os, "add_dll_directory"):
     if ffmpeg_path := shutil.which("ffmpeg"):
 
         def expose_ffmpeg_dlls():  # noqa: F811
-            ffmpeg_dir = Path(ffmpeg_path).parent
+            ffmpeg_dir = Path(ffmpeg_path).parent.absolute()
             return os.add_dll_directory(str(ffmpeg_dir))  # that's the actual CM
 
 


### PR DESCRIPTION
If the command is found in working directory, then relative path is returned, which is unacceptable by os.add_dll_directory on Windows.

`OSError: [WinError 87] The parameter is incorrect: '.'`