### PR TITLE
[merge after 0.11] README indicates default wheel matches torch

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ format you want. Refer to Nvidia's GPU support matrix for more details
 
 3. Install TorchCodec
 
-   On Linux, `pip install torchcodec` defaults to the CUDA 12.8 wheel,
+   On Linux, `pip install torchcodec` defaults to a CUDA wheel,
    matching the default behavior of `pip install torch`.
 
    ```bash


### PR DESCRIPTION
After releasing torchcodec 0.11, we will need to update the README to reflect that `pip install torchcodec` does not install the CPU wheel. This PR makes those adjustments.