### PR TITLE
Remove linux foundation header from docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -186,7 +186,6 @@ html_theme_path = [pytorch_sphinx_theme2.get_html_theme_path()]
 html_theme_options = {
     "navigation_with_keys": False,
     "analytics_id": "GTM-T8XT4PS",
-    "show_lf_header": True,
     "icon_links": [
         {
             "name": "X",


### PR DESCRIPTION
remove linux foundation header from docs to prevent cutoff when navigating to sections