### PR TITLE
Add XPU to the list of recognizable devices

### DIFF
--- a/src/torchcodec/_core/DeviceInterface.cpp
+++ b/src/torchcodec/_core/DeviceInterface.cpp
@@ -38,6 +38,8 @@ StableDeviceType parseDeviceType(const std::string& deviceType) {
     return kStableCPU;
   } else if (deviceType == "cuda") {
     return kStableCUDA;
+  } else if (deviceType == "xpu") {
+    return kStableXPU;
   } else {
     STD_TORCH_CHECK(false, "Unknown device type: ", deviceType);
   }

--- a/src/torchcodec/_core/StableABICompat.h
+++ b/src/torchcodec/_core/StableABICompat.h
@@ -44,5 +44,6 @@ using StableDeviceGuard = torch::stable::accelerator::DeviceGuard;
 // Device type constants
 constexpr auto kStableCPU = torch::headeronly::DeviceType::CPU;
 constexpr auto kStableCUDA = torch::headeronly::DeviceType::CUDA;
+constexpr auto kStableXPU = torch::headeronly::DeviceType::XPU;
 
 } // namespace facebook::torchcodec


### PR DESCRIPTION
The 6f10da0 switched to torch::stable::Device and introduced a check of the device by name which broke torchcodec external plugins registration support. This PR fixes that in a straight forward way - adds the XPU in the list. @NicolasHug , you might wish to generalize this check somehow to avoid hardcoding CPU, CUDA, XPU altogether. Please, help to resolve this issue before the next torchcodec v0.11.0 release.

Fixes: 6f10da0 ("Use `torch::stable::Device` (#1231)")