### PR TITLE
Add motion vector extraction support

### DIFF
--- a/docs/source/api_ref_torchcodec.rst
+++ b/docs/source/api_ref_torchcodec.rst
@@ -14,4 +14,5 @@ torchcodec
 
     Frame
     FrameBatch
+    MotionVectorBatch
     AudioSamples

--- a/examples/decoding/motion_vectors.py
+++ b/examples/decoding/motion_vectors.py
@@ -1,0 +1,179 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+================================
+Extracting motion vectors (CPU)
+================================
+
+This example shows how to export compressed-domain motion vectors using
+``VideoDecoder``. Motion vectors are returned in a padded tensor along with
+per-frame metadata and counts of valid vectors.
+"""
+
+# %%
+# Download a sample video (same source as the basic decoding example).
+import tempfile
+
+import requests
+import torch
+
+from torchcodec.decoders import VideoDecoder
+from torchcodec.encoders import VideoEncoder
+
+url = "https://videos.pexels.com/video-files/854132/854132-sd_640_360_25fps.mp4"
+response = requests.get(url, headers={"User-Agent": ""})
+if response.status_code != 200:
+    raise RuntimeError(f"Failed to download video. {response.status_code = }.")
+
+raw_video_bytes = response.content
+
+# %%
+# Create a decoder with motion vector export enabled (CPU only).
+decoder = VideoDecoder(raw_video_bytes, device="cpu", export_mvs=True)
+mvs = decoder.get_motion_vectors_at([0, 1, 2])
+
+print(mvs)
+print(f"{mvs.data.shape = }")
+print(f"{mvs.counts = }")
+print(f"{mvs.frame_types = }")
+
+# %%
+# Motion vector fields in each 10-element row.
+MV_FIELDS = [
+    "source",
+    "w",
+    "h",
+    "src_x",
+    "src_y",
+    "dst_x",
+    "dst_y",
+    "motion_x",
+    "motion_y",
+    "motion_scale",
+]
+
+# %%
+# Use counts to slice valid vectors per frame.
+frame_index = 0
+count = int(mvs.counts[frame_index])
+valid = mvs.data[frame_index, :count]
+print(f"{count = }")
+print(f"{valid.shape = }")
+
+if count > 0:
+    first_mv = valid[0].tolist()
+    print(dict(zip(MV_FIELDS, first_mv)))
+
+# %%
+# Frame types are ASCII codes (e.g., 'I', 'P', 'B').
+frame_type_chars = [chr(int(x)) for x in mvs.frame_types]
+print(f"{frame_type_chars = }")
+
+# %%
+# Optional: visualize motion vectors over a frame.
+# Note: this uses integer rounding for coordinates. For sub-pixel precision,
+# scale coordinates or use a rendering backend that supports fixed-point shifts.
+try:
+    import matplotlib.pyplot as plt
+    from torchvision.transforms.v2.functional import to_pil_image
+except ImportError:
+    print("Cannot plot, please run `pip install torchvision matplotlib`")
+else:
+    plot_index = int(torch.argmax(mvs.counts).item())
+    if int(mvs.counts[plot_index]) == 0:
+        print("No motion vectors available to plot.")
+    else:
+        frame = decoder.get_frame_at(plot_index).data
+        fig, ax = plt.subplots()
+        ax.imshow(to_pil_image(frame))
+
+        valid = mvs.data[plot_index, : int(mvs.counts[plot_index])]
+        for mv in valid:
+            dst_x, dst_y = int(mv[5]), int(mv[6])
+            motion_scale = int(mv[9])
+            if motion_scale == 0:
+                continue
+            src_x = int(dst_x + mv[7].item() / motion_scale)
+            src_y = int(dst_y + mv[8].item() / motion_scale)
+            ax.arrow(
+                src_x,
+                src_y,
+                dst_x - src_x,
+                dst_y - src_y,
+                color="red",
+                width=0.5,
+                head_width=2.0,
+                length_includes_head=True,
+            )
+            ax.scatter([dst_x], [dst_y], s=5, c="blue")
+
+        ax.set(xticks=[], yticks=[], title=f"Motion vectors (frame {plot_index})")
+        plt.tight_layout()
+
+# %%
+# Optional: encode a short video with MV overlays using VideoEncoder.
+# This overlay is a simple visualization (integer coordinates, no arrowheads).
+def _draw_line(image: torch.Tensor, x0: int, y0: int, x1: int, y1: int):
+    h, w = image.shape[1], image.shape[2]
+    x0 = max(0, min(w - 1, x0))
+    x1 = max(0, min(w - 1, x1))
+    y0 = max(0, min(h - 1, y0))
+    y1 = max(0, min(h - 1, y1))
+
+    dx = abs(x1 - x0)
+    dy = -abs(y1 - y0)
+    sx = 1 if x0 < x1 else -1
+    sy = 1 if y0 < y1 else -1
+    err = dx + dy
+
+    color = torch.tensor([255, 0, 0], dtype=image.dtype)
+    while True:
+        image[:, y0, x0] = color
+        if x0 == x1 and y0 == y1:
+            break
+        e2 = 2 * err
+        if e2 >= dy:
+            err += dy
+            x0 += sx
+        if e2 <= dx:
+            err += dx
+            y0 += sy
+
+
+num_overlay_frames = 10
+overlay_frames = decoder.get_frames_in_range(0, num_overlay_frames).data.clone()
+overlay_mvs = decoder.get_motion_vectors_at(list(range(num_overlay_frames)))
+
+max_draw_per_frame = None
+for i in range(num_overlay_frames):
+    count = int(overlay_mvs.counts[i])
+    if count == 0:
+        continue
+    if max_draw_per_frame is None or count <= max_draw_per_frame:
+        sample_indices = torch.arange(count)
+    else:
+        sample_indices = torch.linspace(
+            0, count - 1, steps=max_draw_per_frame
+        ).round().to(torch.int64)
+    valid = overlay_mvs.data[i, sample_indices]
+    for mv in valid:
+        dst_x, dst_y = int(mv[5]), int(mv[6])
+        motion_scale = int(mv[9])
+        if motion_scale == 0:
+            continue
+        src_x = float(dst_x) + float(mv[7].item()) / motion_scale
+        src_y = float(dst_y) + float(mv[8].item()) / motion_scale
+        src_x = int(round(src_x))
+        src_y = int(round(src_y))
+        _draw_line(overlay_frames[i], src_x, src_y, dst_x, dst_y)
+
+encoder = VideoEncoder(frames=overlay_frames, frame_rate=decoder.metadata.average_fps)
+overlay_path = tempfile.NamedTemporaryFile(
+    suffix=".mp4", prefix="motion_vectors_overlay_", delete=False
+).name
+encoder.to_file(overlay_path)
+print(f"Wrote {overlay_path}")

--- a/src/torchcodec/__init__.py
+++ b/src/torchcodec/__init__.py
@@ -8,7 +8,12 @@ from pathlib import Path
 
 # Note: usort wants to put Frame and FrameBatch after decoders and samplers,
 # but that results in circular import.
-from ._frame import AudioSamples, Frame, FrameBatch  # usort:skip # noqa
+from ._frame import (
+    AudioSamples,
+    Frame,
+    FrameBatch,
+    MotionVectorBatch,
+)  # usort:skip # noqa
 from . import decoders, encoders, samplers, transforms  # noqa
 
 try:

--- a/src/torchcodec/_core/Frame.h
+++ b/src/torchcodec/_core/Frame.h
@@ -49,6 +49,16 @@ struct FrameBatchOutput {
       const torch::Device& device);
 };
 
+constexpr int kMotionVectorNumFields = 10;
+
+struct MotionVectorsBatchOutput {
+  torch::Tensor data; // 3D: of shape (N, max_mvs, kMotionVectorNumFields)
+  torch::Tensor counts; // 1D of shape (N,)
+  torch::Tensor ptsSeconds; // 1D of shape (N,)
+  torch::Tensor durationSeconds; // 1D of shape (N,)
+  torch::Tensor frameTypes; // 1D of shape (N,)
+};
+
 struct AudioFramesOutput {
   torch::Tensor data; // shape is (numChannels, numSamples)
   double ptsSeconds;

--- a/src/torchcodec/_core/SingleStreamDecoder.h
+++ b/src/torchcodec/_core/SingleStreamDecoder.h
@@ -115,6 +115,10 @@ class SingleStreamDecoder {
   // Tensor.
   FrameBatchOutput getFramesAtIndices(const torch::Tensor& frameIndices);
 
+  // Returns motion vectors and metadata for frames at the given indices.
+  MotionVectorsBatchOutput getMotionVectorsAtIndices(
+      const torch::Tensor& frameIndices);
+
   // Returns frames within a given range. The range is defined by [start, stop).
   // The values retrieved from the range are: [start, start+step,
   // start+(2*step), start+(3*step), ..., stop). The default for step is 1.
@@ -176,6 +180,8 @@ class SingleStreamDecoder {
   FrameOutput getFrameAtIndexInternal(
       int64_t frameIndex,
       std::optional<torch::Tensor> preAllocatedOutputTensor = std::nullopt);
+
+  UniqueAVFrame getAVFrameAtIndexInternal(int64_t frameIndex);
 
   // Exposed for _test_frame_pts_equality, which is used to test non-regression
   // of pts resolution (64 to 32 bit floats)
@@ -305,7 +311,8 @@ class SingleStreamDecoder {
       AVMediaType mediaType,
       const torch::Device& device = torch::kCPU,
       const std::string_view deviceVariant = "ffmpeg",
-      std::optional<int> ffmpegThreadCount = std::nullopt);
+      std::optional<int> ffmpegThreadCount = std::nullopt,
+      bool exportMotionVectors = false);
 
   // Returns the "best" stream index for a given media type. The "best" is
   // determined by various heuristics in FFMPEG.

--- a/src/torchcodec/_core/StreamOptions.h
+++ b/src/torchcodec/_core/StreamOptions.h
@@ -47,6 +47,9 @@ struct VideoStreamOptions {
   // Device variant (e.g., "ffmpeg", "beta", etc.)
   std::string_view deviceVariant = "ffmpeg";
 
+  // If true, request FFmpeg to export motion vectors as side data.
+  bool exportMotionVectors = false;
+
   // Encoding options
   std::optional<std::string> codec;
   // Optional pixel format for video encoding (e.g., "yuv420p", "yuv444p")

--- a/src/torchcodec/_core/__init__.py
+++ b/src/torchcodec/_core/__init__.py
@@ -40,6 +40,7 @@ from .ops import (
     get_frames_by_pts_in_range_audio,
     get_frames_in_range,
     get_json_metadata,
+    get_motion_vectors_at_indices,
     get_next_frame,
     scan_all_streams_to_update_metadata,
     seek_to_pts,

--- a/src/torchcodec/_core/custom_ops.cpp
+++ b/src/torchcodec/_core/custom_ops.cpp
@@ -48,9 +48,9 @@ TORCH_LIBRARY(torchcodec_ns, m) {
   m.def(
       "_create_from_file_like(int file_like_context, str? seek_mode=None) -> Tensor");
   m.def(
-      "_add_video_stream(Tensor(a!) decoder, *, int? num_threads=None, str? dimension_order=None, int? stream_index=None, str device=\"cpu\", str device_variant=\"ffmpeg\", str transform_specs=\"\", (Tensor, Tensor, Tensor)? custom_frame_mappings=None, str? color_conversion_library=None) -> ()");
+      "_add_video_stream(Tensor(a!) decoder, *, int? num_threads=None, str? dimension_order=None, int? stream_index=None, str device=\"cpu\", str device_variant=\"ffmpeg\", str transform_specs=\"\", bool? export_mvs=None, (Tensor, Tensor, Tensor)? custom_frame_mappings=None, str? color_conversion_library=None) -> ()");
   m.def(
-      "add_video_stream(Tensor(a!) decoder, *, int? num_threads=None, str? dimension_order=None, int? stream_index=None, str device=\"cpu\", str device_variant=\"ffmpeg\", str transform_specs=\"\", (Tensor, Tensor, Tensor)? custom_frame_mappings=None) -> ()");
+      "add_video_stream(Tensor(a!) decoder, *, int? num_threads=None, str? dimension_order=None, int? stream_index=None, str device=\"cpu\", str device_variant=\"ffmpeg\", str transform_specs=\"\", bool? export_mvs=None, (Tensor, Tensor, Tensor)? custom_frame_mappings=None) -> ()");
   m.def(
       "add_audio_stream(Tensor(a!) decoder, *, int? stream_index=None, int? sample_rate=None, int? num_channels=None) -> ()");
   m.def("seek_to_pts(Tensor(a!) decoder, float seconds) -> ()");
@@ -61,6 +61,8 @@ TORCH_LIBRARY(torchcodec_ns, m) {
       "get_frame_at_index(Tensor(a!) decoder, *, int frame_index) -> (Tensor, Tensor, Tensor)");
   m.def(
       "get_frames_at_indices(Tensor(a!) decoder, *, Tensor frame_indices) -> (Tensor, Tensor, Tensor)");
+  m.def(
+      "get_motion_vectors_at_indices(Tensor(a!) decoder, *, Tensor frame_indices) -> (Tensor, Tensor, Tensor, Tensor, Tensor)");
   m.def(
       "get_frames_in_range(Tensor(a!) decoder, *, int start, int stop, int? step=None) -> (Tensor, Tensor, Tensor)");
   m.def(
@@ -143,6 +145,23 @@ using OpsFrameBatchOutput =
 
 OpsFrameBatchOutput makeOpsFrameBatchOutput(FrameBatchOutput& batch) {
   return std::make_tuple(batch.data, batch.ptsSeconds, batch.durationSeconds);
+}
+
+using OpsMotionVectorsBatchOutput = std::tuple<
+    torch::Tensor,
+    torch::Tensor,
+    torch::Tensor,
+    torch::Tensor,
+    torch::Tensor>;
+
+OpsMotionVectorsBatchOutput makeOpsMotionVectorsBatchOutput(
+    MotionVectorsBatchOutput& batch) {
+  return std::make_tuple(
+      batch.data,
+      batch.counts,
+      batch.ptsSeconds,
+      batch.durationSeconds,
+      batch.frameTypes);
 }
 
 // The elements of this tuple are all tensors that represent the concatenation
@@ -421,6 +440,7 @@ void _add_video_stream(
     std::string_view device = "cpu",
     std::string_view device_variant = "ffmpeg",
     std::string_view transform_specs = "",
+    std::optional<bool> export_mvs = std::nullopt,
     std::optional<std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>>
         custom_frame_mappings = std::nullopt,
     std::optional<std::string_view> color_conversion_library = std::nullopt) {
@@ -453,6 +473,7 @@ void _add_video_stream(
 
   videoStreamOptions.device = torch::Device(std::string(device));
   videoStreamOptions.deviceVariant = device_variant;
+  videoStreamOptions.exportMotionVectors = export_mvs.value_or(false);
 
   std::vector<Transform*> transforms =
       makeTransforms(std::string(transform_specs));
@@ -478,6 +499,7 @@ void add_video_stream(
     std::string_view device = "cpu",
     std::string_view device_variant = "ffmpeg",
     std::string_view transform_specs = "",
+    std::optional<bool> export_mvs = std::nullopt,
     const std::optional<
         std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>>&
         custom_frame_mappings = std::nullopt) {
@@ -489,6 +511,7 @@ void add_video_stream(
       device,
       device_variant,
       transform_specs,
+      export_mvs,
       custom_frame_mappings);
 }
 
@@ -553,6 +576,14 @@ OpsFrameBatchOutput get_frames_at_indices(
   auto videoDecoder = unwrapTensorToGetDecoder(decoder);
   auto result = videoDecoder->getFramesAtIndices(frame_indices);
   return makeOpsFrameBatchOutput(result);
+}
+
+OpsMotionVectorsBatchOutput get_motion_vectors_at_indices(
+    torch::Tensor& decoder,
+    const torch::Tensor& frame_indices) {
+  auto videoDecoder = unwrapTensorToGetDecoder(decoder);
+  auto result = videoDecoder->getMotionVectorsAtIndices(frame_indices);
+  return makeOpsMotionVectorsBatchOutput(result);
 }
 
 // Return the frames inside a range as a single stacked Tensor. The range is
@@ -1082,6 +1113,7 @@ TORCH_LIBRARY_IMPL(torchcodec_ns, CPU, m) {
   m.impl("get_frame_at_pts", &get_frame_at_pts);
   m.impl("get_frame_at_index", &get_frame_at_index);
   m.impl("get_frames_at_indices", &get_frames_at_indices);
+  m.impl("get_motion_vectors_at_indices", &get_motion_vectors_at_indices);
   m.impl("get_frames_in_range", &get_frames_in_range);
   m.impl("get_frames_by_pts_in_range", &get_frames_by_pts_in_range);
   m.impl("get_frames_by_pts_in_range_audio", &get_frames_by_pts_in_range_audio);

--- a/test/test_decoders.py
+++ b/test/test_decoders.py
@@ -11,7 +11,7 @@ from functools import partial
 import numpy
 import pytest
 import torch
-from torchcodec import _core, ffmpeg_major_version, FrameBatch
+from torchcodec import _core, ffmpeg_major_version, FrameBatch, MotionVectorBatch
 from torchcodec.decoders import (
     AudioDecoder,
     AudioStreamMetadata,
@@ -600,6 +600,92 @@ class TestVideoDecoder:
         torch.testing.assert_close(
             frames.duration_seconds, expected_duration_seconds, atol=1e-4, rtol=0
         )
+
+    def test_get_frames_at_empty_indices(self):
+        decoder = VideoDecoder(NASA_VIDEO.path, device="cpu")
+        frames = decoder.get_frames_at([])
+
+        assert isinstance(frames, FrameBatch)
+        assert frames.data.shape[0] == 0
+        assert frames.pts_seconds.shape == (0,)
+        assert frames.duration_seconds.shape == (0,)
+
+    def test_get_motion_vectors_at(self):
+        decoder = VideoDecoder(NASA_VIDEO.path, device="cpu", export_mvs=True)
+        motion_vectors = decoder.get_motion_vectors_at([0, 1, 2])
+
+        assert isinstance(motion_vectors, MotionVectorBatch)
+        assert motion_vectors.data.shape[0] == 3
+        assert motion_vectors.data.shape[2] == 10
+        assert motion_vectors.counts.shape == (3,)
+        assert motion_vectors.pts_seconds.shape == (3,)
+        assert motion_vectors.duration_seconds.shape == (3,)
+        assert motion_vectors.frame_types.shape == (3,)
+        assert motion_vectors.data.dtype == torch.int32
+        assert motion_vectors.counts.dtype == torch.int32
+        assert motion_vectors.frame_types.dtype == torch.int32
+        assert motion_vectors.pts_seconds.dtype == torch.float64
+        assert motion_vectors.duration_seconds.dtype == torch.float64
+        assert int(motion_vectors.counts.max()) <= motion_vectors.data.shape[1]
+
+    def test_get_motion_vectors_at_requires_export(self):
+        decoder = VideoDecoder(NASA_VIDEO.path)
+        with pytest.raises(RuntimeError, match="export_mvs=True"):
+            decoder.get_motion_vectors_at([0])
+
+    def test_get_motion_vectors_at_empty_indices(self):
+        decoder = VideoDecoder(NASA_VIDEO.path, device="cpu", export_mvs=True)
+        motion_vectors = decoder.get_motion_vectors_at([])
+
+        assert isinstance(motion_vectors, MotionVectorBatch)
+        assert motion_vectors.data.shape == (0, 0, 10)
+        assert motion_vectors.counts.shape == (0,)
+        assert motion_vectors.pts_seconds.shape == (0,)
+        assert motion_vectors.duration_seconds.shape == (0,)
+        assert motion_vectors.frame_types.shape == (0,)
+        assert motion_vectors.data.dtype == torch.int32
+        assert motion_vectors.counts.dtype == torch.int32
+        assert motion_vectors.frame_types.dtype == torch.int32
+        assert motion_vectors.pts_seconds.dtype == torch.float64
+        assert motion_vectors.duration_seconds.dtype == torch.float64
+
+    def test_get_motion_vectors_at_unsorted_and_duplicate_indices(self):
+        decoder = VideoDecoder(NASA_VIDEO.path, device="cpu", export_mvs=True)
+        indices = [2, 0, 2, 1]
+        batch = decoder.get_motion_vectors_at(indices)
+
+        assert isinstance(batch, MotionVectorBatch)
+        assert batch.data.shape[0] == len(indices)
+        assert batch.data.shape[2] == 10
+
+        for pos, idx in enumerate(indices):
+            single = decoder.get_motion_vectors_at([idx])
+            assert int(batch.counts[pos]) == int(single.counts[0])
+            assert int(batch.frame_types[pos]) == int(single.frame_types[0])
+            torch.testing.assert_close(
+                batch.pts_seconds[pos], single.pts_seconds[0], atol=1e-6, rtol=0
+            )
+            torch.testing.assert_close(
+                batch.duration_seconds[pos],
+                single.duration_seconds[0],
+                atol=1e-6,
+                rtol=0,
+            )
+
+            count = int(batch.counts[pos])
+            assert count <= batch.data.shape[1]
+            if count > 0:
+                torch.testing.assert_close(
+                    batch.data[pos, :count], single.data[0, :count]
+                )
+            if batch.data.shape[1] > count:
+                assert torch.all(batch.data[pos, count:] == 0)
+
+        torch.testing.assert_close(batch.data[0], batch.data[2])
+        assert int(batch.counts[0]) == int(batch.counts[2])
+        assert int(batch.frame_types[0]) == int(batch.frame_types[2])
+        torch.testing.assert_close(batch.pts_seconds[0], batch.pts_seconds[2])
+        torch.testing.assert_close(batch.duration_seconds[0], batch.duration_seconds[2])
 
     @pytest.mark.parametrize("device", all_supported_devices())
     @pytest.mark.parametrize("seek_mode", ("exact", "approximate"))

--- a/test/test_frame_dataclasses.py
+++ b/test/test_frame_dataclasses.py
@@ -1,6 +1,6 @@
 import pytest
 import torch
-from torchcodec import AudioSamples, Frame, FrameBatch
+from torchcodec import AudioSamples, Frame, FrameBatch, MotionVectorBatch
 
 
 def test_unpacking():
@@ -142,6 +142,44 @@ def test_framebatch_indexing():
     fb_fancy = fb[([0], [1])]  # select T=0 and N=1.
     assert isinstance(fb_fancy, FrameBatch)
     assert fb_fancy.data.shape == (1, C, H, W)
+
+
+def test_motion_vector_batch_error():
+    with pytest.raises(ValueError, match="data must be 3-dimensional"):
+        MotionVectorBatch(
+            data=torch.rand(2, 3),
+            counts=torch.zeros(2, dtype=torch.int32),
+            pts_seconds=torch.zeros(2),
+            duration_seconds=torch.zeros(2),
+            frame_types=torch.zeros(2, dtype=torch.int32),
+        )
+
+    with pytest.raises(ValueError, match="counts must be 1D"):
+        MotionVectorBatch(
+            data=torch.zeros(2, 1, 10),
+            counts=torch.zeros(2, 1, dtype=torch.int32),
+            pts_seconds=torch.zeros(2),
+            duration_seconds=torch.zeros(2),
+            frame_types=torch.zeros(2, dtype=torch.int32),
+        )
+
+    with pytest.raises(ValueError, match="frame_types must be 1D"):
+        MotionVectorBatch(
+            data=torch.zeros(2, 1, 10),
+            counts=torch.zeros(2, dtype=torch.int32),
+            pts_seconds=torch.zeros(2),
+            duration_seconds=torch.zeros(2),
+            frame_types=torch.zeros(2, 1, dtype=torch.int32),
+        )
+
+    with pytest.raises(ValueError, match="counts must be 1D with length 2"):
+        MotionVectorBatch(
+            data=torch.zeros(2, 1, 10),
+            counts=torch.zeros(3, dtype=torch.int32),
+            pts_seconds=torch.zeros(2),
+            duration_seconds=torch.zeros(2),
+            frame_types=torch.zeros(2, dtype=torch.int32),
+        )
 
 
 def test_audio_samples_error():


### PR DESCRIPTION
Adds API support for extracting FFmpeg motion vectors from decoded video frames in torchcodec (CPU-only) and exposes them as a new MotionVectorBatch return type.

Missing GPU support see: https://github.com/NVIDIA/DALI/issues/5363.

FIXES: #1218 