### PR TITLE
CUDA support on streaming encoder

### DIFF
--- a/src/torchcodec/_core/Encoder.cpp
+++ b/src/torchcodec/_core/Encoder.cpp
@@ -540,7 +540,8 @@ namespace {
 
 torch::stable::Tensor validateFrames(
     const torch::stable::Tensor& frames,
-    const AVCodecContext* avCodecContext = nullptr) {
+    const AVCodecContext* avCodecContext = nullptr,
+    DeviceInterface* deviceInterface = nullptr) {
   STD_TORCH_CHECK(
       frames.scalar_type() == kStableUInt8,
       "frames must have uint8 dtype, got ",
@@ -553,6 +554,22 @@ torch::stable::Tensor validateFrames(
       frames.sizes()[1] == 3,
       "frame must have 3 channels (R, G, B), got ",
       frames.sizes()[1]);
+  if (deviceInterface != nullptr) {
+    auto& expectedDevice = deviceInterface->device();
+    auto framesDevice = frames.device();
+    STD_TORCH_CHECK(
+        static_cast<StableDeviceType>(framesDevice.type()) ==
+                expectedDevice.type() &&
+            framesDevice.index() == expectedDevice.index(),
+        "All frames must be on the same device. Expected device type=",
+        deviceTypeName(expectedDevice.type()),
+        " index=",
+        expectedDevice.index(),
+        ", got device type=",
+        deviceTypeName(static_cast<StableDeviceType>(framesDevice.type())),
+        " index=",
+        framesDevice.index());
+  }
   if (avCodecContext) {
     STD_TORCH_CHECK(
         static_cast<int>(frames.sizes()[2]) == avCodecContext->height &&
@@ -1101,9 +1118,6 @@ void MultiStreamEncoder::addVideoStream(
 void MultiStreamEncoder::initializeVideoStream(
     const torch::stable::Tensor& frames) {
   auto tensorDevice = frames.device();
-  // TODO MultiStreamEncoder: Enable CUDA support
-  STD_TORCH_CHECK(
-      tensorDevice.is_cpu(), "Only CPU tensors are supported for encoding.");
   deviceInterface_ = createDeviceInterface(StableDevice(
       static_cast<StableDeviceType>(tensorDevice.type()),
       tensorDevice.index()));
@@ -1126,9 +1140,16 @@ void MultiStreamEncoder::initializeVideoStream(
     STD_TORCH_CHECK(
         avFormatContext_->oformat != nullptr,
         "Output format is null, unable to find default codec.");
-    // TODO MultiStreamEncoder: When CUDA support is enabled, substitute codec
-    // with hardware equivalent
-    avCodec = avcodec_find_encoder(avFormatContext_->oformat->video_codec);
+    // Try to substitute the default codec with its hardware equivalent
+    // This will return std::nullopt when device is CPU.
+    auto hwCodec = deviceInterface_->findCodec(
+        avFormatContext_->oformat->video_codec, /*isDecoder=*/false);
+    if (hwCodec.has_value()) {
+      avCodec = hwCodec.value();
+    }
+    if (!avCodec) {
+      avCodec = avcodec_find_encoder(avFormatContext_->oformat->video_codec);
+    }
   }
   STD_TORCH_CHECK(
       avCodec != nullptr,
@@ -1154,18 +1175,32 @@ void MultiStreamEncoder::initializeVideoStream(
   int outWidth = inWidth;
   int outHeight = inHeight;
   AVPixelFormat outPixelFormat = AV_PIX_FMT_NONE;
+
   if (videoStreamOptions_.pixelFormat.has_value()) {
+    // TODO-VideoEncoder: (P2) Enable pixel formats to be set by user on GPU
+    // and handled with the appropriate NPP function on GPU.
+    if (frames.device().type() == kStableCUDA) {
+      STD_TORCH_CHECK(
+          false,
+          "Video encoding on GPU currently only supports the nv12 pixel format. "
+          "Do not set pixel_format to use nv12 by default.");
+    }
     outPixelFormat =
         validatePixelFormat(*avCodec, videoStreamOptions_.pixelFormat.value());
   } else {
-    const AVPixelFormat* formats = getSupportedPixelFormats(*avCodec);
-    // Use first listed pixel format as default (often yuv420p).
-    // This is similar to FFmpeg's logic:
-    // https://www.ffmpeg.org/doxygen/4.0/decode_8c_source.html#l01087
-    // If pixel formats are undefined for some reason, try yuv420p
-    outPixelFormat = (formats && formats[0] != AV_PIX_FMT_NONE)
-        ? formats[0]
-        : AV_PIX_FMT_YUV420P;
+    if (frames.device().type() == kStableCUDA) {
+      // Default to nv12 pixel format when encoding on GPU.
+      outPixelFormat = DeviceInterface::CUDA_ENCODING_PIXEL_FORMAT;
+    } else {
+      const AVPixelFormat* formats = getSupportedPixelFormats(*avCodec);
+      // Use first listed pixel format as default (often yuv420p).
+      // This is similar to FFmpeg's logic:
+      // https://www.ffmpeg.org/doxygen/4.0/decode_8c_source.html#l01087
+      // If pixel formats are undefined for some reason, try yuv420p
+      outPixelFormat = (formats && formats[0] != AV_PIX_FMT_NONE)
+          ? formats[0]
+          : AV_PIX_FMT_YUV420P;
+    }
   }
 
   // Configure codec parameters
@@ -1209,6 +1244,12 @@ void MultiStreamEncoder::initializeVideoStream(
         0);
   }
 
+  if (frames.device().type() == kStableCUDA) {
+    deviceInterface_->registerHardwareDeviceWithCodec(avCodecContext_.get());
+    deviceInterface_->setupHardwareFrameContextForEncoding(
+        avCodecContext_.get());
+  }
+
   int status = avcodec_open2(
       avCodecContext_.get(), avCodec, avCodecOptions.getAddress());
 
@@ -1246,7 +1287,8 @@ void MultiStreamEncoder::addFrames(const torch::stable::Tensor& frames) {
   STD_TORCH_CHECK(
       inFrameRate_ > 0,
       "No video stream has been added. Call addVideoStream() first.");
-  auto validatedFrames = validateFrames(frames, avCodecContext_.get());
+  auto validatedFrames =
+      validateFrames(frames, avCodecContext_.get(), deviceInterface_.get());
 
   if (!headerWritten_) {
     initializeVideoStream(validatedFrames);

--- a/src/torchcodec/_core/Encoder.cpp
+++ b/src/torchcodec/_core/Encoder.cpp
@@ -558,16 +558,14 @@ torch::stable::Tensor validateFrames(
     auto& expectedDevice = deviceInterface->device();
     auto framesDevice = frames.device();
     STD_TORCH_CHECK(
-        static_cast<StableDeviceType>(framesDevice.type()) ==
-                expectedDevice.type() &&
-            framesDevice.index() == expectedDevice.index(),
-        "All frames must be on the same device. Expected device type=",
+        framesDevice == expectedDevice,
+        "All frames must be on the same device. Expected ",
         deviceTypeName(expectedDevice.type()),
-        " index=",
+        ":",
         expectedDevice.index(),
-        ", got device type=",
-        deviceTypeName(static_cast<StableDeviceType>(framesDevice.type())),
-        " index=",
+        ", got ",
+        deviceTypeName(framesDevice.type()),
+        ":",
         framesDevice.index());
   }
   if (avCodecContext) {
@@ -1177,8 +1175,8 @@ void MultiStreamEncoder::initializeVideoStream(
   AVPixelFormat outPixelFormat = AV_PIX_FMT_NONE;
 
   if (videoStreamOptions_.pixelFormat.has_value()) {
-    // TODO-VideoEncoder: (P2) Enable pixel formats to be set by user on GPU
-    // and handled with the appropriate NPP function on GPU.
+    // TODO-MultiStreamEncoder: (P2) Enable pixel formats to be set by user on
+    // GPU and handled with the appropriate NPP function on GPU.
     if (frames.device().type() == kStableCUDA) {
       STD_TORCH_CHECK(
           false,

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -61,6 +61,7 @@ from .utils import (
     SINE_MONO_S32,
     SINE_MONO_S32_44100,
     SINE_MONO_S32_8000,
+    TEST_SRC_2_720P,
     unsplit_device_str,
 )
 
@@ -1179,18 +1180,25 @@ class TestMultiStreamEncoderOps:
 
     @pytest.mark.parametrize("format", ["mp4", "mov", "mkv"])
     @pytest.mark.parametrize("method", ("to_file", "to_file_like"))
-    def test_add_video_stream_and_encode_frames(self, tmp_path, format, method):
-        source_decoder = VideoDecoder(str(NASA_VIDEO.path))
-        source_frames = source_decoder.get_frames_in_range(start=0, stop=10).data
+    @pytest.mark.parametrize(
+        "device", ("cpu", pytest.param("cuda", marks=pytest.mark.needs_cuda))
+    )
+    def test_add_video_stream_and_encode_frames(self, tmp_path, format, method, device):
+        source_decoder = VideoDecoder(str(TEST_SRC_2_720P.path))
+        source_frames = source_decoder.get_frames_in_range(start=0, stop=10).data.to(
+            device
+        )
         frame_rate = source_decoder.metadata.average_fps
+        percentage, atol = (95, 3) if device == "cuda" else (99, 2)
 
         encoder, encoder_output = self._create_encoder(method, tmp_path, format)
-        streaming_encoder_add_video_stream(
-            encoder,
-            frame_rate=frame_rate,
-            pixel_format="yuv444p",
-            crf=0,
-        )
+        add_video_stream_kwargs = {"frame_rate": frame_rate}
+        if device == "cpu":
+            add_video_stream_kwargs["pixel_format"] = "yuv444p"
+            add_video_stream_kwargs["crf"] = 0
+        else:
+            add_video_stream_kwargs["extra_options"] = ["qp", "1"]
+        streaming_encoder_add_video_stream(encoder, **add_video_stream_kwargs)
         streaming_encoder_add_frames(encoder, source_frames[:5])
         streaming_encoder_add_frames(encoder, source_frames[5:])
         streaming_encoder_close(encoder)
@@ -1201,7 +1209,7 @@ class TestMultiStreamEncoderOps:
             .data
         )
         assert_tensor_close_on_at_least(
-            decoded_frames, source_frames, percentage=99, atol=2
+            decoded_frames, source_frames.cpu(), percentage=percentage, atol=atol
         )
 
     def test_create_invalid_path(self):
@@ -1224,31 +1232,45 @@ class TestMultiStreamEncoderOps:
 
     @pytest.mark.parametrize("format", ["mp4", "mov"])
     @pytest.mark.parametrize("method", ("to_file", "to_file_like"))
-    def test_fragmented_mp4(self, format, tmp_path, method):
-        source_decoder = VideoDecoder(str(NASA_VIDEO.path))
-        source_frames = source_decoder.get_frames_in_range(start=0, stop=10).data
+    @pytest.mark.parametrize(
+        "device", ("cpu", pytest.param("cuda", marks=pytest.mark.needs_cuda))
+    )
+    def test_fragmented_mp4(self, format, tmp_path, method, device):
+        source_decoder = VideoDecoder(str(TEST_SRC_2_720P.path))
+        source_frames = source_decoder.get_frames_in_range(start=0, stop=10).data.to(
+            device
+        )
         frame_rate = source_decoder.metadata.average_fps
+        percentage, atol = (95, 3) if device == "cuda" else (99, 2)
 
         encoder, encoder_output = self._create_encoder(method, tmp_path, format)
-        streaming_encoder_add_video_stream(
-            encoder,
-            frame_rate=frame_rate,
-            pixel_format="yuv444p",
-            crf=0,
-            # In addition to the fragmentation flag, I found "flush_packets" and "threads" to be necessary to decode frames before close().
-            # See other frag flags: https://ffmpeg.org/ffmpeg-formats.html#Fragmentation
-            # TODO MultiStreamEncoder: Get a better understanding of which options are necessary for reading fragmented mp4s
-            extra_options=[
-                "movflags",
-                "+frag_every_frame+empty_moov",
-                "tune",
-                "zerolatency",
-                "flush_packets",
-                "1",
-                "threads",
-                "1",
-            ],
-        )
+        extra_options = [
+            "movflags",
+            "+frag_every_frame+empty_moov",
+            "flush_packets",
+            "1",
+            "threads",
+            "1",
+        ]
+        if device == "cuda":
+            extra_options.extend(["qp", "1"])
+            streaming_encoder_add_video_stream(
+                encoder,
+                frame_rate=frame_rate,
+                extra_options=extra_options,
+            )
+        else:
+            extra_options.extend(["tune", "zerolatency"])
+            streaming_encoder_add_video_stream(
+                encoder,
+                frame_rate=frame_rate,
+                pixel_format="yuv444p",
+                crf=0,
+                # In addition to the fragmentation flag, I found "flush_packets" and "threads" to be necessary to decode frames before close().
+                # See other frag flags: https://ffmpeg.org/ffmpeg-formats.html#Fragmentation
+                # TODO MultiStreamEncoder: Get a better understanding of which options are necessary for reading fragmented mp4s
+                extra_options=extra_options,
+            )
         # Here, we decode the available fragmented mp4 frames before calling close()
         for batch in [source_frames[:5], source_frames[5:]]:
             streaming_encoder_add_frames(encoder, batch)
@@ -1257,9 +1279,9 @@ class TestMultiStreamEncoderOps:
             assert num_available > 0
             assert_tensor_close_on_at_least(
                 mid_decoder.get_frames_in_range(start=0, stop=num_available).data,
-                source_frames[:num_available],
-                percentage=99,
-                atol=2,
+                source_frames[:num_available].cpu(),
+                percentage=percentage,
+                atol=atol,
             )
 
         streaming_encoder_close(encoder)
@@ -1268,9 +1290,9 @@ class TestMultiStreamEncoderOps:
             VideoDecoder(self._get_decoder_source(encoder_output))
             .get_frames_in_range(start=0, stop=10)
             .data,
-            source_frames,
-            percentage=99,
-            atol=2,
+            source_frames.cpu(),
+            percentage=percentage,
+            atol=atol,
         )
 
     @pytest.mark.parametrize("method", ("to_file", "to_file_like"))
@@ -1281,19 +1303,40 @@ class TestMultiStreamEncoderOps:
             streaming_encoder_add_video_stream(encoder, frame_rate=24.0)
 
     @pytest.mark.parametrize("method", ("to_file", "to_file_like"))
-    def test_add_frames_different_sizes_errors(self, tmp_path, method):
+    @pytest.mark.parametrize(
+        "device", ("cpu", pytest.param("cuda", marks=pytest.mark.needs_cuda))
+    )
+    def test_add_frames_different_sizes_errors(self, tmp_path, method, device):
         encoder, _ = self._create_encoder(method, tmp_path, "mp4")
         streaming_encoder_add_video_stream(encoder, frame_rate=30.0)
-        frames_64 = torch.randint(0, 256, (2, 3, 64, 64), dtype=torch.uint8)
-        frames_128 = torch.randint(0, 256, (2, 3, 128, 128), dtype=torch.uint8)
-        streaming_encoder_add_frames(encoder, frames_64)
+        frames_256 = torch.randint(0, 256, (2, 3, 256, 256), dtype=torch.uint8).to(
+            device
+        )
+        frames_512 = torch.randint(0, 256, (2, 3, 512, 512), dtype=torch.uint8).to(
+            device
+        )
+        streaming_encoder_add_frames(encoder, frames_256)
         with pytest.raises(RuntimeError, match="same dimensions"):
-            streaming_encoder_add_frames(encoder, frames_128)
+            streaming_encoder_add_frames(encoder, frames_512)
+
+    @pytest.mark.needs_cuda
+    @pytest.mark.parametrize("method", ("to_file", "to_file_like"))
+    def test_add_frames_different_devices_errors(self, tmp_path, method):
+        encoder, _ = self._create_encoder(method, tmp_path, "mp4")
+        streaming_encoder_add_video_stream(encoder, frame_rate=30.0)
+        cpu_frames = torch.randint(0, 256, (2, 3, 64, 64), dtype=torch.uint8)
+        cuda_frames = cpu_frames.to("cuda")
+        streaming_encoder_add_frames(encoder, cpu_frames)
+        with pytest.raises(RuntimeError, match="same device"):
+            streaming_encoder_add_frames(encoder, cuda_frames)
 
     @pytest.mark.parametrize("method", ("to_file", "to_file_like"))
-    def test_add_frames_without_stream_errors(self, tmp_path, method):
+    @pytest.mark.parametrize(
+        "device", ("cpu", pytest.param("cuda", marks=pytest.mark.needs_cuda))
+    )
+    def test_add_frames_without_stream_errors(self, tmp_path, method, device):
         encoder, _ = self._create_encoder(method, tmp_path, "mp4")
-        frames = torch.randint(0, 256, (5, 3, 64, 64), dtype=torch.uint8)
+        frames = torch.randint(0, 256, (5, 3, 64, 64), dtype=torch.uint8).to(device)
         with pytest.raises(RuntimeError, match="No video stream"):
             streaming_encoder_add_frames(encoder, frames)
 

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1253,7 +1253,7 @@ class TestMultiStreamEncoderOps:
             "1",
         ]
         if device == "cuda":
-            extra_options.extend(["qp", "1"])
+            extra_options.extend(["qp", "1", "delay", "0"])
             streaming_encoder_add_video_stream(
                 encoder,
                 frame_rate=frame_rate,

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1189,7 +1189,7 @@ class TestMultiStreamEncoderOps:
             device
         )
         frame_rate = source_decoder.metadata.average_fps
-        percentage, atol = (95, 3) if device == "cuda" else (99, 2)
+        percentage, atol = (96, 2) if device == "cuda" else (99, 2)
 
         encoder, encoder_output = self._create_encoder(method, tmp_path, format)
         add_video_stream_kwargs = {"frame_rate": frame_rate}
@@ -1241,7 +1241,7 @@ class TestMultiStreamEncoderOps:
             device
         )
         frame_rate = source_decoder.metadata.average_fps
-        percentage, atol = (95, 3) if device == "cuda" else (99, 2)
+        percentage, atol = (96, 2) if device == "cuda" else (99, 2)
 
         encoder, encoder_output = self._create_encoder(method, tmp_path, format)
         # In addition to the fragmentation flag, "flush_packets" and "threads"

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1244,6 +1244,11 @@ class TestMultiStreamEncoderOps:
         percentage, atol = (95, 3) if device == "cuda" else (99, 2)
 
         encoder, encoder_output = self._create_encoder(method, tmp_path, format)
+        # In addition to the fragmentation flag, "flush_packets" and "threads"
+        # are necessary to decode frames before close().
+        # See frag flags: https://ffmpeg.org/ffmpeg-formats.html#Fragmentation
+        # TODO MultiStreamEncoder: Get a better understanding of which options
+        # are necessary for reading fragmented mp4s
         extra_options = [
             "movflags",
             "+frag_every_frame+empty_moov",
@@ -1254,23 +1259,17 @@ class TestMultiStreamEncoderOps:
         ]
         if device == "cuda":
             extra_options.extend(["qp", "1", "delay", "0"])
-            streaming_encoder_add_video_stream(
-                encoder,
-                frame_rate=frame_rate,
-                extra_options=extra_options,
-            )
+            pixel_format, crf = None, None
         else:
             extra_options.extend(["tune", "zerolatency"])
-            streaming_encoder_add_video_stream(
-                encoder,
-                frame_rate=frame_rate,
-                pixel_format="yuv444p",
-                crf=0,
-                # In addition to the fragmentation flag, I found "flush_packets" and "threads" to be necessary to decode frames before close().
-                # See other frag flags: https://ffmpeg.org/ffmpeg-formats.html#Fragmentation
-                # TODO MultiStreamEncoder: Get a better understanding of which options are necessary for reading fragmented mp4s
-                extra_options=extra_options,
-            )
+            pixel_format, crf = "yuv444p", 0
+        streaming_encoder_add_video_stream(
+            encoder,
+            frame_rate=frame_rate,
+            pixel_format=pixel_format,
+            crf=crf,
+            extra_options=extra_options,
+        )
         # Here, we decode the available fragmented mp4 frames before calling close()
         for batch in [source_frames[:5], source_frames[5:]]:
             streaming_encoder_add_frames(encoder, batch)


### PR DESCRIPTION
This PR adds support for GPU encoding in the streaming encoder, copying existing logic from `VideoEncoder`.

* `MultiStreamEncoder::initializeVideoStream()` is updated to detect the device from the passed in frames, and handle CUDA options accordingly. This function is parallel with [VideoEncoder::initializeEncoder](https://github.com/meta-pytorch/torchcodec/blob/910005cf5328d9d44ff8123ad540a51db9ce15b5/src/torchcodec/_core/Encoder.cpp#L746)
  * See [this diffing](https://www.internalfb.com/intern/diffing/?paste_number=2275591167) for a side by side comparison
  
### Testing
These tests are updated to ensure encoding succeeds on CUDA:
* `test_add_video_stream_and_encode_frames` and `test_fragmented_mp4`
These tests are updated to ensure expected errors are raised on CUDA:
* `test_add_frames_different_sizes_errors`
* `test_add_frames_without_stream_errors`
This test is added to ensure adding frames on different devices raises an error:
* `test_add_frames_different_devices_errors`