### PR TITLE
Use torch::Tensor instead of at::Tensor

### DIFF
--- a/src/torchcodec/_core/custom_ops.cpp
+++ b/src/torchcodec/_core/custom_ops.cpp
@@ -82,12 +82,12 @@ TORCH_LIBRARY(torchcodec_ns, m) {
 
 namespace {
 
-at::Tensor wrapDecoderPointerToTensor(
+torch::Tensor wrapDecoderPointerToTensor(
     std::unique_ptr<SingleStreamDecoder> uniqueDecoder) {
   SingleStreamDecoder* decoder = uniqueDecoder.release();
 
   auto deleter = [decoder](void*) { delete decoder; };
-  at::Tensor tensor = at::from_blob(
+  torch::Tensor tensor = at::from_blob(
       decoder, {sizeof(SingleStreamDecoder*)}, deleter, {at::kLong});
   auto videoDecoder =
       static_cast<SingleStreamDecoder*>(tensor.mutable_data_ptr());
@@ -95,7 +95,7 @@ at::Tensor wrapDecoderPointerToTensor(
   return tensor;
 }
 
-SingleStreamDecoder* unwrapTensorToGetDecoder(at::Tensor& tensor) {
+SingleStreamDecoder* unwrapTensorToGetDecoder(torch::Tensor& tensor) {
   TORCH_CHECK(
       tensor.is_contiguous(),
       "fake decoder tensor must be contiguous! This is an internal error, please report on the torchcodec issue tracker.");
@@ -110,7 +110,7 @@ SingleStreamDecoder* unwrapTensorToGetDecoder(at::Tensor& tensor) {
 //   3. A single float value for the duration in seconds.
 // The reason we use Tensors for the second and third values is so we can run
 // under torch.compile().
-using OpsFrameOutput = std::tuple<at::Tensor, at::Tensor, at::Tensor>;
+using OpsFrameOutput = std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>;
 
 OpsFrameOutput makeOpsFrameOutput(FrameOutput& frame) {
   return std::make_tuple(
@@ -120,7 +120,8 @@ OpsFrameOutput makeOpsFrameOutput(FrameOutput& frame) {
 }
 
 SingleStreamDecoder::FrameMappings makeFrameMappings(
-    std::tuple<at::Tensor, at::Tensor, at::Tensor> custom_frame_mappings) {
+    std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>
+        custom_frame_mappings) {
   return SingleStreamDecoder::FrameMappings{
       std::move(std::get<0>(custom_frame_mappings)),
       std::move(std::get<1>(custom_frame_mappings)),
@@ -136,7 +137,8 @@ SingleStreamDecoder::FrameMappings makeFrameMappings(
 //   float.
 //   3. Tensor of N durationis in seconds, where each duration is a
 //   single float.
-using OpsFrameBatchOutput = std::tuple<at::Tensor, at::Tensor, at::Tensor>;
+using OpsFrameBatchOutput =
+    std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>;
 
 OpsFrameBatchOutput makeOpsFrameBatchOutput(FrameBatchOutput& batch) {
   return std::make_tuple(batch.data, batch.ptsSeconds, batch.durationSeconds);
@@ -146,7 +148,7 @@ OpsFrameBatchOutput makeOpsFrameBatchOutput(FrameBatchOutput& batch) {
 // of multiple audio frames:
 //   1. The frames data (concatenated)
 //   2. A single float value for the pts of the first frame, in seconds.
-using OpsAudioFramesOutput = std::tuple<at::Tensor, at::Tensor>;
+using OpsAudioFramesOutput = std::tuple<torch::Tensor, torch::Tensor>;
 
 OpsAudioFramesOutput makeOpsAudioFramesOutput(AudioFramesOutput& audioFrames) {
   return std::make_tuple(
@@ -350,7 +352,7 @@ std::vector<Transform*> makeTransforms(const std::string& transformSpecsRaw) {
 // ==============================
 
 // Create a SingleStreamDecoder from file and wrap the pointer in a tensor.
-at::Tensor create_from_file(
+torch::Tensor create_from_file(
     std::string_view filename,
     std::optional<std::string_view> seek_mode = std::nullopt) {
   std::string filenameStr(filename);
@@ -368,8 +370,8 @@ at::Tensor create_from_file(
 
 // Create a SingleStreamDecoder from the actual bytes of a video and wrap the
 // pointer in a tensor. The SingleStreamDecoder will decode the provided bytes.
-at::Tensor create_from_tensor(
-    at::Tensor video_tensor,
+torch::Tensor create_from_tensor(
+    torch::Tensor video_tensor,
     std::optional<std::string_view> seek_mode = std::nullopt) {
   TORCH_CHECK(video_tensor.is_contiguous(), "video_tensor must be contiguous");
   TORCH_CHECK(
@@ -390,7 +392,7 @@ at::Tensor create_from_tensor(
   return wrapDecoderPointerToTensor(std::move(uniqueDecoder));
 }
 
-at::Tensor _create_from_file_like(
+torch::Tensor _create_from_file_like(
     int64_t file_like_context,
     std::optional<std::string_view> seek_mode) {
   auto fileLikeContext =
@@ -411,14 +413,14 @@ at::Tensor _create_from_file_like(
 }
 
 void _add_video_stream(
-    at::Tensor& decoder,
+    torch::Tensor& decoder,
     std::optional<int64_t> num_threads = std::nullopt,
     std::optional<std::string_view> dimension_order = std::nullopt,
     std::optional<int64_t> stream_index = std::nullopt,
     std::string_view device = "cpu",
     std::string_view device_variant = "ffmpeg",
     std::string_view transform_specs = "",
-    std::optional<std::tuple<at::Tensor, at::Tensor, at::Tensor>>
+    std::optional<std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>>
         custom_frame_mappings = std::nullopt,
     std::optional<std::string_view> color_conversion_library = std::nullopt) {
   VideoStreamOptions videoStreamOptions;
@@ -468,14 +470,15 @@ void _add_video_stream(
 
 // Add a new video stream at `stream_index` using the provided options.
 void add_video_stream(
-    at::Tensor& decoder,
+    torch::Tensor& decoder,
     std::optional<int64_t> num_threads = std::nullopt,
     std::optional<std::string_view> dimension_order = std::nullopt,
     std::optional<int64_t> stream_index = std::nullopt,
     std::string_view device = "cpu",
     std::string_view device_variant = "ffmpeg",
     std::string_view transform_specs = "",
-    const std::optional<std::tuple<at::Tensor, at::Tensor, at::Tensor>>&
+    const std::optional<
+        std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>>&
         custom_frame_mappings = std::nullopt) {
   _add_video_stream(
       decoder,
@@ -489,7 +492,7 @@ void add_video_stream(
 }
 
 void add_audio_stream(
-    at::Tensor& decoder,
+    torch::Tensor& decoder,
     std::optional<int64_t> stream_index = std::nullopt,
     std::optional<int64_t> sample_rate = std::nullopt,
     std::optional<int64_t> num_channels = std::nullopt) {
@@ -502,7 +505,7 @@ void add_audio_stream(
 }
 
 // Seek to a particular presentation timestamp in the video in seconds.
-void seek_to_pts(at::Tensor& decoder, double seconds) {
+void seek_to_pts(torch::Tensor& decoder, double seconds) {
   auto videoDecoder =
       static_cast<SingleStreamDecoder*>(decoder.mutable_data_ptr());
   videoDecoder->setCursorPtsInSeconds(seconds);
@@ -510,7 +513,7 @@ void seek_to_pts(at::Tensor& decoder, double seconds) {
 
 // Get the next frame from the video as a tuple that has the frame data, pts and
 // duration as tensors.
-OpsFrameOutput get_next_frame(at::Tensor& decoder) {
+OpsFrameOutput get_next_frame(torch::Tensor& decoder) {
   auto videoDecoder = unwrapTensorToGetDecoder(decoder);
   FrameOutput result;
   try {
@@ -524,7 +527,7 @@ OpsFrameOutput get_next_frame(at::Tensor& decoder) {
 // Return the frame that is visible at a given timestamp in seconds. Each frame
 // in FFMPEG has a presentation timestamp and a duration. The frame visible at a
 // given timestamp T has T >= PTS and T < PTS + Duration.
-OpsFrameOutput get_frame_at_pts(at::Tensor& decoder, double seconds) {
+OpsFrameOutput get_frame_at_pts(torch::Tensor& decoder, double seconds) {
   auto videoDecoder = unwrapTensorToGetDecoder(decoder);
   FrameOutput result;
   try {
@@ -536,7 +539,7 @@ OpsFrameOutput get_frame_at_pts(at::Tensor& decoder, double seconds) {
 }
 
 // Return the frame that is visible at a given index in the video.
-OpsFrameOutput get_frame_at_index(at::Tensor& decoder, int64_t frame_index) {
+OpsFrameOutput get_frame_at_index(torch::Tensor& decoder, int64_t frame_index) {
   auto videoDecoder = unwrapTensorToGetDecoder(decoder);
   auto result = videoDecoder->getFrameAtIndex(frame_index);
   return makeOpsFrameOutput(result);
@@ -544,8 +547,8 @@ OpsFrameOutput get_frame_at_index(at::Tensor& decoder, int64_t frame_index) {
 
 // Return the frames at given indices for a given stream
 OpsFrameBatchOutput get_frames_at_indices(
-    at::Tensor& decoder,
-    const at::Tensor& frame_indices) {
+    torch::Tensor& decoder,
+    const torch::Tensor& frame_indices) {
   auto videoDecoder = unwrapTensorToGetDecoder(decoder);
   auto result = videoDecoder->getFramesAtIndices(frame_indices);
   return makeOpsFrameBatchOutput(result);
@@ -554,7 +557,7 @@ OpsFrameBatchOutput get_frames_at_indices(
 // Return the frames inside a range as a single stacked Tensor. The range is
 // defined as [start, stop).
 OpsFrameBatchOutput get_frames_in_range(
-    at::Tensor& decoder,
+    torch::Tensor& decoder,
     int64_t start,
     int64_t stop,
     std::optional<int64_t> step = std::nullopt) {
@@ -565,8 +568,8 @@ OpsFrameBatchOutput get_frames_in_range(
 
 // Return the frames at given ptss for a given stream
 OpsFrameBatchOutput get_frames_by_pts(
-    at::Tensor& decoder,
-    const at::Tensor& timestamps) {
+    torch::Tensor& decoder,
+    const torch::Tensor& timestamps) {
   auto videoDecoder = unwrapTensorToGetDecoder(decoder);
   auto result = videoDecoder->getFramesPlayedAt(timestamps);
   return makeOpsFrameBatchOutput(result);
@@ -576,7 +579,7 @@ OpsFrameBatchOutput get_frames_by_pts(
 // defined as [start_seconds, stop_seconds). The frames are stacked in pts
 // order.
 OpsFrameBatchOutput get_frames_by_pts_in_range(
-    at::Tensor& decoder,
+    torch::Tensor& decoder,
     double start_seconds,
     double stop_seconds) {
   auto videoDecoder = unwrapTensorToGetDecoder(decoder);
@@ -586,7 +589,7 @@ OpsFrameBatchOutput get_frames_by_pts_in_range(
 }
 
 OpsAudioFramesOutput get_frames_by_pts_in_range_audio(
-    at::Tensor& decoder,
+    torch::Tensor& decoder,
     double start_seconds,
     std::optional<double> stop_seconds = std::nullopt) {
   auto videoDecoder = unwrapTensorToGetDecoder(decoder);
@@ -596,7 +599,7 @@ OpsAudioFramesOutput get_frames_by_pts_in_range_audio(
 }
 
 void encode_audio_to_file(
-    const at::Tensor& samples,
+    const torch::Tensor& samples,
     int64_t sample_rate,
     std::string_view file_name,
     std::optional<int64_t> bit_rate = std::nullopt,
@@ -616,8 +619,8 @@ void encode_audio_to_file(
       .encode();
 }
 
-at::Tensor encode_audio_to_tensor(
-    const at::Tensor& samples,
+torch::Tensor encode_audio_to_tensor(
+    const torch::Tensor& samples,
     int64_t sample_rate,
     std::string_view format,
     std::optional<int64_t> bit_rate = std::nullopt,
@@ -640,7 +643,7 @@ at::Tensor encode_audio_to_tensor(
 }
 
 void _encode_audio_to_file_like(
-    const at::Tensor& samples,
+    const torch::Tensor& samples,
     int64_t sample_rate,
     std::string_view format,
     int64_t file_like_context,
@@ -670,7 +673,7 @@ void _encode_audio_to_file_like(
 }
 
 void encode_video_to_file(
-    const at::Tensor& frames,
+    const torch::Tensor& frames,
     double frame_rate,
     std::string_view file_name,
     std::optional<std::string_view> codec = std::nullopt,
@@ -692,8 +695,8 @@ void encode_video_to_file(
   VideoEncoder(frames, frame_rate, file_name, videoStreamOptions).encode();
 }
 
-at::Tensor encode_video_to_tensor(
-    const at::Tensor& frames,
+torch::Tensor encode_video_to_tensor(
+    const torch::Tensor& frames,
     double frame_rate,
     std::string_view format,
     std::optional<std::string_view> codec = std::nullopt,
@@ -723,7 +726,7 @@ at::Tensor encode_video_to_tensor(
 }
 
 void _encode_video_to_file_like(
-    const at::Tensor& frames,
+    const torch::Tensor& frames,
     double frame_rate,
     std::string_view format,
     int64_t file_like_context,
@@ -768,7 +771,7 @@ void _encode_video_to_file_like(
 // value when converted to seconds as a double is exactly pts_seconds_to_test.
 // Returns false otherwise.
 bool _test_frame_pts_equality(
-    at::Tensor& decoder,
+    torch::Tensor& decoder,
     int64_t frame_index,
     double pts_seconds_to_test) {
   auto videoDecoder = unwrapTensorToGetDecoder(decoder);
@@ -776,13 +779,13 @@ bool _test_frame_pts_equality(
       videoDecoder->getPtsSecondsForFrame(frame_index);
 }
 
-torch::Tensor _get_key_frame_indices(at::Tensor& decoder) {
+torch::Tensor _get_key_frame_indices(torch::Tensor& decoder) {
   auto videoDecoder = unwrapTensorToGetDecoder(decoder);
   return videoDecoder->getKeyFrameIndices();
 }
 
 // Get the metadata from the video as a string.
-std::string get_json_metadata(at::Tensor& decoder) {
+std::string get_json_metadata(torch::Tensor& decoder) {
   auto videoDecoder = unwrapTensorToGetDecoder(decoder);
 
   ContainerMetadata videoMetadata = videoDecoder->getContainerMetadata();
@@ -854,7 +857,7 @@ std::string get_json_metadata(at::Tensor& decoder) {
 }
 
 // Get the container metadata as a string.
-std::string get_container_json_metadata(at::Tensor& decoder) {
+std::string get_container_json_metadata(torch::Tensor& decoder) {
   auto videoDecoder = unwrapTensorToGetDecoder(decoder);
 
   auto containerMetadata = videoDecoder->getContainerMetadata();
@@ -887,7 +890,7 @@ std::string get_container_json_metadata(at::Tensor& decoder) {
 
 // Get the stream metadata as a string.
 std::string get_stream_json_metadata(
-    at::Tensor& decoder,
+    torch::Tensor& decoder,
     int64_t stream_index) {
   auto videoDecoder = unwrapTensorToGetDecoder(decoder);
   auto allStreamMetadata =
@@ -1031,7 +1034,7 @@ std::string _get_json_ffmpeg_library_versions() {
   return ss.str();
 }
 
-std::string get_backend_details(at::Tensor& decoder) {
+std::string get_backend_details(torch::Tensor& decoder) {
   auto videoDecoder = unwrapTensorToGetDecoder(decoder);
   return videoDecoder->getDeviceInterfaceDetails();
 }
@@ -1040,7 +1043,7 @@ std::string get_backend_details(at::Tensor& decoder) {
 // keyframe positions, etc. Exact keyframe positions are useful for efficient
 // accurate seeking. Note that this function reads the entire video but it does
 // not decode frames. Reading a video file is much cheaper than decoding it.
-void scan_all_streams_to_update_metadata(at::Tensor& decoder) {
+void scan_all_streams_to_update_metadata(torch::Tensor& decoder) {
   auto videoDecoder = unwrapTensorToGetDecoder(decoder);
   videoDecoder->scanFileAndUpdateMetadataAndIndex();
 }

--- a/test/VideoDecoderTest.cpp
+++ b/test/VideoDecoderTest.cpp
@@ -59,7 +59,7 @@ class SingleStreamDecoderTest : public testing::TestWithParam<bool> {
       char* data = new char[length];
       std::memcpy(data, content_.data(), length);
       auto deleter = [data](void*) { delete[] data; };
-      at::Tensor tensor = at::from_blob(
+      torch::Tensor tensor = at::from_blob(
           static_cast<void*>(data), {length}, deleter, {torch::kUInt8});
 
       auto contextHolder = std::make_unique<AVIOFromTensorContext>(tensor);


### PR DESCRIPTION
Closes https://github.com/meta-pytorch/torchcodec/issues/767

We had a mixed use of `torch::Tensor` and `at::Tensor`. This PR uses `torch::Tensor` everywhere.