### PR TITLE
[video][cuda][beta] decoder caps cache

### DIFF
--- a/src/torchcodec/_core/BetaCudaDeviceInterface.cpp
+++ b/src/torchcodec/_core/BetaCudaDeviceInterface.cpp
@@ -69,7 +69,6 @@ static DecoderCapsCache& getDecoderCapsCache() {
   return cache;
 }
 
-
 static bool g_cuda_beta = registerDeviceInterface(
     DeviceInterfaceKey(torch::kCUDA, /*variant=*/"beta"),
     [](const torch::Device& device) {


### PR DESCRIPTION
# Summary

Creates a cache for GPU decoder (`cuda:beta`) caps data to avoid calling `cuvidGetDecoderCaps` each time.

Significantly improves decoder throughput.
On the plot below, benchmark results for a sample video (resolution 1280x720, 30 fps, 385 frames long) are summarized:

<img width="991" height="611" alt="Screenshot 2026-02-10 at 11 09 34" src="https://github.com/user-attachments/assets/2136afc7-fd33-4347-8615-d6f7d83ea8a4" />

Here throughput (number of decoded frames per second) is plotted against the number of decoder workers for different sampling schemes. 15 frames are sampled from the video with different frame steps (step 1 = 15 consecutive frames (0 - 14); step 2 = frames 0, 2, 4, 6, 8, ...; step 3 = frames 0, 3, 6, 9, ...)

Solid lines correspond to benchmark results with caps cache (this PR), dashed lines of the same color correspond to similar benchmark results without cache (before this PR).

We see that decoder performance in terms of throughput is strictly superior with cache enabled.

Average gain per number of decoder workers (averaged across sampling schemes):

| # workers |  2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Average Gain | 49% | 55% | 78% | 52% | 40% | 34% | 33% | 31% | 29% |

Video encoding details:
```
Video: h264 (Main) (avc1 / 0x31637661), yuv420p(tv, smpte170m/bt470bg/smpte170m, progressive), 720x1280, 4464 kb/s, 30 fps, 30 tbr, 15360 tbn
```