### PR TITLE
Restore +cpu to CPU wheels

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -202,14 +202,12 @@ def _write_version_files():
         # the content of `version.txt` plus some suffix like "+cpu" or "+cu112".
         # See
         # https://github.com/pytorch/test-infra/blob/61e6da7a6557152eb9879e461a26ad667c15f0fd/tools/pkg-helpers/pytorch_pkg_helpers/version.py#L113
-        version = version.replace("+cpu", "")
         with open(_ROOT_DIR / "version.txt", "w") as f:
             f.write(f"{version}")
     else:
         with open(_ROOT_DIR / "version.txt") as f:
             version = f.readline().strip()
         try:
-            version = version.replace("+cpu", "")
             sha = (
                 subprocess.check_output(
                     ["git", "rev-parse", "HEAD"], cwd=str(_ROOT_DIR)


### PR DESCRIPTION
In the past, we had to remove the `+cpu` suffix from wheels to be able to upload them to PyPI. 

In the upcoming release, we will onboard to the updated [test-infra release process](https://github.com/pytorch/test-infra/wiki/Releasing-to-download.pytorch.org-and-pypi), which will handle removing suffixes. 

To be more inline with other repos, this PR restores the `+cpu` suffix.

### Testing
The [logs](https://github.com/meta-pytorch/torchcodec/actions/runs/22589761455/job/65444331276?pr=1269) indicate CPU wheels have the `cpu` suffix:
`creating '/__w/torchcodec/torchcodec/meta-pytorch/torchcodec/dist/.tmp-obsbzlnz/torchcodec-0.11.0.dev20260302+cpu-cp310-cp310-linux_x86_64.whl' and adding 'build/bdist.linux-x86_64/wheel' to it`
