### PR TITLE
Direct link to libpython3.so is not needed

### DIFF
--- a/src/torchcodec/_core/CMakeLists.txt
+++ b/src/torchcodec/_core/CMakeLists.txt
@@ -169,7 +169,7 @@ function(make_torchcodec_libraries
     )
     set(custom_ops_dependencies
         ${core_library_name}
-        ${Python3_LIBRARIES}
+        ""
     )
     make_torchcodec_sublibrary(
         "${custom_ops_library_name}"


### PR DESCRIPTION
There is no need to link custom_ops libraries directly against the libpython as python interpreter will load the python related dependencies at runtime.

Building, linking and execution of applications using torchcodec will work without linking the custom_ops libraries directly against the libpython-library.

I have tested this fix on environment which have
python 3.12 installed but does not have separate libpython library installed.

Related to: https://github.com/meta-pytorch/torchcodec/issues/1164