### PR TITLE
Add 'main' in doc version picker

### DIFF
--- a/torchcodec-versions.json
+++ b/torchcodec-versions.json
@@ -1,5 +1,11 @@
 [
     {
+        "name": "main (unstable)",
+        "version": "main",
+        "url": "https://meta-pytorch.org/torchcodec/main/",
+        "preferred": true
+    },
+    {
         "name": "0.10 (stable)",
         "version": "0.10",
         "url": "https://meta-pytorch.org/torchcodec/stable/",


### PR DESCRIPTION
Our [version picker](https://meta-pytorch.org/torchcodec/main/) currently renders like this:


<img width="201" height="125" alt="image" src="https://github.com/user-attachments/assets/a8c02f0e-6dd6-4a7e-8079-841f1fc59dbe" />

while on [executorch](https://docs.pytorch.org/executorch/stable/index.html) it looks like this:

<img width="181" height="102" alt="image" src="https://github.com/user-attachments/assets/c02ca779-1936-4957-b2cf-3869b4cfdbc6" />

and I suspect it's because we don't have the `main` entry in there.

Regardless of the renderring, we should add a `main` entry in the version picker, because it's a convenient way to reach to latest docs!