### PR TITLE
[8/12] Upgrade torchcodec build configs to C++20

### DIFF
--- a/src/torchcodec/_core/CMakeLists.txt
+++ b/src/torchcodec/_core/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.18)
 project(TorchCodec)
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(PYBIND11_FINDPYTHON ON)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 include(CMakePrintHelpers)
 project(TorchCodecTests)
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED)
 
 find_package(Torch REQUIRED)


### PR DESCRIPTION
Summary:
Update CMAKE_CXX_STANDARD from 17 to 20 in torchcodec's
CMakeLists.txt files (main and test).

Differential Revision: D95101179


