### PR TITLE
[video][cuda][beta] decoder nvtx annotations

### DIFF
--- a/src/torchcodec/_core/BetaCudaDeviceInterface.cpp
+++ b/src/torchcodec/_core/BetaCudaDeviceInterface.cpp
@@ -27,9 +27,22 @@ extern "C" {
 }
 
 #ifdef USE_NVTX
-#include "nvtx3/nvtx3.hpp"
+#include "nvtx3/nvToolsExt.h"
 
-#define NVTX_SCOPED_RANGE(NAME) nvtx3::scoped_range NVTX_RANGE_##__LINE__{NAME};
+struct NvtxRange {
+  explicit NvtxRange(const char* name) {
+    nvtxRangePushA(name);
+  }
+
+  ~NvtxRange() {
+    nvtxRangePop();
+  }
+
+  NvtxRange(const NvtxRange&) = delete;
+  NvtxRange& operator=(const NvtxRange&) = delete;
+};
+
+#define NVTX_SCOPED_RANGE(NAME) NvtxRange NVTX_RANGE_##__LINE__{NAME};
 #else
 #define NVTX_SCOPED_RANGE(NAME) ((void)0)
 #endif

--- a/src/torchcodec/_core/CMakeLists.txt
+++ b/src/torchcodec/_core/CMakeLists.txt
@@ -8,23 +8,6 @@ find_package(pybind11 REQUIRED)
 find_package(Torch REQUIRED)
 find_package(Python3 ${PYTHON_VERSION} EXACT COMPONENTS Development)
 
-# NVTX support - read env variable into a normal variable
-set(USE_NVTX_ENV OFF)
-if(DEFINED ENV{USE_NVTX})
-    if($ENV{USE_NVTX} STREQUAL "1" OR $ENV{USE_NVTX} STREQUAL "ON")
-        set(USE_NVTX_ENV ON)
-    endif()
-endif()
-
-# NVTX support - only if ENABLE_CUDA is set
-include(CMakeDependentOption)
-cmake_dependent_option(
-    USE_NVTX
-    "Enable NVTX annotations for profiling (requires CUDA)"
-    ${USE_NVTX_ENV}  # default if dependency satisfied
-    "ENABLE_CUDA"    # dependency
-    OFF  # value if dependency not satisfied
-)
 
 if(DEFINED TORCHCODEC_DISABLE_COMPILE_WARNING_AS_ERROR AND TORCHCODEC_DISABLE_COMPILE_WARNING_AS_ERROR)
     set(TORCHCODEC_WERROR_OPTION "")
@@ -75,10 +58,6 @@ function(make_torchcodec_sublibrary
     # torch, we want to rely on the "header-only" mode of these headers and hit
     # all the `#ifdef FMT_HEADER_ONLY` paths, so we define FMT_HEADER_ONLY here.```
     target_compile_definitions(${library_name} PRIVATE FMT_HEADER_ONLY)
-
-    if(USE_NVTX)
-        target_compile_definitions(${library_name} PRIVATE USE_NVTX)
-    endif()
 
     # Avoid adding the "lib" prefix which we already add explicitly.
     set_target_properties(${library_name} PROPERTIES PREFIX "")
@@ -182,6 +161,13 @@ function(make_torchcodec_libraries
         "${core_sources}"
         "${core_library_dependencies}"
     )
+
+    if(ENABLE_CUDA AND USE_NVTX)
+        target_compile_definitions(${core_library_name} PRIVATE USE_NVTX)
+        if(NVTX_INCLUDE_DIR)
+            target_include_directories(${core_library_name} PRIVATE ${NVTX_INCLUDE_DIR})
+        endif()
+    endif()
 
     # 2. Create libtorchcodec_custom_opsN.{ext}.
     set(custom_ops_library_name "libtorchcodec_custom_ops${ffmpeg_major_version}")


### PR DESCRIPTION
# Summary

Introduces `USE_NVTX` CMake flag, which, if enabled, defines `USE_NVTX` C++ preprocessor macro.
The `USE_NVTX` macro defined whether NVTX annotations shold be added to the `cuda:beta` interface of `torchcodec`. NVTX annotations facilitate reading and analyzing data collected by NSight profiler.

### Profile With Annotations (this PR)
Command line:
```
nsys profile \
--trace=cuda,nvtx,nvvideo,osrt \
--cuda-memory-usage=true \
--capture-range=none \
--sample=none \
-o nsight_report \
python3 <script> <arg0> <arg1> ...
```

Profile (note NVTX annotations related to decoder instantiation and frames decoding):
<img width="1301" height="275" alt="Screenshot 2026-02-10 at 14 01 45" src="https://github.com/user-attachments/assets/301fda13-d352-406c-ae82-98c0489e6a26" />

### Profile Without Annotations (before)
Same command line, profile (no NVTX annotations):
<img width="1285" height="135" alt="Screenshot 2026-02-10 at 14 04 38" src="https://github.com/user-attachments/assets/5c2c7880-29de-4d1b-ae71-32477d65753a" />

Note: used NSight 2026.1.1 to visualize both profiles

# Test Plan

1. Tested `torchcodec` build with NVTX annotations enabled via an environment variable:
```
USE_NVTX=1 ENABLE_CUDA=1 pip install -e . --no-build-isolation -vv
```
and verified CMake cache entry:
```
//Enable NVTX annotations for profiling (requires CUDA)
USE_NVTX:BOOL=ON
```
Used this build to produce profile with NVTX annotations.

2. Tested `torchcodec` build with NVTX annotations enabled via an environment variable, but disabled by CMake when `ENABLE_CUDA` is not set:
```
USE_NVTX=1 pip install -e . --no-build-isolation -vv
```
Observed the following message on build:
```
  CMake Warning at src/torchcodec/_core/CMakeLists.txt:17 (message): 
  USE_NVTX requires ENABLE_CUDA=ON.  Disabling USE_NVTX.
```
and the following entry in `CMakeCache.txt`:
```
//Enable NVTX annotations for profiling (requires CUDA)
USE_NVTX:BOOL=OFF
```

3. Tested `torchcodec` build with NVTX annotations not enabled explicitly, with `ENABLE_CUDA=1`:
```
ENABLE_CUDA=1 pip install -e . --no-build-isolation -vv
```
and verified the CMake cache entry:
```
//Enable NVTX annotations for profiling (requires CUDA)
USE_NVTX:BOOL=OFF
```

4. Tested `torchcodec` build without any environment variables:
```
pip install -e . --no-build-isolation -vv
```
and verified the CMake cache entry:
```
//Enable NVTX annotations for profiling (requires CUDA)
USE_NVTX:BOOL=OFF
```