### PR TITLE
[8/12] Upgrade torchcodec build configs to C++20

### DIFF
--- a/src/torchcodec/_core/CMakeLists.txt
+++ b/src/torchcodec/_core/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.18)
 project(TorchCodec)
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(PYBIND11_FINDPYTHON ON)
@@ -44,7 +44,7 @@ function(make_torchcodec_sublibrary
     library_dependencies)
 
     add_library(${library_name} ${type} ${sources})
-    set_target_properties(${library_name} PROPERTIES CXX_STANDARD 17)
+    set_target_properties(${library_name} PROPERTIES CXX_STANDARD 20)
     target_include_directories(${library_name}
         PRIVATE
         ./../../../

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 include(CMakePrintHelpers)
 project(TorchCodecTests)
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED)
 
 find_package(Torch REQUIRED)


### PR DESCRIPTION
PyTorch is [moving to C++20](https://github.com/pytorch/pytorch/issues/176662). Putting up this PR to keep the ecosystem in sync.

Summary:
Update CMAKE_CXX_STANDARD from 17 to 20 in torchcodec's
CMakeLists.txt files (main and test).

Reviewed By: meyering

Differential Revision: D95103076


