### PR TITLE
[video][cuda][beta] decoder cache with multimap

### DIFF
--- a/src/torchcodec/_core/NVDECCache.cpp
+++ b/src/torchcodec/_core/NVDECCache.cpp
@@ -29,11 +29,15 @@ UniqueCUvideodecoder NVDECCache::getDecoder(CUVIDEOFORMAT* videoFormat) {
   CacheKey key(videoFormat);
   std::lock_guard<std::mutex> lock(cacheLock_);
 
-  auto it = cache_.find(key);
-  if (it != cache_.end()) {
-    auto decoder = std::move(it->second);
-    cache_.erase(it);
-    return decoder;
+  // Find all entries with matching key and look for one not in use
+  auto range = cache_.equal_range(key);
+  for (auto it = range.first; it != range.second; ++it) {
+    if (!it->second.inUse) {
+      // Take ownership of the decoder and remove the entry from cache
+      auto decoder = std::move(it->second.decoder);
+      cache_.erase(it);
+      return decoder;
+    }
   }
 
   return nullptr;
@@ -53,7 +57,8 @@ bool NVDECCache::returnDecoder(
     return false;
   }
 
-  cache_[key] = std::move(decoder);
+  // Add the decoder back to cache as not in use
+  cache_.emplace(key, CacheEntry(std::move(decoder), false));
   return true;
 }
 

--- a/src/torchcodec/_core/NVDECCache.h
+++ b/src/torchcodec/_core/NVDECCache.h
@@ -35,16 +35,30 @@ struct CUvideoDecoderDeleter {
 using UniqueCUvideodecoder =
     std::unique_ptr<CUvideodecoder, CUvideoDecoderDeleter>;
 
+// Cache entry that holds a decoder and tracks whether it's currently in use.
+struct CacheEntry {
+  UniqueCUvideodecoder decoder;
+  bool inUse;
+
+  CacheEntry(UniqueCUvideodecoder dec, bool used)
+      : decoder(std::move(dec)), inUse(used) {}
+};
+
 // A per-device cache for NVDEC decoders. There is one instance of this class
 // per GPU device, and it is accessed through the static getCache() method.
+// The cache supports multiple decoders with the same parameters, tracking
+// which ones are currently in use.
 class NVDECCache {
  public:
   static NVDECCache& getCache(const torch::Device& device);
 
-  // Get decoder from cache - returns nullptr if none available
+  // Get decoder from cache - returns nullptr if none available.
+  // The returned decoder is marked as "in use" until returned via
+  // returnDecoder.
   UniqueCUvideodecoder getDecoder(CUVIDEOFORMAT* videoFormat);
 
-  // Return decoder to cache - returns true if added to cache
+  // Return decoder to cache - marks the decoder as not in use.
+  // Returns true if the decoder was successfully returned to cache.
   bool returnDecoder(CUVIDEOFORMAT* videoFormat, UniqueCUvideodecoder decoder);
 
  private:
@@ -92,7 +106,7 @@ class NVDECCache {
   NVDECCache() = default;
   ~NVDECCache() = default;
 
-  std::map<CacheKey, UniqueCUvideodecoder> cache_;
+  std::multimap<CacheKey, CacheEntry> cache_;
   std::mutex cacheLock_;
 
   // Max number of cached decoders, per device


### PR DESCRIPTION
# Summary

Made cache storage a `std::multimap` to allow decoders with similar format to be cached by different workers.

Significantly improves decoder throughput and scaling with the number of workers.

On the plot below, benchmark results for a sample video (resolution 1280x720, 30 fps, 385 frames long) are summarized:

<img width="991" height="612" alt="Screenshot 2026-02-11 at 10 06 44" src="https://github.com/user-attachments/assets/505c9f6c-d5bf-4960-9539-bb171b7b13ea" />

Here throughput (number of decoded frames per second) is plotted against the number of decoder workers for different sampling schemes. 15 frames are sampled from the video with different frame steps (step 1 = 15 consecutive frames (0 - 14); step 2 = frames 0, 2, 4, 6, 8, ...; step 3 = frames 0, 3, 6, 9, ...)

Solid lines correspond to benchmark results with multimap-based cache (this PR), dashed lines of the same color correspond to similar benchmark results with map-based cache (before https://github.com/meta-pytorch/torchcodec/pull/1227).

We see that decoder performance in terms of throughput and scaling properties are way better with `multimap`-based cache proposed in this PR.

Average gain per number of decoder workers (averaged across sampling schemes):

| # workers |  2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Average Gain | 81% | 135% | 256% | 337% | 443% | 509% | 597% | 631% | 682% |

Video encoding details:
```
Video: h264 (Main) (avc1 / 0x31637661), yuv420p(tv, smpte170m/bt470bg/smpte170m, progressive), 720x1280, 4464 kb/s, 30 fps, 30 tbr, 15360 tbn
```
