### PR TITLE
Update aarch64 workflow to set cuda version in matrix

### DIFF
--- a/.github/workflows/linux_cuda_aarch64_wheel.yaml
+++ b/.github/workflows/linux_cuda_aarch64_wheel.yaml
@@ -59,17 +59,21 @@ jobs:
 
   install-and-test:
     runs-on: linux.arm64.2xlarge
-    container:
-      image: pytorch/manylinuxaarch64-builder:cuda12.6
-    env:
-      cuda_version_without_periods: "126"
     strategy:
       fail-fast: false
       matrix:
         python-version: ['3.10']
+        cuda-version: ['12.6']
         ffmpeg-version-for-tests: ['4.4.2', '5.1.2', '6.1.1', '7.0.1', '8.0']
+    container:
+      image: "pytorch/manylinuxaarch64-builder:cuda${{ matrix.cuda-version }}"
     needs: build
     steps:
+      - name: Setup env vars
+        run: |
+          cuda_version_without_periods=$(echo "${{ matrix.cuda-version }}" | sed 's/\.//g')
+          echo cuda_version_without_periods=${cuda_version_without_periods} >> $GITHUB_ENV
+
       - name: Check out repo
         uses: actions/checkout@v6
 


### PR DESCRIPTION
This PR moves `cuda-version` to the `matrix` section, which will make it easier to test other CUDA versions during the release process.