### PR TITLE
Test stable abi on 2 11

### DIFF
--- a/src/torchcodec/_core/AVIOFileLikeContext.h
+++ b/src/torchcodec/_core/AVIOFileLikeContext.h
@@ -6,8 +6,14 @@
 
 #pragma once
 
+// pybind11 headers from torch error out if TORCH_TARGET_VERSION is defined,
+// so we temporarily undefine it.
+// See https://github.com/pytorch/pytorch/pull/174372 for context
+#pragma push_macro("TORCH_TARGET_VERSION")
+#undef TORCH_TARGET_VERSION
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+#pragma pop_macro("TORCH_TARGET_VERSION")
 
 #include "AVIOContextHolder.h"
 

--- a/src/torchcodec/_core/CMakeLists.txt
+++ b/src/torchcodec/_core/CMakeLists.txt
@@ -57,8 +57,8 @@ function(make_torchcodec_sublibrary
     # torch, we want to rely on the "header-only" mode of these headers and hit
     # all the `#ifdef FMT_HEADER_ONLY` paths, so we define FMT_HEADER_ONLY here.```
     target_compile_definitions(${library_name} PRIVATE FMT_HEADER_ONLY)
-    # TC is ABI-stable w.r.t. torch since torch 2.12
-    target_compile_definitions(${library_name} PRIVATE TORCH_TARGET_VERSION=0x020c000000000000)
+    # TC is ABI-stable w.r.t. torch since torch 2.11
+    target_compile_definitions(${library_name} PRIVATE TORCH_TARGET_VERSION=0x020b000000000000)
 
     # Avoid adding the "lib" prefix which we already add explicitly.
     set_target_properties(${library_name} PROPERTIES PREFIX "")

--- a/src/torchcodec/_core/CMakeLists.txt
+++ b/src/torchcodec/_core/CMakeLists.txt
@@ -57,6 +57,8 @@ function(make_torchcodec_sublibrary
     # torch, we want to rely on the "header-only" mode of these headers and hit
     # all the `#ifdef FMT_HEADER_ONLY` paths, so we define FMT_HEADER_ONLY here.```
     target_compile_definitions(${library_name} PRIVATE FMT_HEADER_ONLY)
+    # TC is ABI-stable w.r.t. torch since torch 2.12
+    target_compile_definitions(${library_name} PRIVATE TORCH_TARGET_VERSION=0x020c000000000000)
 
     # Avoid adding the "lib" prefix which we already add explicitly.
     set_target_properties(${library_name} PROPERTIES PREFIX "")

--- a/src/torchcodec/_core/DeviceInterface.cpp
+++ b/src/torchcodec/_core/DeviceInterface.cpp
@@ -5,7 +5,6 @@
 // LICENSE file in the root directory of this source tree.
 
 #include "DeviceInterface.h"
-#include <ATen/ops/from_blob.h>
 #include <map>
 #include <mutex>
 #include "StableABICompat.h"
@@ -126,22 +125,17 @@ torch::stable::Tensor rgbAVFrameToTensor(const UniqueAVFrame& avFrame) {
   std::vector<int64_t> strides = {avFrame->linesize[0], 3, 1};
   AVFrame* avFrameClone = av_frame_clone(avFrame.get());
 
-  // TODO_STABLE_ABI: we're still using the non-stable ABI here. That's because
-  // stable::from_blob doesn't yet support a capturing lambda deleter. We need
-  // to land https://github.com/pytorch/pytorch/pull/175089.
-  // TC won't be able stable until this is resolved.
   auto deleter = [avFrameClone](void*) {
     UniqueAVFrame avFrameToDelete(avFrameClone);
   };
 
-  at::Tensor tensor = at::from_blob(
-      avFrameClone->data[0], shape, strides, deleter, {at::kByte});
-
-  // We got an at::Tensor, we have to convert it to a torch::stable::Tensor.
-  // This is safe, there won't be any memory leak, i.e. the at::Tensor's deleter
-  // will properly be passed down to the torch::stable::Tensor.
-  at::Tensor* p = new at::Tensor(std::move(tensor));
-  return torch::stable::Tensor(reinterpret_cast<AtenTensorHandle>(p));
+  return torch::stable::from_blob(
+      avFrameClone->data[0],
+      shape,
+      strides,
+      StableDevice(kStableCPU),
+      kStableUInt8,
+      deleter);
 }
 
 } // namespace facebook::torchcodec

--- a/src/torchcodec/_core/NVDECCacheConfig.cpp
+++ b/src/torchcodec/_core/NVDECCacheConfig.cpp
@@ -5,11 +5,10 @@
 // LICENSE file in the root directory of this source tree.
 
 #include "NVDECCacheConfig.h"
+#include "StableABICompat.h"
 
 #include <atomic>
 #include <mutex>
-
-#include "c10/util/Exception.h"
 
 #ifdef USE_CUDA
 #include "CUDACommon.h"
@@ -30,7 +29,7 @@ static std::atomic<int> g_nvdecCacheCapacity{DEFAULT_NVDEC_CACHE_CAPACITY};
 static std::mutex g_nvdecCacheCapacityMutex;
 
 void setNVDECCacheCapacity(int capacity) {
-  TORCH_CHECK(
+  STD_TORCH_CHECK(
       capacity >= 0,
       "NVDEC cache capacity must be non-negative, got ",
       capacity);
@@ -47,7 +46,7 @@ int getNVDECCacheCapacity() {
 
 int getNVDECCacheSize([[maybe_unused]] int device_index) {
 #ifdef USE_CUDA
-  TORCH_CHECK(
+  STD_TORCH_CHECK(
       device_index >= 0 && device_index < MAX_CUDA_GPUS,
       "device_index must be between 0 and ",
       MAX_CUDA_GPUS - 1,

--- a/src/torchcodec/_core/custom_ops.cpp
+++ b/src/torchcodec/_core/custom_ops.cpp
@@ -4,8 +4,14 @@
 // This source code is licensed under the BSD-style license found in the
 // LICENSE file in the root directory of this source tree.
 
+// fmt and pybind11 headers from torch error out if TORCH_TARGET_VERSION is
+// defined, so we temporarily undefine it.
+// See https://github.com/pytorch/pytorch/pull/174372 for context
+#pragma push_macro("TORCH_TARGET_VERSION")
+#undef TORCH_TARGET_VERSION
 #include <fmt/format.h>
 #include <pybind11/pybind11.h>
+#pragma pop_macro("TORCH_TARGET_VERSION")
 #include <cstdint>
 #include <sstream>
 #include <string>
@@ -89,16 +95,11 @@ STABLE_TORCH_LIBRARY(torchcodec_ns, m) {
 
 namespace {
 
-// TODO_STABLE_ABI: use previous deleter pattern with a lambda, once
-// https://github.com/pytorch/pytorch/pull/175089 is available.
-void decoderDeleter(void* data) {
-  delete static_cast<SingleStreamDecoder*>(data);
-}
-
 torch::stable::Tensor wrapDecoderPointerToTensor(
     std::unique_ptr<SingleStreamDecoder> uniqueDecoder) {
   SingleStreamDecoder* decoder = uniqueDecoder.release();
 
+  auto deleter = [decoder](void*) { delete decoder; };
   int64_t sizes[] = {static_cast<int64_t>(sizeof(SingleStreamDecoder*))};
   int64_t strides[] = {1};
   torch::stable::Tensor tensor = torch::stable::from_blob(
@@ -107,7 +108,7 @@ torch::stable::Tensor wrapDecoderPointerToTensor(
       {strides, 1},
       StableDevice(kStableCPU),
       kStableInt64,
-      &decoderDeleter);
+      deleter);
   auto videoDecoder =
       static_cast<SingleStreamDecoder*>(tensor.mutable_data_ptr());
   STD_TORCH_CHECK(videoDecoder == decoder, "videoDecoder != decoder");

--- a/src/torchcodec/_core/pybind_ops.cpp
+++ b/src/torchcodec/_core/pybind_ops.cpp
@@ -4,8 +4,14 @@
 // This source code is licensed under the BSD-style license found in the
 // LICENSE file in the root directory of this source tree.
 
+// pybind11 headers from torch error out if TORCH_TARGET_VERSION is defined,
+// so we temporarily undefine it.
+// See https://github.com/pytorch/pytorch/pull/174372 for context
+#pragma push_macro("TORCH_TARGET_VERSION")
+#undef TORCH_TARGET_VERSION
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+#pragma pop_macro("TORCH_TARGET_VERSION")
 #include <cstdint>
 
 #include "AVIOFileLikeContext.h"


### PR DESCRIPTION
Importantly, this PR targets the `release/0.11` branch to test if https://github.com/meta-pytorch/torchcodec/pull/1260 would actually work against torch 2.11 (it does!)