### PR TITLE
Further consolidate AudioDecoder creation with unified C++ ops

### DIFF
--- a/src/torchcodec/_core/SingleStreamDecoder.cpp
+++ b/src/torchcodec/_core/SingleStreamDecoder.cpp
@@ -658,28 +658,25 @@ void SingleStreamDecoder::addAudioStream(
 }
 
 // --------------------------------------------------------------------------
-// STATIC FACTORY METHODS
+// AUDIO STREAM CONSTRUCTORS
 // --------------------------------------------------------------------------
 
-std::unique_ptr<SingleStreamDecoder> SingleStreamDecoder::createAudioDecoder(
+SingleStreamDecoder::SingleStreamDecoder(
     const std::string& audioFilePath,
     SeekMode seekMode,
     int streamIndex,
-    const AudioStreamOptions& audioStreamOptions) {
-  auto decoder = std::make_unique<SingleStreamDecoder>(audioFilePath, seekMode);
-  decoder->addAudioStream(streamIndex, audioStreamOptions);
-  return decoder;
+    const AudioStreamOptions& audioStreamOptions)
+    : SingleStreamDecoder(audioFilePath, seekMode) {
+  addAudioStream(streamIndex, audioStreamOptions);
 }
 
-std::unique_ptr<SingleStreamDecoder> SingleStreamDecoder::createAudioDecoder(
+SingleStreamDecoder::SingleStreamDecoder(
     std::unique_ptr<AVIOContextHolder> context,
     SeekMode seekMode,
     int streamIndex,
-    const AudioStreamOptions& audioStreamOptions) {
-  auto decoder =
-      std::make_unique<SingleStreamDecoder>(std::move(context), seekMode);
-  decoder->addAudioStream(streamIndex, audioStreamOptions);
-  return decoder;
+    const AudioStreamOptions& audioStreamOptions)
+    : SingleStreamDecoder(std::move(context), seekMode) {
+  addAudioStream(streamIndex, audioStreamOptions);
 }
 
 // --------------------------------------------------------------------------

--- a/src/torchcodec/_core/SingleStreamDecoder.cpp
+++ b/src/torchcodec/_core/SingleStreamDecoder.cpp
@@ -658,6 +658,31 @@ void SingleStreamDecoder::addAudioStream(
 }
 
 // --------------------------------------------------------------------------
+// STATIC FACTORY METHODS
+// --------------------------------------------------------------------------
+
+std::unique_ptr<SingleStreamDecoder> SingleStreamDecoder::createAudioDecoder(
+    const std::string& audioFilePath,
+    SeekMode seekMode,
+    int streamIndex,
+    const AudioStreamOptions& audioStreamOptions) {
+  auto decoder = std::make_unique<SingleStreamDecoder>(audioFilePath, seekMode);
+  decoder->addAudioStream(streamIndex, audioStreamOptions);
+  return decoder;
+}
+
+std::unique_ptr<SingleStreamDecoder> SingleStreamDecoder::createAudioDecoder(
+    std::unique_ptr<AVIOContextHolder> context,
+    SeekMode seekMode,
+    int streamIndex,
+    const AudioStreamOptions& audioStreamOptions) {
+  auto decoder =
+      std::make_unique<SingleStreamDecoder>(std::move(context), seekMode);
+  decoder->addAudioStream(streamIndex, audioStreamOptions);
+  return decoder;
+}
+
+// --------------------------------------------------------------------------
 // HIGH-LEVEL DECODING ENTRY-POINTS
 // --------------------------------------------------------------------------
 

--- a/src/torchcodec/_core/SingleStreamDecoder.h
+++ b/src/torchcodec/_core/SingleStreamDecoder.h
@@ -97,6 +97,28 @@ class FORCE_PUBLIC_VISIBILITY SingleStreamDecoder {
       const AudioStreamOptions& audioStreamOptions = AudioStreamOptions());
 
   // --------------------------------------------------------------------------
+  // STATIC FACTORY METHODS
+  // --------------------------------------------------------------------------
+  // These factory methods create a SingleStreamDecoder and add a stream in one
+  // step, matching the public Python API. They consolidate the two-step pattern
+  // of construction + addStream into a single call.
+
+  // Creates an audio decoder from a file path with stream already added.
+  static std::unique_ptr<SingleStreamDecoder> createAudioDecoder(
+      const std::string& audioFilePath,
+      SeekMode seekMode,
+      int streamIndex,
+      const AudioStreamOptions& audioStreamOptions = AudioStreamOptions());
+
+  // Creates an audio decoder from an AVIOContextHolder with stream already
+  // added.
+  static std::unique_ptr<SingleStreamDecoder> createAudioDecoder(
+      std::unique_ptr<AVIOContextHolder> context,
+      SeekMode seekMode,
+      int streamIndex,
+      const AudioStreamOptions& audioStreamOptions = AudioStreamOptions());
+
+  // --------------------------------------------------------------------------
   // DECODING AND SEEKING APIs
   // --------------------------------------------------------------------------
 

--- a/src/torchcodec/_core/SingleStreamDecoder.h
+++ b/src/torchcodec/_core/SingleStreamDecoder.h
@@ -103,15 +103,12 @@ class FORCE_PUBLIC_VISIBILITY SingleStreamDecoder {
   // step, matching the public Python API. They consolidate the two-step pattern
   // of construction + addStream into a single call.
 
-  // Creates an audio decoder from a file path with stream already added.
   static std::unique_ptr<SingleStreamDecoder> createAudioDecoder(
       const std::string& audioFilePath,
       SeekMode seekMode,
       int streamIndex,
       const AudioStreamOptions& audioStreamOptions = AudioStreamOptions());
 
-  // Creates an audio decoder from an AVIOContextHolder with stream already
-  // added.
   static std::unique_ptr<SingleStreamDecoder> createAudioDecoder(
       std::unique_ptr<AVIOContextHolder> context,
       SeekMode seekMode,

--- a/src/torchcodec/_core/SingleStreamDecoder.h
+++ b/src/torchcodec/_core/SingleStreamDecoder.h
@@ -44,6 +44,21 @@ class FORCE_PUBLIC_VISIBILITY SingleStreamDecoder {
       std::unique_ptr<AVIOContextHolder> context,
       SeekMode seekMode = SeekMode::exact);
 
+  // Creates a SingleStreamDecoder from a file path with audio stream added.
+  SingleStreamDecoder(
+      const std::string& audioFilePath,
+      SeekMode seekMode,
+      int streamIndex,
+      const AudioStreamOptions& audioStreamOptions);
+
+  // Creates a SingleStreamDecoder using the provided AVIOContext with audio
+  // stream added.
+  SingleStreamDecoder(
+      std::unique_ptr<AVIOContextHolder> context,
+      SeekMode seekMode,
+      int streamIndex,
+      const AudioStreamOptions& audioStreamOptions);
+
   // --------------------------------------------------------------------------
   // VIDEO METADATA QUERY API
   // --------------------------------------------------------------------------
@@ -93,25 +108,6 @@ class FORCE_PUBLIC_VISIBILITY SingleStreamDecoder {
       const VideoStreamOptions& videoStreamOptions = VideoStreamOptions(),
       std::optional<FrameMappings> customFrameMappings = std::nullopt);
   void addAudioStream(
-      int streamIndex,
-      const AudioStreamOptions& audioStreamOptions = AudioStreamOptions());
-
-  // --------------------------------------------------------------------------
-  // STATIC FACTORY METHODS
-  // --------------------------------------------------------------------------
-  // These factory methods create a SingleStreamDecoder and add a stream in one
-  // step, matching the public Python API. They consolidate the two-step pattern
-  // of construction + addStream into a single call.
-
-  static std::unique_ptr<SingleStreamDecoder> createAudioDecoder(
-      const std::string& audioFilePath,
-      SeekMode seekMode,
-      int streamIndex,
-      const AudioStreamOptions& audioStreamOptions = AudioStreamOptions());
-
-  static std::unique_ptr<SingleStreamDecoder> createAudioDecoder(
-      std::unique_ptr<AVIOContextHolder> context,
-      SeekMode seekMode,
       int streamIndex,
       const AudioStreamOptions& audioStreamOptions = AudioStreamOptions());
 

--- a/src/torchcodec/_core/_decoder_utils.py
+++ b/src/torchcodec/_core/_decoder_utils.py
@@ -39,8 +39,7 @@ def create_audio_decoder(
     sample_rate: int | None = None,
     num_channels: int | None = None,
 ) -> tuple[Tensor, int, AudioStreamMetadata]:
-    # Use unified audio decoder op that creates decoder and adds stream in one step
-    # Validation is done inside _create_audio_decoder_op
+
     decoder = _create_audio_decoder_op(
         source,
         stream_index=stream_index,
@@ -48,10 +47,8 @@ def create_audio_decoder(
         num_channels=num_channels,
     )
 
-    # Get the actual stream index that was used (in case stream_index was None)
     actual_stream_index = get_active_stream_index(decoder)
 
-    # Get metadata for the stream
     container_metadata = get_container_metadata(decoder)
     metadata = container_metadata.streams[actual_stream_index]
     if not isinstance(metadata, AudioStreamMetadata):

--- a/src/torchcodec/_core/_decoder_utils.py
+++ b/src/torchcodec/_core/_decoder_utils.py
@@ -16,12 +16,10 @@ from torchcodec._core._metadata import (
     VideoStreamMetadata,
 )
 from torchcodec._core.ops import (
-    add_audio_stream,
     add_video_stream,
-    create_from_bytes,
-    create_from_file,
-    create_from_file_like,
-    create_from_tensor,
+    create_audio_decoder as _create_audio_decoder_op,
+    create_decoder,
+    get_active_stream_index,
 )
 from torchcodec.transforms import DecoderTransform
 from torchcodec.transforms._decoder_transforms import _make_transform_specs
@@ -33,36 +31,6 @@ https://github.com/pytorch/torchcodec/issues/new?assignees=&labels=&projects=&te
 """
 
 
-def create_decoder(
-    *,
-    source: str | Path | io.RawIOBase | io.BufferedReader | bytes | Tensor,
-    seek_mode: str,
-) -> Tensor:
-    if isinstance(source, str):
-        return create_from_file(source, seek_mode)
-    elif isinstance(source, Path):
-        return create_from_file(str(source), seek_mode)
-    elif isinstance(source, io.RawIOBase) or isinstance(source, io.BufferedReader):
-        return create_from_file_like(source, seek_mode)
-    elif isinstance(source, bytes):
-        return create_from_bytes(source, seek_mode)
-    elif isinstance(source, Tensor):
-        return create_from_tensor(source, seek_mode)
-    elif isinstance(source, io.TextIOBase):
-        raise TypeError(
-            "source is for reading text, likely from open(..., 'r'). Try with 'rb' for binary reading?"
-        )
-    elif hasattr(source, "read") and hasattr(source, "seek"):
-        return create_from_file_like(source, seek_mode)
-
-    raise TypeError(
-        f"Unknown source type: {type(source)}. "
-        "Supported types are str, Path, bytes, Tensor and file-like objects with "
-        "read(self, size: int) -> bytes and "
-        "seek(self, offset: int, whence: int) -> int methods."
-    )
-
-
 def create_audio_decoder(
     *,
     source: str | Path | io.RawIOBase | io.BufferedReader | bytes | Tensor,
@@ -71,34 +39,27 @@ def create_audio_decoder(
     sample_rate: int | None = None,
     num_channels: int | None = None,
 ) -> tuple[Tensor, int, AudioStreamMetadata]:
-
-    decoder = create_decoder(source=source, seek_mode=seek_mode)
-
-    container_metadata = get_container_metadata(decoder)
-
-    if stream_index is None:
-        stream_index = container_metadata.best_audio_stream_index
-        if stream_index is None:
-            raise ValueError(
-                "The best audio stream is unknown and there is no specified stream. "
-                + _ERROR_REPORTING_INSTRUCTIONS
-            )
-
-    if stream_index >= len(container_metadata.streams):
-        raise ValueError(f"The stream at index {stream_index} is not a valid stream.")
-
-    metadata = container_metadata.streams[stream_index]
-    if not isinstance(metadata, AudioStreamMetadata):
-        raise ValueError(f"The stream at index {stream_index} is not an audio stream.")
-
-    add_audio_stream(
-        decoder,
+    # Use unified audio decoder op that creates decoder and adds stream in one step
+    # Validation is done inside _create_audio_decoder_op
+    decoder = _create_audio_decoder_op(
+        source,
         stream_index=stream_index,
         sample_rate=sample_rate,
         num_channels=num_channels,
     )
 
-    return (decoder, stream_index, metadata)
+    # Get the actual stream index that was used (in case stream_index was None)
+    actual_stream_index = get_active_stream_index(decoder)
+
+    # Get metadata for the stream
+    container_metadata = get_container_metadata(decoder)
+    metadata = container_metadata.streams[actual_stream_index]
+    if not isinstance(metadata, AudioStreamMetadata):
+        raise ValueError(
+            f"The stream at index {actual_stream_index} is not an audio stream."
+        )
+
+    return (decoder, actual_stream_index, metadata)
 
 
 def _get_and_validate_video_stream_metadata(

--- a/src/torchcodec/_core/custom_ops.cpp
+++ b/src/torchcodec/_core/custom_ops.cpp
@@ -557,13 +557,14 @@ torch::stable::Tensor create_audio_decoder_from_file(
   audioStreamOptions.sampleRate = sample_rate;
   audioStreamOptions.numChannels = num_channels;
 
-  auto decoder = SingleStreamDecoder::createAudioDecoder(
-      filename,
-      SeekMode::approximate,
-      stream_index.value_or(-1),
-      audioStreamOptions);
+  std::unique_ptr<SingleStreamDecoder> uniqueDecoder =
+      std::make_unique<SingleStreamDecoder>(
+          filename,
+          SeekMode::approximate,
+          stream_index.value_or(-1),
+          audioStreamOptions);
 
-  return wrapDecoderPointerToTensor(std::move(decoder));
+  return wrapDecoderPointerToTensor(std::move(uniqueDecoder));
 }
 
 torch::stable::Tensor create_audio_decoder_from_tensor(
@@ -584,13 +585,14 @@ torch::stable::Tensor create_audio_decoder_from_tensor(
   auto avioContextHolder =
       std::make_unique<AVIOFromTensorContext>(audio_tensor);
 
-  auto decoder = SingleStreamDecoder::createAudioDecoder(
-      std::move(avioContextHolder),
-      SeekMode::approximate,
-      stream_index.value_or(-1),
-      audioStreamOptions);
+  std::unique_ptr<SingleStreamDecoder> uniqueDecoder =
+      std::make_unique<SingleStreamDecoder>(
+          std::move(avioContextHolder),
+          SeekMode::approximate,
+          stream_index.value_or(-1),
+          audioStreamOptions);
 
-  return wrapDecoderPointerToTensor(std::move(decoder));
+  return wrapDecoderPointerToTensor(std::move(uniqueDecoder));
 }
 
 torch::stable::Tensor _create_audio_decoder_from_file_like(
@@ -608,13 +610,14 @@ torch::stable::Tensor _create_audio_decoder_from_file_like(
   audioStreamOptions.sampleRate = sample_rate;
   audioStreamOptions.numChannels = num_channels;
 
-  auto decoder = SingleStreamDecoder::createAudioDecoder(
-      std::move(avioContextHolder),
-      SeekMode::approximate,
-      stream_index.value_or(-1),
-      audioStreamOptions);
+  std::unique_ptr<SingleStreamDecoder> uniqueDecoder =
+      std::make_unique<SingleStreamDecoder>(
+          std::move(avioContextHolder),
+          SeekMode::approximate,
+          stream_index.value_or(-1),
+          audioStreamOptions);
 
-  return wrapDecoderPointerToTensor(std::move(decoder));
+  return wrapDecoderPointerToTensor(std::move(uniqueDecoder));
 }
 
 // --------------------------------------------------------------------------

--- a/src/torchcodec/_core/custom_ops.cpp
+++ b/src/torchcodec/_core/custom_ops.cpp
@@ -56,8 +56,6 @@ STABLE_TORCH_LIBRARY(torchcodec_ns, m) {
       "add_video_stream(Tensor(a!) decoder, *, int? num_threads=None, str? dimension_order=None, int? stream_index=None, str device=\"cpu\", str device_variant=\"ffmpeg\", str transform_specs=\"\", Tensor? custom_frame_mappings_pts=None, Tensor? custom_frame_mappings_duration=None, Tensor? custom_frame_mappings_keyframe_indices=None) -> ()");
   m.def(
       "add_audio_stream(Tensor(a!) decoder, *, int? stream_index=None, int? sample_rate=None, int? num_channels=None) -> ()");
-  // Unified audio decoder creation ops - these combine create +
-  // add_audio_stream
   m.def(
       "create_audio_decoder_from_file(str filename, *, int? stream_index=None, int? sample_rate=None, int? num_channels=None) -> Tensor");
   m.def(
@@ -550,13 +548,11 @@ void add_audio_stream(
 // UNIFIED AUDIO DECODER CREATION OPS
 // --------------------------------------------------------------------------
 
-// Create an audio decoder from file with stream already added.
 torch::stable::Tensor create_audio_decoder_from_file(
     std::string filename,
     std::optional<int64_t> stream_index = std::nullopt,
     std::optional<int64_t> sample_rate = std::nullopt,
     std::optional<int64_t> num_channels = std::nullopt) {
-  // Audio always uses approximate seek mode
   AudioStreamOptions audioStreamOptions;
   audioStreamOptions.sampleRate = sample_rate;
   audioStreamOptions.numChannels = num_channels;
@@ -570,7 +566,6 @@ torch::stable::Tensor create_audio_decoder_from_file(
   return wrapDecoderPointerToTensor(std::move(decoder));
 }
 
-// Create an audio decoder from tensor with stream already added.
 torch::stable::Tensor create_audio_decoder_from_tensor(
     const torch::stable::Tensor& audio_tensor,
     std::optional<int64_t> stream_index = std::nullopt,
@@ -598,7 +593,6 @@ torch::stable::Tensor create_audio_decoder_from_tensor(
   return wrapDecoderPointerToTensor(std::move(decoder));
 }
 
-// Create an audio decoder from file-like object with stream already added.
 torch::stable::Tensor _create_audio_decoder_from_file_like(
     int64_t file_like_context,
     std::optional<int64_t> stream_index = std::nullopt,
@@ -627,7 +621,6 @@ torch::stable::Tensor _create_audio_decoder_from_file_like(
 // STREAM INFO OP
 // --------------------------------------------------------------------------
 
-// Get the active stream index from the decoder.
 int64_t get_active_stream_index(torch::stable::Tensor& decoder) {
   auto videoDecoder = unwrapTensorToGetDecoder(decoder);
   return videoDecoder->getActiveStreamIndex();
@@ -1234,7 +1227,6 @@ STABLE_TORCH_LIBRARY_IMPL(torchcodec_ns, BackendSelect, m) {
   m.impl("set_nvdec_cache_capacity", TORCH_BOX(&set_nvdec_cache_capacity));
   m.impl("get_nvdec_cache_capacity", TORCH_BOX(&get_nvdec_cache_capacity));
   m.impl("_get_nvdec_cache_size", TORCH_BOX(&_get_nvdec_cache_size));
-  // Unified audio decoder creation ops
   m.impl(
       "create_audio_decoder_from_file",
       TORCH_BOX(&create_audio_decoder_from_file));

--- a/src/torchcodec/_core/custom_ops.cpp
+++ b/src/torchcodec/_core/custom_ops.cpp
@@ -56,6 +56,15 @@ STABLE_TORCH_LIBRARY(torchcodec_ns, m) {
       "add_video_stream(Tensor(a!) decoder, *, int? num_threads=None, str? dimension_order=None, int? stream_index=None, str device=\"cpu\", str device_variant=\"ffmpeg\", str transform_specs=\"\", Tensor? custom_frame_mappings_pts=None, Tensor? custom_frame_mappings_duration=None, Tensor? custom_frame_mappings_keyframe_indices=None) -> ()");
   m.def(
       "add_audio_stream(Tensor(a!) decoder, *, int? stream_index=None, int? sample_rate=None, int? num_channels=None) -> ()");
+  // Unified audio decoder creation ops - these combine create +
+  // add_audio_stream
+  m.def(
+      "create_audio_decoder_from_file(str filename, *, int? stream_index=None, int? sample_rate=None, int? num_channels=None) -> Tensor");
+  m.def(
+      "create_audio_decoder_from_tensor(Tensor audio_tensor, *, int? stream_index=None, int? sample_rate=None, int? num_channels=None) -> Tensor");
+  m.def(
+      "_create_audio_decoder_from_file_like(int file_like_context, *, int? stream_index=None, int? sample_rate=None, int? num_channels=None) -> Tensor");
+  m.def("get_active_stream_index(Tensor(a!) decoder) -> int");
   m.def("seek_to_pts(Tensor(a!) decoder, float seconds) -> ()");
   m.def("get_next_frame(Tensor(a!) decoder) -> (Tensor, Tensor, Tensor)");
   m.def(
@@ -535,6 +544,93 @@ void add_audio_stream(
 
   auto videoDecoder = unwrapTensorToGetDecoder(decoder);
   videoDecoder->addAudioStream(stream_index.value_or(-1), audioStreamOptions);
+}
+
+// --------------------------------------------------------------------------
+// UNIFIED AUDIO DECODER CREATION OPS
+// --------------------------------------------------------------------------
+
+// Create an audio decoder from file with stream already added.
+torch::stable::Tensor create_audio_decoder_from_file(
+    std::string filename,
+    std::optional<int64_t> stream_index = std::nullopt,
+    std::optional<int64_t> sample_rate = std::nullopt,
+    std::optional<int64_t> num_channels = std::nullopt) {
+  // Audio always uses approximate seek mode
+  AudioStreamOptions audioStreamOptions;
+  audioStreamOptions.sampleRate = sample_rate;
+  audioStreamOptions.numChannels = num_channels;
+
+  auto decoder = SingleStreamDecoder::createAudioDecoder(
+      filename,
+      SeekMode::approximate,
+      stream_index.value_or(-1),
+      audioStreamOptions);
+
+  return wrapDecoderPointerToTensor(std::move(decoder));
+}
+
+// Create an audio decoder from tensor with stream already added.
+torch::stable::Tensor create_audio_decoder_from_tensor(
+    const torch::stable::Tensor& audio_tensor,
+    std::optional<int64_t> stream_index = std::nullopt,
+    std::optional<int64_t> sample_rate = std::nullopt,
+    std::optional<int64_t> num_channels = std::nullopt) {
+  STD_TORCH_CHECK(
+      audio_tensor.is_contiguous(), "audio_tensor must be contiguous");
+  STD_TORCH_CHECK(
+      audio_tensor.scalar_type() == kStableUInt8,
+      "audio_tensor must be kUInt8");
+
+  AudioStreamOptions audioStreamOptions;
+  audioStreamOptions.sampleRate = sample_rate;
+  audioStreamOptions.numChannels = num_channels;
+
+  auto avioContextHolder =
+      std::make_unique<AVIOFromTensorContext>(audio_tensor);
+
+  auto decoder = SingleStreamDecoder::createAudioDecoder(
+      std::move(avioContextHolder),
+      SeekMode::approximate,
+      stream_index.value_or(-1),
+      audioStreamOptions);
+
+  return wrapDecoderPointerToTensor(std::move(decoder));
+}
+
+// Create an audio decoder from file-like object with stream already added.
+torch::stable::Tensor _create_audio_decoder_from_file_like(
+    int64_t file_like_context,
+    std::optional<int64_t> stream_index = std::nullopt,
+    std::optional<int64_t> sample_rate = std::nullopt,
+    std::optional<int64_t> num_channels = std::nullopt) {
+  auto fileLikeContext =
+      reinterpret_cast<AVIOFileLikeContext*>(file_like_context);
+  STD_TORCH_CHECK(
+      fileLikeContext != nullptr, "file_like_context must be a valid pointer");
+  std::unique_ptr<AVIOFileLikeContext> avioContextHolder(fileLikeContext);
+
+  AudioStreamOptions audioStreamOptions;
+  audioStreamOptions.sampleRate = sample_rate;
+  audioStreamOptions.numChannels = num_channels;
+
+  auto decoder = SingleStreamDecoder::createAudioDecoder(
+      std::move(avioContextHolder),
+      SeekMode::approximate,
+      stream_index.value_or(-1),
+      audioStreamOptions);
+
+  return wrapDecoderPointerToTensor(std::move(decoder));
+}
+
+// --------------------------------------------------------------------------
+// STREAM INFO OP
+// --------------------------------------------------------------------------
+
+// Get the active stream index from the decoder.
+int64_t get_active_stream_index(torch::stable::Tensor& decoder) {
+  auto videoDecoder = unwrapTensorToGetDecoder(decoder);
+  return videoDecoder->getActiveStreamIndex();
 }
 
 // Seek to a particular presentation timestamp in the video in seconds.
@@ -1138,6 +1234,17 @@ STABLE_TORCH_LIBRARY_IMPL(torchcodec_ns, BackendSelect, m) {
   m.impl("set_nvdec_cache_capacity", TORCH_BOX(&set_nvdec_cache_capacity));
   m.impl("get_nvdec_cache_capacity", TORCH_BOX(&get_nvdec_cache_capacity));
   m.impl("_get_nvdec_cache_size", TORCH_BOX(&_get_nvdec_cache_size));
+  // Unified audio decoder creation ops
+  m.impl(
+      "create_audio_decoder_from_file",
+      TORCH_BOX(&create_audio_decoder_from_file));
+  m.impl(
+      "create_audio_decoder_from_tensor",
+      TORCH_BOX(&create_audio_decoder_from_tensor));
+  m.impl(
+      "_create_audio_decoder_from_file_like",
+      TORCH_BOX(&_create_audio_decoder_from_file_like));
+  m.impl("get_active_stream_index", TORCH_BOX(&get_active_stream_index));
 }
 
 STABLE_TORCH_LIBRARY_IMPL(torchcodec_ns, CPU, m) {

--- a/src/torchcodec/_core/ops.py
+++ b/src/torchcodec/_core/ops.py
@@ -71,49 +71,18 @@ _create_from_file_like = torch._dynamo.disallow_in_graph(
 _add_video_stream_raw = torch.ops.torchcodec_ns.add_video_stream.default
 _add_video_stream = torch.ops.torchcodec_ns._add_video_stream.default
 
-_create_audio_decoder_from_file_raw = torch._dynamo.disallow_in_graph(
+# Unified audio decoder creation ops
+create_audio_decoder_from_file = torch._dynamo.disallow_in_graph(
     torch.ops.torchcodec_ns.create_audio_decoder_from_file.default
 )
-_create_audio_decoder_from_tensor_raw = torch._dynamo.disallow_in_graph(
+create_audio_decoder_from_tensor = torch._dynamo.disallow_in_graph(
     torch.ops.torchcodec_ns.create_audio_decoder_from_tensor.default
 )
-_create_audio_decoder_from_file_like_raw = torch._dynamo.disallow_in_graph(
+_create_audio_decoder_from_file_like = torch._dynamo.disallow_in_graph(
     torch.ops.torchcodec_ns._create_audio_decoder_from_file_like.default
 )
 
 get_active_stream_index = torch.ops.torchcodec_ns.get_active_stream_index.default
-
-
-def create_audio_decoder_from_file(
-    filename: str,
-    *,
-    stream_index: int | None = None,
-    sample_rate: int | None = None,
-    num_channels: int | None = None,
-) -> torch.Tensor:
-    """Create an audio decoder from a file with the stream already added."""
-    return _create_audio_decoder_from_file_raw(
-        filename,
-        stream_index=stream_index,
-        sample_rate=sample_rate,
-        num_channels=num_channels,
-    )
-
-
-def create_audio_decoder_from_tensor(
-    audio_tensor: torch.Tensor,
-    *,
-    stream_index: int | None = None,
-    sample_rate: int | None = None,
-    num_channels: int | None = None,
-) -> torch.Tensor:
-    """Create an audio decoder from a tensor with the stream already added."""
-    return _create_audio_decoder_from_tensor_raw(
-        audio_tensor,
-        stream_index=stream_index,
-        sample_rate=sample_rate,
-        num_channels=num_channels,
-    )
 
 
 def create_audio_decoder_from_bytes(
@@ -144,7 +113,7 @@ def create_audio_decoder_from_file_like(
 ) -> torch.Tensor:
     """Create an audio decoder from a file-like object with the stream already added."""
     assert _pybind_ops is not None
-    return _create_audio_decoder_from_file_like_raw(
+    return _create_audio_decoder_from_file_like(
         _pybind_ops.create_file_like_context(
             file_like, False  # False means not for writing
         ),

--- a/src/torchcodec/_core/ops.py
+++ b/src/torchcodec/_core/ops.py
@@ -71,7 +71,6 @@ _create_from_file_like = torch._dynamo.disallow_in_graph(
 _add_video_stream_raw = torch.ops.torchcodec_ns.add_video_stream.default
 _add_video_stream = torch.ops.torchcodec_ns._add_video_stream.default
 
-# Unified audio decoder creation ops (raw C++ ops)
 _create_audio_decoder_from_file_raw = torch._dynamo.disallow_in_graph(
     torch.ops.torchcodec_ns.create_audio_decoder_from_file.default
 )
@@ -82,7 +81,6 @@ _create_audio_decoder_from_file_like_raw = torch._dynamo.disallow_in_graph(
     torch.ops.torchcodec_ns._create_audio_decoder_from_file_like.default
 )
 
-# Stream info op
 get_active_stream_index = torch.ops.torchcodec_ns.get_active_stream_index.default
 
 
@@ -202,7 +200,7 @@ def create_audio_decoder(
     This is a convenience function that dispatches to the appropriate
     create_audio_decoder_from_* function based on the source type.
     """
-    # Validate stream_index if provided (before calling C++ ops)
+
     if stream_index is not None:
         from torchcodec._core._metadata import (
             AudioStreamMetadata,
@@ -221,7 +219,6 @@ def create_audio_decoder(
                 f"The stream at index {stream_index} is not an audio stream."
             )
 
-    # Now dispatch to the appropriate create_audio_decoder_from_* function
     if isinstance(source, str):
         return create_audio_decoder_from_file(
             source,
@@ -620,7 +617,6 @@ def add_audio_stream_abstract(
     return
 
 
-# Abstract implementations for unified audio decoder creation ops
 @register_fake("torchcodec_ns::create_audio_decoder_from_file")
 def create_audio_decoder_from_file_abstract(
     filename: str,

--- a/src/torchcodec/_core/ops.py
+++ b/src/torchcodec/_core/ops.py
@@ -71,6 +71,211 @@ _create_from_file_like = torch._dynamo.disallow_in_graph(
 _add_video_stream_raw = torch.ops.torchcodec_ns.add_video_stream.default
 _add_video_stream = torch.ops.torchcodec_ns._add_video_stream.default
 
+# Unified audio decoder creation ops (raw C++ ops)
+_create_audio_decoder_from_file_raw = torch._dynamo.disallow_in_graph(
+    torch.ops.torchcodec_ns.create_audio_decoder_from_file.default
+)
+_create_audio_decoder_from_tensor_raw = torch._dynamo.disallow_in_graph(
+    torch.ops.torchcodec_ns.create_audio_decoder_from_tensor.default
+)
+_create_audio_decoder_from_file_like_raw = torch._dynamo.disallow_in_graph(
+    torch.ops.torchcodec_ns._create_audio_decoder_from_file_like.default
+)
+
+# Stream info op
+get_active_stream_index = torch.ops.torchcodec_ns.get_active_stream_index.default
+
+
+def create_audio_decoder_from_file(
+    filename: str,
+    *,
+    stream_index: int | None = None,
+    sample_rate: int | None = None,
+    num_channels: int | None = None,
+) -> torch.Tensor:
+    """Create an audio decoder from a file with the stream already added."""
+    return _create_audio_decoder_from_file_raw(
+        filename,
+        stream_index=stream_index,
+        sample_rate=sample_rate,
+        num_channels=num_channels,
+    )
+
+
+def create_audio_decoder_from_tensor(
+    audio_tensor: torch.Tensor,
+    *,
+    stream_index: int | None = None,
+    sample_rate: int | None = None,
+    num_channels: int | None = None,
+) -> torch.Tensor:
+    """Create an audio decoder from a tensor with the stream already added."""
+    return _create_audio_decoder_from_tensor_raw(
+        audio_tensor,
+        stream_index=stream_index,
+        sample_rate=sample_rate,
+        num_channels=num_channels,
+    )
+
+
+def create_audio_decoder_from_bytes(
+    audio_bytes: bytes,
+    *,
+    stream_index: int | None = None,
+    sample_rate: int | None = None,
+    num_channels: int | None = None,
+) -> torch.Tensor:
+    """Create an audio decoder from bytes with the stream already added."""
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=UserWarning)
+        buffer = torch.frombuffer(audio_bytes, dtype=torch.uint8)
+    return create_audio_decoder_from_tensor(
+        buffer,
+        stream_index=stream_index,
+        sample_rate=sample_rate,
+        num_channels=num_channels,
+    )
+
+
+def create_audio_decoder_from_file_like(
+    file_like: io.RawIOBase | io.BufferedReader,
+    *,
+    stream_index: int | None = None,
+    sample_rate: int | None = None,
+    num_channels: int | None = None,
+) -> torch.Tensor:
+    """Create an audio decoder from a file-like object with the stream already added."""
+    assert _pybind_ops is not None
+    return _create_audio_decoder_from_file_like_raw(
+        _pybind_ops.create_file_like_context(
+            file_like, False  # False means not for writing
+        ),
+        stream_index=stream_index,
+        sample_rate=sample_rate,
+        num_channels=num_channels,
+    )
+
+
+def create_decoder(
+    source: str | Path | io.RawIOBase | io.BufferedReader | bytes | torch.Tensor,
+    seek_mode: str | None = None,
+) -> torch.Tensor:
+    """Create a decoder from any supported source (without adding a stream).
+
+    This is a convenience function that dispatches to the appropriate
+    create_from_* function based on the source type.
+    """
+    if isinstance(source, str):
+        return create_from_file(source, seek_mode)
+    elif isinstance(source, Path):
+        return create_from_file(str(source), seek_mode)
+    elif isinstance(source, io.RawIOBase) or isinstance(source, io.BufferedReader):
+        return create_from_file_like(source, seek_mode)
+    elif isinstance(source, bytes):
+        return create_from_bytes(source, seek_mode)
+    elif isinstance(source, torch.Tensor):
+        return create_from_tensor(source, seek_mode)
+    elif isinstance(source, io.TextIOBase):
+        raise TypeError(
+            "source is for reading text, likely from open(..., 'r'). Try with 'rb' for binary reading?"
+        )
+    elif hasattr(source, "read") and hasattr(source, "seek"):
+        return create_from_file_like(source, seek_mode)
+    else:
+        raise TypeError(
+            f"Unknown source type: {type(source)}. "
+            "Supported types are str, Path, bytes, Tensor and file-like objects with "
+            "read(self, size: int) -> bytes and "
+            "seek(self, offset: int, whence: int) -> int methods."
+        )
+
+
+def create_audio_decoder(
+    source: str | Path | io.RawIOBase | io.BufferedReader | bytes | torch.Tensor,
+    *,
+    stream_index: int | None = None,
+    sample_rate: int | None = None,
+    num_channels: int | None = None,
+) -> torch.Tensor:
+    """Create an audio decoder from any supported source with the stream already added.
+
+    This is a convenience function that dispatches to the appropriate
+    create_audio_decoder_from_* function based on the source type.
+    """
+    # Validate stream_index if provided (before calling C++ ops)
+    if stream_index is not None:
+        from torchcodec._core._metadata import (
+            AudioStreamMetadata,
+            get_container_metadata,
+        )
+
+        temp_decoder = create_decoder(source)
+        container_metadata = get_container_metadata(temp_decoder)
+
+        if stream_index >= len(container_metadata.streams):
+            raise ValueError(f"{stream_index} is not a valid stream index.")
+
+        metadata = container_metadata.streams[stream_index]
+        if not isinstance(metadata, AudioStreamMetadata):
+            raise ValueError(
+                f"The stream at index {stream_index} is not an audio stream."
+            )
+
+    # Now dispatch to the appropriate create_audio_decoder_from_* function
+    if isinstance(source, str):
+        return create_audio_decoder_from_file(
+            source,
+            stream_index=stream_index,
+            sample_rate=sample_rate,
+            num_channels=num_channels,
+        )
+    elif isinstance(source, Path):
+        return create_audio_decoder_from_file(
+            str(source),
+            stream_index=stream_index,
+            sample_rate=sample_rate,
+            num_channels=num_channels,
+        )
+    elif isinstance(source, io.RawIOBase) or isinstance(source, io.BufferedReader):
+        return create_audio_decoder_from_file_like(
+            source,
+            stream_index=stream_index,
+            sample_rate=sample_rate,
+            num_channels=num_channels,
+        )
+    elif isinstance(source, bytes):
+        return create_audio_decoder_from_bytes(
+            source,
+            stream_index=stream_index,
+            sample_rate=sample_rate,
+            num_channels=num_channels,
+        )
+    elif isinstance(source, torch.Tensor):
+        return create_audio_decoder_from_tensor(
+            source,
+            stream_index=stream_index,
+            sample_rate=sample_rate,
+            num_channels=num_channels,
+        )
+    elif isinstance(source, io.TextIOBase):
+        raise TypeError(
+            "source is for reading text, likely from open(..., 'r'). Try with 'rb' for binary reading?"
+        )
+    elif hasattr(source, "read") and hasattr(source, "seek"):
+        return create_audio_decoder_from_file_like(
+            source,
+            stream_index=stream_index,
+            sample_rate=sample_rate,
+            num_channels=num_channels,
+        )
+    else:
+        raise TypeError(
+            f"Unknown source type: {type(source)}. "
+            "Supported types are str, Path, bytes, Tensor and file-like objects with "
+            "read(self, size: int) -> bytes and "
+            "seek(self, offset: int, whence: int) -> int methods."
+        )
+
 
 def add_video_stream(
     decoder: torch.Tensor,
@@ -413,6 +618,40 @@ def add_audio_stream_abstract(
     num_channels: int | None = None,
 ) -> None:
     return
+
+
+# Abstract implementations for unified audio decoder creation ops
+@register_fake("torchcodec_ns::create_audio_decoder_from_file")
+def create_audio_decoder_from_file_abstract(
+    filename: str,
+    *,
+    stream_index: int | None = None,
+    sample_rate: int | None = None,
+    num_channels: int | None = None,
+) -> torch.Tensor:
+    return torch.empty([], dtype=torch.long)
+
+
+@register_fake("torchcodec_ns::create_audio_decoder_from_tensor")
+def create_audio_decoder_from_tensor_abstract(
+    audio_tensor: torch.Tensor,
+    *,
+    stream_index: int | None = None,
+    sample_rate: int | None = None,
+    num_channels: int | None = None,
+) -> torch.Tensor:
+    return torch.empty([], dtype=torch.long)
+
+
+@register_fake("torchcodec_ns::_create_audio_decoder_from_file_like")
+def _create_audio_decoder_from_file_like_abstract(
+    file_like_context: int,
+    *,
+    stream_index: int | None = None,
+    sample_rate: int | None = None,
+    num_channels: int | None = None,
+) -> torch.Tensor:
+    return torch.empty([], dtype=torch.long)
 
 
 @register_fake("torchcodec_ns::seek_to_pts")

--- a/src/torchcodec/_core/ops.py
+++ b/src/torchcodec/_core/ops.py
@@ -123,6 +123,40 @@ def create_audio_decoder_from_file_like(
     )
 
 
+def _dispatch_by_source(
+    source: str | Path | io.RawIOBase | io.BufferedReader | bytes | torch.Tensor,
+    file_fn,
+    tensor_fn,
+    bytes_fn,
+    file_like_fn,
+    **kwargs,
+):
+    """Dispatch to the appropriate function based on source type."""
+    if isinstance(source, str):
+        return file_fn(source, **kwargs)
+    elif isinstance(source, Path):
+        return file_fn(str(source), **kwargs)
+    elif isinstance(source, io.RawIOBase) or isinstance(source, io.BufferedReader):
+        return file_like_fn(source, **kwargs)
+    elif isinstance(source, bytes):
+        return bytes_fn(source, **kwargs)
+    elif isinstance(source, torch.Tensor):
+        return tensor_fn(source, **kwargs)
+    elif isinstance(source, io.TextIOBase):
+        raise TypeError(
+            "source is for reading text, likely from open(..., 'r'). Try with 'rb' for binary reading?"
+        )
+    elif hasattr(source, "read") and hasattr(source, "seek"):
+        return file_like_fn(source, **kwargs)
+    else:
+        raise TypeError(
+            f"Unknown source type: {type(source)}. "
+            "Supported types are str, Path, bytes, Tensor and file-like objects with "
+            "read(self, size: int) -> bytes and "
+            "seek(self, offset: int, whence: int) -> int methods."
+        )
+
+
 def create_decoder(
     source: str | Path | io.RawIOBase | io.BufferedReader | bytes | torch.Tensor,
     seek_mode: str | None = None,
@@ -132,29 +166,14 @@ def create_decoder(
     This is a convenience function that dispatches to the appropriate
     create_from_* function based on the source type.
     """
-    if isinstance(source, str):
-        return create_from_file(source, seek_mode)
-    elif isinstance(source, Path):
-        return create_from_file(str(source), seek_mode)
-    elif isinstance(source, io.RawIOBase) or isinstance(source, io.BufferedReader):
-        return create_from_file_like(source, seek_mode)
-    elif isinstance(source, bytes):
-        return create_from_bytes(source, seek_mode)
-    elif isinstance(source, torch.Tensor):
-        return create_from_tensor(source, seek_mode)
-    elif isinstance(source, io.TextIOBase):
-        raise TypeError(
-            "source is for reading text, likely from open(..., 'r'). Try with 'rb' for binary reading?"
-        )
-    elif hasattr(source, "read") and hasattr(source, "seek"):
-        return create_from_file_like(source, seek_mode)
-    else:
-        raise TypeError(
-            f"Unknown source type: {type(source)}. "
-            "Supported types are str, Path, bytes, Tensor and file-like objects with "
-            "read(self, size: int) -> bytes and "
-            "seek(self, offset: int, whence: int) -> int methods."
-        )
+    return _dispatch_by_source(
+        source,
+        file_fn=create_from_file,
+        tensor_fn=create_from_tensor,
+        bytes_fn=create_from_bytes,
+        file_like_fn=create_from_file_like,
+        seek_mode=seek_mode,
+    )
 
 
 def create_audio_decoder(
@@ -169,7 +188,6 @@ def create_audio_decoder(
     This is a convenience function that dispatches to the appropriate
     create_audio_decoder_from_* function based on the source type.
     """
-
     if stream_index is not None:
         from torchcodec._core._metadata import (
             AudioStreamMetadata,
@@ -188,59 +206,16 @@ def create_audio_decoder(
                 f"The stream at index {stream_index} is not an audio stream."
             )
 
-    if isinstance(source, str):
-        return create_audio_decoder_from_file(
-            source,
-            stream_index=stream_index,
-            sample_rate=sample_rate,
-            num_channels=num_channels,
-        )
-    elif isinstance(source, Path):
-        return create_audio_decoder_from_file(
-            str(source),
-            stream_index=stream_index,
-            sample_rate=sample_rate,
-            num_channels=num_channels,
-        )
-    elif isinstance(source, io.RawIOBase) or isinstance(source, io.BufferedReader):
-        return create_audio_decoder_from_file_like(
-            source,
-            stream_index=stream_index,
-            sample_rate=sample_rate,
-            num_channels=num_channels,
-        )
-    elif isinstance(source, bytes):
-        return create_audio_decoder_from_bytes(
-            source,
-            stream_index=stream_index,
-            sample_rate=sample_rate,
-            num_channels=num_channels,
-        )
-    elif isinstance(source, torch.Tensor):
-        return create_audio_decoder_from_tensor(
-            source,
-            stream_index=stream_index,
-            sample_rate=sample_rate,
-            num_channels=num_channels,
-        )
-    elif isinstance(source, io.TextIOBase):
-        raise TypeError(
-            "source is for reading text, likely from open(..., 'r'). Try with 'rb' for binary reading?"
-        )
-    elif hasattr(source, "read") and hasattr(source, "seek"):
-        return create_audio_decoder_from_file_like(
-            source,
-            stream_index=stream_index,
-            sample_rate=sample_rate,
-            num_channels=num_channels,
-        )
-    else:
-        raise TypeError(
-            f"Unknown source type: {type(source)}. "
-            "Supported types are str, Path, bytes, Tensor and file-like objects with "
-            "read(self, size: int) -> bytes and "
-            "seek(self, offset: int, whence: int) -> int methods."
-        )
+    return _dispatch_by_source(
+        source,
+        file_fn=create_audio_decoder_from_file,
+        tensor_fn=create_audio_decoder_from_tensor,
+        bytes_fn=create_audio_decoder_from_bytes,
+        file_like_fn=create_audio_decoder_from_file_like,
+        stream_index=stream_index,
+        sample_rate=sample_rate,
+        num_channels=num_channels,
+    )
 
 
 def add_video_stream(


### PR DESCRIPTION
Summary
This diff adds unified C++ ops for AudioDecoder creation, consolidating the two-step pattern (create_decoder + add_audio_stream) into a single C++ call. This reduces Python-to-C++ boundary crossings and simplifies the decoder creation flow.

Changes
C++ Layer (SingleStreamDecoder.h/.cpp)
Added new SingleStreamDecoder constructors that take stream parameters directly, creating a decoder and adding an audio stream in one step.

C++ Layer (custom_ops.cpp)
Added new ops: create_audio_decoder_from_file, create_audio_decoder_from_tensor, _create_audio_decoder_from_file_like
Added get_active_stream_index op to query which stream was selected (needed when stream_index=None)

Python Layer (ops.py)
Added Python bindings for the new unified audio decoder ops (following existing code style with direct bindings)
Added _dispatch_by_source() helper function to reduce source-type dispatching duplication
Added create_decoder() convenience function using the helper
Added create_audio_decoder() convenience function that validates stream_index before calling C++ and dispatches based on source type
Added abstract implementations (@register_fake) for torch.compile support

Python Layer (_decoder_utils.py)
Updated create_audio_decoder() to use the unified ops from ops.py
Now imports create_decoder from ops.py instead of defining its own


Test Plan:
`pytest test/test_decoders.py -v -k "Audio"`
All tests passed locally. 

Note: 

VideoDecoder was intentionally not changed for this PR because it requires metadata (height/width) before adding the stream to build transform specs. Will create a PR for VideoDecoder after this PR get merged. 
