### PR TITLE
Add filelike support and tests to streaming encoder

### DIFF
--- a/src/torchcodec/_core/Encoder.cpp
+++ b/src/torchcodec/_core/Encoder.cpp
@@ -1056,6 +1056,29 @@ MultiStreamEncoder::MultiStreamEncoder(std::string_view fileName) {
       getFFMPEGErrorStringFromErrorCode(status));
 }
 
+MultiStreamEncoder::MultiStreamEncoder(
+    std::string_view formatName,
+    std::unique_ptr<AVIOContextHolder> avioContextHolder)
+    : avioContextHolder_(std::move(avioContextHolder)) {
+  setFFmpegLogLevel();
+  // Map mkv -> matroska when used as format name
+  formatName = (formatName == "mkv") ? "matroska" : formatName;
+  AVFormatContext* avFormatContext = nullptr;
+  int status = avformat_alloc_output_context2(
+      &avFormatContext, nullptr, formatName.data(), nullptr);
+
+  STD_TORCH_CHECK(
+      avFormatContext != nullptr,
+      "Couldn't allocate AVFormatContext. ",
+      "Check the desired format? Got format=",
+      formatName,
+      ". ",
+      getFFMPEGErrorStringFromErrorCode(status));
+  avFormatContext_.reset(avFormatContext);
+
+  avFormatContext_->pb = avioContextHolder_->getAVIOContext();
+}
+
 void MultiStreamEncoder::addVideoStream(
     double frameRate,
     std::optional<std::string> codec,

--- a/src/torchcodec/_core/Encoder.h
+++ b/src/torchcodec/_core/Encoder.h
@@ -187,6 +187,9 @@ class FORCE_PUBLIC_VISIBILITY MultiStreamEncoder {
   MultiStreamEncoder& operator=(MultiStreamEncoder&&) = delete;
 
   MultiStreamEncoder(std::string_view fileName);
+  MultiStreamEncoder(
+      std::string_view formatName,
+      std::unique_ptr<AVIOContextHolder> avioContextHolder);
 
   void addVideoStream(
       double frameRate,

--- a/src/torchcodec/_core/__init__.py
+++ b/src/torchcodec/_core/__init__.py
@@ -19,6 +19,7 @@ from .ops import (
     _test_frame_pts_equality,
     core_library_path,
     create_streaming_encoder_to_file,
+    create_streaming_encoder_to_file_like,
     create_wav_decoder_from_file,
     encode_audio_to_file,
     encode_audio_to_file_like,

--- a/src/torchcodec/_core/custom_ops.cpp
+++ b/src/torchcodec/_core/custom_ops.cpp
@@ -83,6 +83,8 @@ STABLE_TORCH_LIBRARY(torchcodec_ns, m) {
       "_test_frame_pts_equality(Tensor(a!) decoder, *, int frame_index, float pts_seconds_to_test) -> bool");
   m.def("scan_all_streams_to_update_metadata(Tensor(a!) decoder) -> ()");
   m.def("create_streaming_encoder_to_file(str filename) -> Tensor");
+  m.def(
+      "create_streaming_encoder_to_file_like(str format, int file_like_context) -> Tensor");
   m.def("streaming_encoder_close(Tensor(a!) encoder) -> ()");
   m.def(
       "streaming_encoder_add_video_stream(Tensor(a!) encoder, float frame_rate, str? codec=None, str? pixel_format=None, float? crf=None, str? preset=None, str[]? extra_options=None) -> ()");
@@ -1184,6 +1186,20 @@ torch::stable::Tensor create_streaming_encoder_to_file(std::string file_name) {
   return wrapMultiStreamEncoderPointerToTensor(std::move(encoder));
 }
 
+torch::stable::Tensor create_streaming_encoder_to_file_like(
+    std::string format,
+    int64_t file_like_context) {
+  auto fileLikeContext =
+      reinterpret_cast<AVIOFileLikeContext*>(file_like_context);
+  STD_TORCH_CHECK(
+      fileLikeContext != nullptr, "file_like_context must be a valid pointer");
+  std::unique_ptr<AVIOFileLikeContext> avioContextHolder(fileLikeContext);
+
+  auto encoder = std::make_unique<MultiStreamEncoder>(
+      format, std::move(avioContextHolder));
+  return wrapMultiStreamEncoderPointerToTensor(std::move(encoder));
+}
+
 void streaming_encoder_close(torch::stable::Tensor& encoder) {
   unwrapTensorToGetMultiStreamEncoder(encoder)->close();
 }
@@ -1285,6 +1301,9 @@ STABLE_TORCH_LIBRARY_IMPL(torchcodec_ns, BackendSelect, m) {
       "create_streaming_encoder_to_file",
       TORCH_BOX(&create_streaming_encoder_to_file));
   m.impl(
+      "create_streaming_encoder_to_file_like",
+      TORCH_BOX(&create_streaming_encoder_to_file_like));
+  m.impl(
       "streaming_encoder_add_video_stream",
       TORCH_BOX(&streaming_encoder_add_video_stream));
   m.impl(
@@ -1335,6 +1354,9 @@ STABLE_TORCH_LIBRARY_IMPL(torchcodec_ns, CPU, m) {
   m.impl(
       "create_streaming_encoder_to_file",
       TORCH_BOX(&create_streaming_encoder_to_file));
+  m.impl(
+      "create_streaming_encoder_to_file_like",
+      TORCH_BOX(&create_streaming_encoder_to_file_like));
   m.impl("streaming_encoder_close", TORCH_BOX(&streaming_encoder_close));
   m.impl(
       "streaming_encoder_add_video_stream",

--- a/src/torchcodec/_core/ops.py
+++ b/src/torchcodec/_core/ops.py
@@ -139,6 +139,9 @@ _get_backend_details = torch.ops.torchcodec_ns._get_backend_details.default
 create_streaming_encoder_to_file = torch._dynamo.disallow_in_graph(
     torch.ops.torchcodec_ns.create_streaming_encoder_to_file.default
 )
+_create_streaming_encoder_to_file_like = torch._dynamo.disallow_in_graph(
+    torch.ops.torchcodec_ns.create_streaming_encoder_to_file_like.default
+)
 streaming_encoder_close = torch.ops.torchcodec_ns.streaming_encoder_close.default
 streaming_encoder_add_video_stream = (
     torch.ops.torchcodec_ns.streaming_encoder_add_video_stream.default
@@ -254,6 +257,17 @@ def encode_video_to_file_like(
         crf,
         preset,
         extra_options,
+    )
+
+
+def create_streaming_encoder_to_file_like(
+    format: str,
+    file_like: io.RawIOBase | io.BufferedIOBase,
+) -> torch.Tensor:
+    assert _pybind_ops is not None
+    return _create_streaming_encoder_to_file_like(
+        format,
+        _pybind_ops.create_file_like_context(file_like, True),  # True means for writing
     )
 
 
@@ -597,6 +611,14 @@ def _get_backend_details_abstract(decoder: torch.Tensor) -> str:
 @register_fake("torchcodec_ns::create_streaming_encoder_to_file")
 def _create_streaming_encoder_to_file_abstract(
     filename: str,
+) -> torch.Tensor:
+    return torch.empty([], dtype=torch.long)
+
+
+@register_fake("torchcodec_ns::create_streaming_encoder_to_file_like")
+def _create_streaming_encoder_to_file_like_abstract(
+    format: str,
+    file_like_context: int,
 ) -> torch.Tensor:
     return torch.empty([], dtype=torch.long)
 

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1154,19 +1154,22 @@ class TestMultiStreamEncoderOps:
     @staticmethod
     def _create_encoder(method, tmp_path, format):
         if method == "to_file":
-            output = tmp_path / f"test.{format}"
-            return create_streaming_encoder_to_file(str(output)), output
+            encoder_output = tmp_path / f"test.{format}"
+            return create_streaming_encoder_to_file(str(encoder_output)), encoder_output
         elif method == "to_file_like":
-            output = io.BytesIO()
-            return create_streaming_encoder_to_file_like(format, output), output
+            encoder_output = io.BytesIO()
+            return (
+                create_streaming_encoder_to_file_like(format, encoder_output),
+                encoder_output,
+            )
         else:
             raise ValueError(f"Unknown method: {method}")
 
     @staticmethod
-    def _get_decoder_source(output):
-        if isinstance(output, io.BytesIO):
-            return output.getvalue()
-        return str(output)
+    def _get_decoder_source(encoder_output):
+        if isinstance(encoder_output, io.BytesIO):
+            return encoder_output.getvalue()
+        return str(encoder_output)
 
     @pytest.mark.parametrize("method", ("to_file", "to_file_like"))
     def test_double_close(self, tmp_path, method):
@@ -1181,7 +1184,7 @@ class TestMultiStreamEncoderOps:
         source_frames = source_decoder.get_frames_in_range(start=0, stop=10).data
         frame_rate = source_decoder.metadata.average_fps
 
-        encoder, output = self._create_encoder(method, tmp_path, format)
+        encoder, encoder_output = self._create_encoder(method, tmp_path, format)
         streaming_encoder_add_video_stream(
             encoder,
             frame_rate=frame_rate,
@@ -1193,7 +1196,7 @@ class TestMultiStreamEncoderOps:
         streaming_encoder_close(encoder)
 
         decoded_frames = (
-            VideoDecoder(self._get_decoder_source(output))
+            VideoDecoder(self._get_decoder_source(encoder_output))
             .get_frames_in_range(start=0, stop=10)
             .data
         )
@@ -1226,7 +1229,7 @@ class TestMultiStreamEncoderOps:
         source_frames = source_decoder.get_frames_in_range(start=0, stop=10).data
         frame_rate = source_decoder.metadata.average_fps
 
-        encoder, output = self._create_encoder(method, tmp_path, format)
+        encoder, encoder_output = self._create_encoder(method, tmp_path, format)
         streaming_encoder_add_video_stream(
             encoder,
             frame_rate=frame_rate,
@@ -1249,7 +1252,7 @@ class TestMultiStreamEncoderOps:
         # Here, we decode the available fragmented mp4 frames before calling close()
         for batch in [source_frames[:5], source_frames[5:]]:
             streaming_encoder_add_frames(encoder, batch)
-            mid_decoder = VideoDecoder(self._get_decoder_source(output))
+            mid_decoder = VideoDecoder(self._get_decoder_source(encoder_output))
             num_available = len(mid_decoder)
             assert num_available > 0
             assert_tensor_close_on_at_least(
@@ -1262,7 +1265,7 @@ class TestMultiStreamEncoderOps:
         streaming_encoder_close(encoder)
         # After close, all frames must be decodable
         assert_tensor_close_on_at_least(
-            VideoDecoder(self._get_decoder_source(output))
+            VideoDecoder(self._get_decoder_source(encoder_output))
             .get_frames_in_range(start=0, stop=10)
             .data,
             source_frames,

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -19,6 +19,7 @@ import torch
 from torchcodec._core import (
     _test_frame_pts_equality,
     create_streaming_encoder_to_file,
+    create_streaming_encoder_to_file_like,
     encode_audio_to_file,
     get_ffmpeg_library_versions,
     get_frame_at_index,
@@ -1150,19 +1151,37 @@ class TestAudioEncoderOps:
 
 
 class TestMultiStreamEncoderOps:
-    def test_double_close(self, tmp_path):
-        encoder_tensor = create_streaming_encoder_to_file(str(tmp_path / "test.mp4"))
+    @staticmethod
+    def _create_encoder(method, tmp_path, format):
+        if method == "to_file":
+            output = tmp_path / f"test.{format}"
+            return create_streaming_encoder_to_file(str(output)), output
+        elif method == "to_file_like":
+            output = io.BytesIO()
+            return create_streaming_encoder_to_file_like(format, output), output
+        else:
+            raise ValueError(f"Unknown method: {method}")
+
+    @staticmethod
+    def _get_decoder_source(output):
+        if isinstance(output, io.BytesIO):
+            return output.getvalue()
+        return str(output)
+
+    @pytest.mark.parametrize("method", ("to_file", "to_file_like"))
+    def test_double_close(self, tmp_path, method):
+        encoder_tensor, _ = self._create_encoder(method, tmp_path, "mp4")
         streaming_encoder_close(encoder_tensor)
         streaming_encoder_close(encoder_tensor)  # double close is a no-op
 
     @pytest.mark.parametrize("format", ["mp4", "mov", "mkv"])
-    def test_add_video_stream_and_encode_frames(self, tmp_path, format):
+    @pytest.mark.parametrize("method", ("to_file", "to_file_like"))
+    def test_add_video_stream_and_encode_frames(self, tmp_path, format, method):
         source_decoder = VideoDecoder(str(NASA_VIDEO.path))
         source_frames = source_decoder.get_frames_in_range(start=0, stop=10).data
         frame_rate = source_decoder.metadata.average_fps
 
-        output_file = str(tmp_path / f"test.{format}")
-        encoder = create_streaming_encoder_to_file(output_file)
+        encoder, output = self._create_encoder(method, tmp_path, format)
         streaming_encoder_add_video_stream(
             encoder,
             frame_rate=frame_rate,
@@ -1174,7 +1193,9 @@ class TestMultiStreamEncoderOps:
         streaming_encoder_close(encoder)
 
         decoded_frames = (
-            VideoDecoder(output_file).get_frames_in_range(start=0, stop=10).data
+            VideoDecoder(self._get_decoder_source(output))
+            .get_frames_in_range(start=0, stop=10)
+            .data
         )
         assert_tensor_close_on_at_least(
             decoded_frames, source_frames, percentage=99, atol=2
@@ -1184,18 +1205,28 @@ class TestMultiStreamEncoderOps:
         with pytest.raises(RuntimeError, match="make sure it's a valid path"):
             create_streaming_encoder_to_file("/nonexistent/dir/test.mp4")
 
-    def test_create_invalid_format(self, tmp_path):
-        with pytest.raises(RuntimeError, match="check the desired extension"):
-            create_streaming_encoder_to_file(str(tmp_path / "test.bad_extension"))
+    @pytest.mark.parametrize("method", ("to_file", "to_file_like"))
+    def test_create_invalid_format(self, tmp_path, method):
+        if method == "to_file":
+            with pytest.raises(RuntimeError, match="check the desired extension"):
+                create_streaming_encoder_to_file(str(tmp_path / "test.bad_extension"))
+        elif method == "to_file_like":
+            with pytest.raises(
+                RuntimeError,
+                match=r"Check the desired format\? Got format=bad_extension",
+            ):
+                create_streaming_encoder_to_file_like("bad_extension", io.BytesIO())
+        else:
+            raise ValueError(f"Unknown method: {method}")
 
     @pytest.mark.parametrize("format", ["mp4", "mov"])
-    def test_fragmented_mp4(self, format, tmp_path):
+    @pytest.mark.parametrize("method", ("to_file", "to_file_like"))
+    def test_fragmented_mp4(self, format, tmp_path, method):
         source_decoder = VideoDecoder(str(NASA_VIDEO.path))
         source_frames = source_decoder.get_frames_in_range(start=0, stop=10).data
         frame_rate = source_decoder.metadata.average_fps
 
-        output_file = str(tmp_path / f"test.{format}")
-        encoder = create_streaming_encoder_to_file(output_file)
+        encoder, output = self._create_encoder(method, tmp_path, format)
         streaming_encoder_add_video_stream(
             encoder,
             frame_rate=frame_rate,
@@ -1218,7 +1249,7 @@ class TestMultiStreamEncoderOps:
         # Here, we decode the available fragmented mp4 frames before calling close()
         for batch in [source_frames[:5], source_frames[5:]]:
             streaming_encoder_add_frames(encoder, batch)
-            mid_decoder = VideoDecoder(output_file)
+            mid_decoder = VideoDecoder(self._get_decoder_source(output))
             num_available = len(mid_decoder)
             assert num_available > 0
             assert_tensor_close_on_at_least(
@@ -1231,20 +1262,24 @@ class TestMultiStreamEncoderOps:
         streaming_encoder_close(encoder)
         # After close, all frames must be decodable
         assert_tensor_close_on_at_least(
-            VideoDecoder(output_file).get_frames_in_range(start=0, stop=10).data,
+            VideoDecoder(self._get_decoder_source(output))
+            .get_frames_in_range(start=0, stop=10)
+            .data,
             source_frames,
             percentage=99,
             atol=2,
         )
 
-    def test_add_video_stream_twice_errors(self, tmp_path):
-        encoder = create_streaming_encoder_to_file(str(tmp_path / "test.mp4"))
+    @pytest.mark.parametrize("method", ("to_file", "to_file_like"))
+    def test_add_video_stream_twice_errors(self, tmp_path, method):
+        encoder, _ = self._create_encoder(method, tmp_path, "mp4")
         streaming_encoder_add_video_stream(encoder, frame_rate=30.0)
         with pytest.raises(RuntimeError, match="already been added"):
             streaming_encoder_add_video_stream(encoder, frame_rate=24.0)
 
-    def test_add_frames_different_sizes_errors(self, tmp_path):
-        encoder = create_streaming_encoder_to_file(str(tmp_path / "test.mp4"))
+    @pytest.mark.parametrize("method", ("to_file", "to_file_like"))
+    def test_add_frames_different_sizes_errors(self, tmp_path, method):
+        encoder, _ = self._create_encoder(method, tmp_path, "mp4")
         streaming_encoder_add_video_stream(encoder, frame_rate=30.0)
         frames_64 = torch.randint(0, 256, (2, 3, 64, 64), dtype=torch.uint8)
         frames_128 = torch.randint(0, 256, (2, 3, 128, 128), dtype=torch.uint8)
@@ -1252,8 +1287,9 @@ class TestMultiStreamEncoderOps:
         with pytest.raises(RuntimeError, match="same dimensions"):
             streaming_encoder_add_frames(encoder, frames_128)
 
-    def test_add_frames_without_stream_errors(self, tmp_path):
-        encoder = create_streaming_encoder_to_file(str(tmp_path / "test.mp4"))
+    @pytest.mark.parametrize("method", ("to_file", "to_file_like"))
+    def test_add_frames_without_stream_errors(self, tmp_path, method):
+        encoder, _ = self._create_encoder(method, tmp_path, "mp4")
         frames = torch.randint(0, 256, (5, 3, 64, 64), dtype=torch.uint8)
         with pytest.raises(RuntimeError, match="No video stream"):
             streaming_encoder_add_frames(encoder, frames)


### PR DESCRIPTION
This PR adds a `MultiStreamEncoder` constructor that accepts an `AVIOContextHolder` to support writing to a file-like. 
Tests are updated to call both `create_streaming_encoder_to_file_like` and `create_streaming_encoder_to_file`.