### PR TITLE
Use FFmpeg 6 only for reference resource CI job

### DIFF
--- a/.github/workflows/reference_resources.yaml
+++ b/.github/workflows/reference_resources.yaml
@@ -53,7 +53,10 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.10']
-        ffmpeg-version-for-tests: ['4.4.2', '5.1.2', '6.1.1', '7.0.1']
+        # Traditionally we generate the resources locally on FFmpeg 4 or 6.
+        # The exact version shouln't matter as long as the unit tests pass
+        # across all version for a given generated resource.
+        ffmpeg-version-for-tests: ['6.1.1']
     steps:
       - name: Check out repo
         uses: actions/checkout@v3


### PR DESCRIPTION
See comment.

Also just noting: this CI job is *not* what we've been using to generate resources. The resources have always been generated from local laptops or devvms. The CI jobs only exists to check that our resource generation python script isn't broken.