### PR TITLE
Fix resource generation script

### DIFF
--- a/.github/workflows/reference_resources.yaml
+++ b/.github/workflows/reference_resources.yaml
@@ -55,10 +55,9 @@ jobs:
         python-version: ['3.10']
         ffmpeg-version-for-tests: ['4.4.2', '5.1.2', '6.1.1', '7.0.1']
     steps:
-      - uses: actions/download-artifact@v4
-        with:
-          name: meta-pytorch_torchcodec__${{ matrix.python-version }}_cpu_x86_64
-          path: pytorch/torchcodec/dist/
+      - name: Check out repo
+        uses: actions/checkout@v3
+
       - name: Setup conda env
         uses: conda-incubator/setup-miniconda@v2
         with:
@@ -67,28 +66,25 @@ jobs:
           activate-environment: test
           python-version: ${{ matrix.python-version }}
 
-      - name: Install ffmpeg
-        run: |
-          conda install "ffmpeg=${{ matrix.ffmpeg-version-for-tests }}" -c conda-forge
-          ffmpeg -version
-
       - name: Update pip
         run: python -m pip install --upgrade pip
 
-      - name: Install generation dependencies
-        run: |
-          # Note that we're installing stable - this is for running a script where we're a normal PyTorch
-          # user, not for building TorhCodec.
-          python -m pip install torch --index-url https://download.pytorch.org/whl/cpu
-          python -m pip install numpy pillow pytest
+      - name: Install PyTorch
+        run: bash packaging/install_pytorch.sh cpu "torch"
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: meta-pytorch_torchcodec__${{ matrix.python-version }}_cpu_x86_64
+          path: dist/
 
       - name: Install torchcodec from the wheel
-        run: |
-          wheel_path=`find pytorch/torchcodec/dist -type f -name "*.whl"`
-          echo Installing $wheel_path
-          python -m pip install $wheel_path -vvv
-      - name: Check out repo
-        uses: actions/checkout@v3
+        run: bash packaging/install_torchcodec_wheel.sh
+
+      - name: Install ffmpeg, post build
+        run: bash packaging/install_ffmpeg.sh ${{ matrix.ffmpeg-version-for-tests }}
+
+      - name: Install test dependencies
+        run: bash packaging/install_test_dependencies.sh
 
       - name: Run generation reference resources
         run: |


### PR DESCRIPTION
Fixes https://github.com/meta-pytorch/torchcodec/issues/1103

This PR fixes the resource generation script on FFmpeg > 4. Currently on main, all are failing (see https://github.com/meta-pytorch/torchcodec/pull/1196). I think FFmpeg 4 will be fixed with the use of `miniforge`, done in https://github.com/meta-pytorch/torchcodec/pull/1187.


The fix in this PR is mainly just to install pytorch nightly instead of installing the stable version of torch: we migrated these scripts recently to install the torchcodec wheel. That wheel is built from torch nightlies, so it needs to be tested against torch nightly as well. The rest of the changes in this PR is just to align the yaml file to use the existing utilities and have a similar order to our linux wheel job.