### PR TITLE
Use  `TORCH_CHECK*` instead of C++'s `throw`

### DIFF
--- a/src/torchcodec/_core/custom_ops.cpp
+++ b/src/torchcodec/_core/custom_ops.cpp
@@ -892,11 +892,11 @@ std::string get_stream_json_metadata(
   auto videoDecoder = unwrapTensorToGetDecoder(decoder);
   auto allStreamMetadata =
       videoDecoder->getContainerMetadata().allStreamMetadata;
-  if (stream_index < 0 ||
-      stream_index >= static_cast<int64_t>(allStreamMetadata.size())) {
-    throw std::out_of_range(
-        "stream_index out of bounds: " + std::to_string(stream_index));
-  }
+  TORCH_CHECK_INDEX(
+      stream_index >= 0 &&
+          stream_index < static_cast<int64_t>(allStreamMetadata.size()),
+      "stream_index out of bounds: ",
+      stream_index);
 
   auto streamMetadata = allStreamMetadata[stream_index];
   auto seekMode = videoDecoder->getSeekMode();


### PR DESCRIPTION
Closes https://github.com/meta-pytorch/torchcodec/issues/537
Closes https://github.com/meta-pytorch/torchcodec/issues/212

This PR remove all-but-one uses of the C++ `throw`, replacing them with equivalent `TORCH_CHECK*` utils. Note that the original Python exception types are preserved - e.g. `std::out_of_range` used to throw `IndexError`, and that's preserved through `TORCH_CHECK_INDEX`.

There's one remaining use of throw, but it's not one that we'd want to remove, because it's used for control flow (rather than for raising user-facing exceptions):

https://github.com/meta-pytorch/torchcodec/blob/de7d14811d7e80d526218b7aea411337e7c85585/src/torchcodec/_core/SingleStreamDecoder.cpp#L1286-L1291

which it is caught in the AudioDecoder logic:

https://github.com/meta-pytorch/torchcodec/blob/de7d14811d7e80d526218b7aea411337e7c85585/src/torchcodec/_core/SingleStreamDecoder.cpp#L1044-L1046

and in custom_ops:

https://github.com/meta-pytorch/torchcodec/blob/de7d14811d7e80d526218b7aea411337e7c85585/src/torchcodec/_core/custom_ops.cpp#L518-L520


It never bubbles up to Python.