### PR TITLE
Use float64 instead of float32 in time-based samplers

### DIFF
--- a/src/torchcodec/samplers/_time_based.py
+++ b/src/torchcodec/samplers/_time_based.py
@@ -192,7 +192,8 @@ def _generic_time_based_sampler(
         # torch.rand() returns in [0, 1)
         # which ensures all clip starts are < sampling_range_end
         clip_start_seconds = (
-            torch.rand(num_clips) * sampling_range_width + sampling_range_start
+            torch.rand(num_clips, dtype=torch.float64) * sampling_range_width
+            + sampling_range_start
         )
     else:
         assert seconds_between_clip_starts is not None  # appease type-checker
@@ -200,6 +201,7 @@ def _generic_time_based_sampler(
             sampling_range_start,
             sampling_range_end,  # excluded
             seconds_between_clip_starts,
+            dtype=torch.float64,
         )
         # As mentioned in the docs, torch.arange may return values
         # equal to or above `end` because of floating precision errors.


### PR DESCRIPTION
This fixes D96878258 - there's a reproducing video in there, which I won't share here for obvious reasons.

A simple reproducing example is:

```py
import torch
from torchcodec.decoders import VideoDecoder
from torchcodec.samplers import clips_at_regular_timestamps


dec = VideoDecoder("/home/nicolashug/bad_video.mp4")

clips_at_regular_timestamps(dec, seconds_between_clip_starts=120)
```

which yields

```
RuntimeError: getFramesPlayedAt, /home/nicolashug/dev/torchcodec/src/torchcodec/_core/SingleStreamDecoder.cpp:886, frame pts is 0.066733; must be greater than or equal to 0.066733.
```

The `0.066733` value corresponds to `dec.metadata.begin_stream_seconds`, and the issue is that the sampler passes it as a float32 instead of a float64. The same problem can be reproduced as follows:

```py
# with get_frame_played_at
dec.get_frame_played_at(dec.metadata.begin_stream_seconds)  # works
dec.get_frame_played_at(torch.tensor([dec.metadata.begin_stream_seconds], dtype=torch.float64).item())  # works
dec.get_frame_played_at(torch.tensor([dec.metadata.begin_stream_seconds], dtype=torch.float32).item())  # fails!!

# with get_frames_played_at
dec.get_frames_played_at([dec.metadata.begin_stream_seconds])  # works
dec.get_frames_played_at(torch.tensor([dec.metadata.begin_stream_seconds], dtype=torch.float64))  # works
dec.get_frames_played_at(torch.tensor([dec.metadata.begin_stream_seconds], dtype=torch.float32))  # fails!
```

The fix is to generate clip indices in float64 instead of float32. This is consistent with our list -> tensor conversion logic in `get_frames_played_at()`, where clearly we want pts values to be in float64:

https://github.com/meta-pytorch/torchcodec/blob/cba63d7e05db8184775c06e55835253a68a687dc/src/torchcodec/_core/ops.py#L264