### PR TITLE
Set num_ffmpeg_threads to 1 on AudioDecoder

### DIFF
--- a/src/torchcodec/_core/SingleStreamDecoder.cpp
+++ b/src/torchcodec/_core/SingleStreamDecoder.cpp
@@ -615,6 +615,9 @@ void SingleStreamDecoder::addAudioStream(
         *audioStreamOptions.numChannels);
   }
 
+  // We hardcode ffmpegThreadCount=1 for audio, see
+  // https://github.com/pytorch/torchcodec/issues/1253 and
+  // https://github.com/pytorch/torchcodec/pull/1254
   addStream(
       streamIndex, AVMEDIA_TYPE_AUDIO, StableDevice(kStableCPU), "ffmpeg", 1);
 


### PR DESCRIPTION
Set `num_ffmpeg_threads` parameter to 1 on AudioDecoder to avoid oversubscription

Related issue: #1253