### PR TITLE
Address internal lint

### DIFF
--- a/src/torchcodec/_core/CUDACommon.cpp
+++ b/src/torchcodec/_core/CUDACommon.cpp
@@ -8,6 +8,7 @@
 #include <torch/csrc/inductor/aoti_torch/c/shim.h>
 #include "Cache.h" // for PerGpuCache
 #include "StableABICompat.h"
+#include "ValidationUtils.h"
 
 namespace facebook::torchcodec {
 
@@ -381,7 +382,7 @@ torch::stable::Tensor convertNV12FrameToRGB(
           yuvData,
           srcStep,
           dst.mutable_data_ptr<Npp8u>(),
-          static_cast<int>(dst.stride(0)),
+          validateInt64ToInt(dst.stride(0), "dst.stride(0)"),
           oSizeROI,
           bt601FullRangeColorTwist,
           *nppCtx);
@@ -395,7 +396,7 @@ torch::stable::Tensor convertNV12FrameToRGB(
           yuvData,
           srcStep,
           dst.mutable_data_ptr<Npp8u>(),
-          static_cast<int>(dst.stride(0)),
+          validateInt64ToInt(dst.stride(0), "dst.stride(0)"),
           oSizeROI,
           bt601LimitedRangeColorTwist,
           *nppCtx);


### PR DESCRIPTION
Address some internal lints from https://www.internalfb.com/diff/D95819469, mainly to avoid implicit conversion