### PR TITLE
Skip 24 channel test on some FFmpeg versions

### DIFF
--- a/test/test_decoders.py
+++ b/test/test_decoders.py
@@ -2288,9 +2288,9 @@ class TestAudioDecoder:
             pytest.param(
                 24,
                 marks=pytest.mark.skipif(
-                    get_ffmpeg_major_version() == 4 and get_ffmpeg_minor_version() < 4
+                    get_ffmpeg_major_version() == 4 and get_ffmpeg_minor_version() < 4,
+                    reason="24 channel layout requires FFmpeg >= 4.4",
                 ),
-                reason="24 channel layout requires FFmpeg >= 4.4",
             ),
             None,
         ),


### PR DESCRIPTION
`test_num_channels` decodes audio into 24 channels. Github CI uses `ffmpeg=4.4.2` so it passed, but this test will fail on any ffmpeg version before 4.4, since the default channel layout for 24 channels was added in ffmpeg 4.4.

* [libavutil on FFmpeg 4.3](https://github.com/FFmpeg/FFmpeg/blob/n4.3/libavutil/channel_layout.c) does not mention 24 channel layout.
* [libavutil on FFmpeg 4.4](https://github.com/FFmpeg/FFmpeg/blob/n4.4/libavutil/channel_layout.c) has 24 channel layout.