### PR TITLE
Linter fixes

### DIFF
--- a/src/torchcodec/_core/SingleStreamDecoder.cpp
+++ b/src/torchcodec/_core/SingleStreamDecoder.cpp
@@ -8,9 +8,6 @@
 #include <cstdint>
 #include <cstdio>
 #include <iostream>
-#include <limits>
-#include <sstream>
-#include <stdexcept>
 #include <string_view>
 #include "Metadata.h"
 #include "torch/types.h"

--- a/src/torchcodec/_core/custom_ops.cpp
+++ b/src/torchcodec/_core/custom_ops.cpp
@@ -371,7 +371,7 @@ torch::Tensor create_from_file(
 // Create a SingleStreamDecoder from the actual bytes of a video and wrap the
 // pointer in a tensor. The SingleStreamDecoder will decode the provided bytes.
 torch::Tensor create_from_tensor(
-    torch::Tensor video_tensor,
+    const torch::Tensor& video_tensor,
     std::optional<std::string_view> seek_mode = std::nullopt) {
   TORCH_CHECK(video_tensor.is_contiguous(), "video_tensor must be contiguous");
   TORCH_CHECK(


### PR DESCRIPTION
* Removes unused headers in `SingleStreamDecoder.cpp`
* Uses `const` reference in `create_from_tensor`.