### PR TITLE
Refactor streaming encoder to use VideoStream struct

### DIFF
--- a/src/torchcodec/_core/Encoder.cpp
+++ b/src/torchcodec/_core/Encoder.cpp
@@ -1119,7 +1119,7 @@ void MultiStreamEncoder::initializeVideoStream(
     const torch::stable::Tensor& frames) {
   auto& videoStream = *videoStream_;
   auto tensorDevice = frames.device();
-  videoStream.deviceInterface = createDeviceInterface(StableDevice(
+  deviceInterface_ = createDeviceInterface(StableDevice(
       static_cast<StableDeviceType>(tensorDevice.type()),
       tensorDevice.index()));
   const AVCodec* avCodec = nullptr;
@@ -1143,7 +1143,7 @@ void MultiStreamEncoder::initializeVideoStream(
         "Output format is null, unable to find default codec.");
     // Try to substitute the default codec with its hardware equivalent
     // This will return std::nullopt when device is CPU.
-    auto hwCodec = videoStream.deviceInterface->findCodec(
+    auto hwCodec = deviceInterface_->findCodec(
         avFormatContext_->oformat->video_codec, /*isDecoder=*/false);
     if (hwCodec.has_value()) {
       avCodec = hwCodec.value();
@@ -1163,7 +1163,7 @@ void MultiStreamEncoder::initializeVideoStream(
   AVCodecContext* avCodecContext = avcodec_alloc_context3(avCodec);
   STD_TORCH_CHECK(
       avCodecContext != nullptr, "Couldn't allocate codec context.");
-  videoStream.avCodecContext_.reset(avCodecContext);
+  videoStream.avCodecContext.reset(avCodecContext);
 
   // Store dimensions of input frames
   // TODO MultiStreamEncoder: Enable tensors in NHWC shape
@@ -1178,6 +1178,8 @@ void MultiStreamEncoder::initializeVideoStream(
   AVPixelFormat outPixelFormat = AV_PIX_FMT_NONE;
 
   if (videoStream.options.pixelFormat.has_value()) {
+    // TODO-MultiStreamEncoder: (P2) Enable pixel formats to be set by user on
+    // GPU and handled with the appropriate NPP function on GPU.
     if (frames.device().type() == kStableCUDA) {
       STD_TORCH_CHECK(
           false,
@@ -1203,19 +1205,19 @@ void MultiStreamEncoder::initializeVideoStream(
   }
 
   // Configure codec parameters
-  videoStream.avCodecContext_->codec_id = avCodec->id;
-  videoStream.avCodecContext_->width = outWidth;
-  videoStream.avCodecContext_->height = outHeight;
-  videoStream.avCodecContext_->pix_fmt = outPixelFormat;
+  videoStream.avCodecContext->codec_id = avCodec->id;
+  videoStream.avCodecContext->width = outWidth;
+  videoStream.avCodecContext->height = outHeight;
+  videoStream.avCodecContext->pix_fmt = outPixelFormat;
   // TODO MultiStreamEncoder: Add and utilize output frame_rate option
-  videoStream.avCodecContext_->framerate =
+  videoStream.avCodecContext->framerate =
       av_d2q(videoStream.inFrameRate, INT_MAX);
-  videoStream.avCodecContext_->time_base =
-      av_inv_q(videoStream.avCodecContext_->framerate);
+  videoStream.avCodecContext->time_base =
+      av_inv_q(videoStream.avCodecContext->framerate);
 
   // Set flag for containers that require extradata to be in the codec context
   if (avFormatContext_->oformat->flags & AVFMT_GLOBALHEADER) {
-    videoStream.avCodecContext_->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
+    videoStream.avCodecContext->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
   }
 
   // Apply videoStreamOptions
@@ -1246,14 +1248,14 @@ void MultiStreamEncoder::initializeVideoStream(
   }
 
   if (frames.device().type() == kStableCUDA) {
-    videoStream.deviceInterface->registerHardwareDeviceWithCodec(
-        videoStream.avCodecContext_.get());
-    videoStream.deviceInterface->setupHardwareFrameContextForEncoding(
-        videoStream.avCodecContext_.get());
+    deviceInterface_->registerHardwareDeviceWithCodec(
+        videoStream.avCodecContext.get());
+    deviceInterface_->setupHardwareFrameContextForEncoding(
+        videoStream.avCodecContext.get());
   }
 
   int status = avcodec_open2(
-      videoStream.avCodecContext_.get(), avCodec, avCodecOptions.getAddress());
+      videoStream.avCodecContext.get(), avCodec, avCodecOptions.getAddress());
 
   STD_TORCH_CHECK(
       status == AVSUCCESS,
@@ -1265,13 +1267,13 @@ void MultiStreamEncoder::initializeVideoStream(
       videoStream.avStream != nullptr, "Couldn't create new stream.");
 
   // Set the stream time base to encode correct frame timestamps
-  videoStream.avStream->time_base = videoStream.avCodecContext_->time_base;
+  videoStream.avStream->time_base = videoStream.avCodecContext->time_base;
   // Set the stream frame rate to store correct frame durations for some
   // containers (webm, mkv)
-  videoStream.avStream->r_frame_rate = videoStream.avCodecContext_->framerate;
+  videoStream.avStream->r_frame_rate = videoStream.avCodecContext->framerate;
 
   status = avcodec_parameters_from_context(
-      videoStream.avStream->codecpar, videoStream.avCodecContext_.get());
+      videoStream.avStream->codecpar, videoStream.avCodecContext.get());
   STD_TORCH_CHECK(
       status == AVSUCCESS,
       "avcodec_parameters_from_context failed: ",
@@ -1290,38 +1292,31 @@ void MultiStreamEncoder::addFrames(const torch::stable::Tensor& frames) {
   STD_TORCH_CHECK(
       videoStream_.has_value(),
       "No video stream has been added. Call addVideoStream() first.");
-  auto& videoStream = *videoStream_;
   auto validatedFrames = validateFrames(
       frames,
-      videoStream.avStream ? videoStream.avCodecContext_.get() : nullptr,
-      videoStream.deviceInterface.get());
+      videoStream_->avStream ? videoStream_->avCodecContext.get() : nullptr,
+      deviceInterface_.get());
 
   if (!headerWritten_) {
     initializeVideoStream(validatedFrames);
   }
 
-  encodeVideoFrames(validatedFrames);
-}
-
-void MultiStreamEncoder::encodeVideoFrames(
-    const torch::stable::Tensor& frames) {
   auto& videoStream = *videoStream_;
   AutoAVPacket autoAVPacket;
   // TODO MultiStreamEncoder: Consider using accessor for potential performance
   // improvement
-  int numFrames = static_cast<int>(frames.sizes()[0]);
+  int numFrames = static_cast<int>(validatedFrames.sizes()[0]);
   for (int i = 0; i < numFrames; ++i) {
-    torch::stable::Tensor currFrame = selectRow(frames, i);
+    torch::stable::Tensor currFrame = selectRow(validatedFrames, i);
     int frameIndex = videoStream.numEncodedFrames + i;
-    UniqueAVFrame avFrame =
-        videoStream.deviceInterface->convertTensorToAVFrameForEncoding(
-            currFrame, frameIndex, videoStream.avCodecContext_.get());
+    UniqueAVFrame avFrame = deviceInterface_->convertTensorToAVFrameForEncoding(
+        currFrame, frameIndex, videoStream.avCodecContext.get());
     STD_TORCH_CHECK(
         avFrame != nullptr,
         "convertTensorToAVFrameForEncoding failed for frame ",
         frameIndex,
         " on device: ",
-        deviceTypeName(frames.device().type()));
+        deviceTypeName(validatedFrames.device().type()));
     encodeVideoFrame(autoAVPacket, avFrame);
   }
   videoStream.numEncodedFrames += numFrames;
@@ -1332,7 +1327,7 @@ void MultiStreamEncoder::encodeVideoFrame(
     const UniqueAVFrame& avFrame) {
   auto& videoStream = *videoStream_;
   auto status =
-      avcodec_send_frame(videoStream.avCodecContext_.get(), avFrame.get());
+      avcodec_send_frame(videoStream.avCodecContext.get(), avFrame.get());
   STD_TORCH_CHECK(
       status == AVSUCCESS,
       "Error while sending frame: ",
@@ -1341,7 +1336,7 @@ void MultiStreamEncoder::encodeVideoFrame(
   while (status >= 0) {
     ReferenceAVPacket packet(autoAVPacket);
     status =
-        avcodec_receive_packet(videoStream.avCodecContext_.get(), packet.get());
+        avcodec_receive_packet(videoStream.avCodecContext.get(), packet.get());
     if (status == AVERROR(EAGAIN) || status == AVERROR_EOF) {
       if (status == AVERROR_EOF) {
         // Flush remaining buffered packets
@@ -1362,19 +1357,12 @@ void MultiStreamEncoder::encodeVideoFrame(
     // https://github.com/pytorch/audio/blob/b6a3368a45aaafe05f1a6a9f10c68adc5e944d9e/src/libtorio/ffmpeg/stream_writer/encoder.cpp#L46
     // Setting packet->duration to 1 allows the last frame to be properly
     // encoded, and needs to be set before calling av_packet_rescale_ts.
-    // Some fragmented muxing paths can surface negative durations here as well.
-    if (packet->duration <= 0) {
+    if (packet->duration == 0) {
       packet->duration = 1;
-    }
-    if (packet->pts == AV_NOPTS_VALUE) {
-      packet->pts = packet->dts;
-    }
-    if (packet->dts == AV_NOPTS_VALUE) {
-      packet->dts = packet->pts;
     }
     av_packet_rescale_ts(
         packet.get(),
-        videoStream.avCodecContext_->time_base,
+        videoStream.avCodecContext->time_base,
         videoStream.avStream->time_base);
     packet->stream_index = videoStream.avStream->index;
 

--- a/src/torchcodec/_core/Encoder.cpp
+++ b/src/torchcodec/_core/Encoder.cpp
@@ -1105,14 +1105,13 @@ void MultiStreamEncoder::addVideoStream(
       !videoStream_.has_value(),
       "A video stream has already been added. Cannot add another.");
   STD_TORCH_CHECK(frameRate > 0, "frame_rate must be > 0, got ", frameRate);
-  VideoStream videoStream;
-  videoStream.inFrameRate = frameRate;
-  videoStream.options.codec = std::move(codec);
-  videoStream.options.pixelFormat = std::move(pixelFormat);
-  videoStream.options.crf = crf;
-  videoStream.options.preset = std::move(preset);
-  videoStream.options.extraOptions = std::move(extraOptions);
-  videoStream_ = std::move(videoStream);
+  videoStream_.emplace();
+  videoStream_->inFrameRate = frameRate;
+  videoStream_->options.codec = std::move(codec);
+  videoStream_->options.pixelFormat = std::move(pixelFormat);
+  videoStream_->options.crf = crf;
+  videoStream_->options.preset = std::move(preset);
+  videoStream_->options.extraOptions = std::move(extraOptions);
 }
 
 void MultiStreamEncoder::initializeVideoStream(

--- a/src/torchcodec/_core/Encoder.cpp
+++ b/src/torchcodec/_core/Encoder.cpp
@@ -1102,28 +1102,31 @@ void MultiStreamEncoder::addVideoStream(
     std::optional<std::string> preset,
     std::optional<std::map<std::string, std::string>> extraOptions) {
   STD_TORCH_CHECK(
-      inFrameRate_ == 0,
+      !videoStream_.has_value(),
       "A video stream has already been added. Cannot add another.");
   STD_TORCH_CHECK(frameRate > 0, "frame_rate must be > 0, got ", frameRate);
-  inFrameRate_ = frameRate;
-  videoStreamOptions_.codec = std::move(codec);
-  videoStreamOptions_.pixelFormat = std::move(pixelFormat);
-  videoStreamOptions_.crf = crf;
-  videoStreamOptions_.preset = std::move(preset);
-  videoStreamOptions_.extraOptions = std::move(extraOptions);
+  VideoStream videoStream;
+  videoStream.inFrameRate = frameRate;
+  videoStream.options.codec = std::move(codec);
+  videoStream.options.pixelFormat = std::move(pixelFormat);
+  videoStream.options.crf = crf;
+  videoStream.options.preset = std::move(preset);
+  videoStream.options.extraOptions = std::move(extraOptions);
+  videoStream_ = std::move(videoStream);
 }
 
 void MultiStreamEncoder::initializeVideoStream(
     const torch::stable::Tensor& frames) {
+  auto& videoStream = *videoStream_;
   auto tensorDevice = frames.device();
-  deviceInterface_ = createDeviceInterface(StableDevice(
+  videoStream.deviceInterface = createDeviceInterface(StableDevice(
       static_cast<StableDeviceType>(tensorDevice.type()),
       tensorDevice.index()));
   const AVCodec* avCodec = nullptr;
   // If codec arg is provided, find codec using logic similar to FFmpeg:
   // https://github.com/FFmpeg/FFmpeg/blob/master/fftools/ffmpeg_opt.c#L804-L835
-  if (videoStreamOptions_.codec.has_value()) {
-    const std::string& codec = videoStreamOptions_.codec.value();
+  if (videoStream.options.codec.has_value()) {
+    const std::string& codec = videoStream.options.codec.value();
     // Try to find codec by name ("libx264", "libsvtav1")
     avCodec = avcodec_find_encoder_by_name(codec.c_str());
     // Try to find by codec descriptor ("h264", "av1")
@@ -1140,7 +1143,7 @@ void MultiStreamEncoder::initializeVideoStream(
         "Output format is null, unable to find default codec.");
     // Try to substitute the default codec with its hardware equivalent
     // This will return std::nullopt when device is CPU.
-    auto hwCodec = deviceInterface_->findCodec(
+    auto hwCodec = videoStream.deviceInterface->findCodec(
         avFormatContext_->oformat->video_codec, /*isDecoder=*/false);
     if (hwCodec.has_value()) {
       avCodec = hwCodec.value();
@@ -1152,15 +1155,15 @@ void MultiStreamEncoder::initializeVideoStream(
   STD_TORCH_CHECK(
       avCodec != nullptr,
       "Video codec ",
-      videoStreamOptions_.codec.has_value()
-          ? videoStreamOptions_.codec.value() + " "
+      videoStream.options.codec.has_value()
+          ? videoStream.options.codec.value() + " "
           : "",
       "not found. To see available codecs, run: ffmpeg -encoders");
 
   AVCodecContext* avCodecContext = avcodec_alloc_context3(avCodec);
   STD_TORCH_CHECK(
       avCodecContext != nullptr, "Couldn't allocate codec context.");
-  avCodecContext_.reset(avCodecContext);
+  videoStream.avCodecContext_.reset(avCodecContext);
 
   // Store dimensions of input frames
   // TODO MultiStreamEncoder: Enable tensors in NHWC shape
@@ -1174,9 +1177,7 @@ void MultiStreamEncoder::initializeVideoStream(
   int outHeight = inHeight;
   AVPixelFormat outPixelFormat = AV_PIX_FMT_NONE;
 
-  if (videoStreamOptions_.pixelFormat.has_value()) {
-    // TODO-MultiStreamEncoder: (P2) Enable pixel formats to be set by user on
-    // GPU and handled with the appropriate NPP function on GPU.
+  if (videoStream.options.pixelFormat.has_value()) {
     if (frames.device().type() == kStableCUDA) {
       STD_TORCH_CHECK(
           false,
@@ -1184,7 +1185,7 @@ void MultiStreamEncoder::initializeVideoStream(
           "Do not set pixel_format to use nv12 by default.");
     }
     outPixelFormat =
-        validatePixelFormat(*avCodec, videoStreamOptions_.pixelFormat.value());
+        validatePixelFormat(*avCodec, videoStream.options.pixelFormat.value());
   } else {
     if (frames.device().type() == kStableCUDA) {
       // Default to nv12 pixel format when encoding on GPU.
@@ -1202,71 +1203,75 @@ void MultiStreamEncoder::initializeVideoStream(
   }
 
   // Configure codec parameters
-  avCodecContext_->codec_id = avCodec->id;
-  avCodecContext_->width = outWidth;
-  avCodecContext_->height = outHeight;
-  avCodecContext_->pix_fmt = outPixelFormat;
+  videoStream.avCodecContext_->codec_id = avCodec->id;
+  videoStream.avCodecContext_->width = outWidth;
+  videoStream.avCodecContext_->height = outHeight;
+  videoStream.avCodecContext_->pix_fmt = outPixelFormat;
   // TODO MultiStreamEncoder: Add and utilize output frame_rate option
-  avCodecContext_->framerate = av_d2q(inFrameRate_, INT_MAX);
-  avCodecContext_->time_base = av_inv_q(avCodecContext_->framerate);
+  videoStream.avCodecContext_->framerate =
+      av_d2q(videoStream.inFrameRate, INT_MAX);
+  videoStream.avCodecContext_->time_base =
+      av_inv_q(videoStream.avCodecContext_->framerate);
 
   // Set flag for containers that require extradata to be in the codec context
   if (avFormatContext_->oformat->flags & AVFMT_GLOBALHEADER) {
-    avCodecContext_->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
+    videoStream.avCodecContext_->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
   }
 
   // Apply videoStreamOptions
   UniqueAVDictionary avCodecOptions;
-  if (videoStreamOptions_.extraOptions.has_value()) {
-    for (const auto& [key, value] : videoStreamOptions_.extraOptions.value()) {
+  if (videoStream.options.extraOptions.has_value()) {
+    for (const auto& [key, value] : videoStream.options.extraOptions.value()) {
       tryToValidateCodecOption(*avCodec, key.c_str(), value);
     }
     sortCodecOptions(
         avFormatContext_.get(),
-        videoStreamOptions_.extraOptions.value(),
+        videoStream.options.extraOptions.value(),
         avCodecOptions,
         avFormatOptions_);
   }
 
-  if (videoStreamOptions_.crf.has_value()) {
-    std::string crfValue = std::to_string(videoStreamOptions_.crf.value());
+  if (videoStream.options.crf.has_value()) {
+    std::string crfValue = std::to_string(videoStream.options.crf.value());
     tryToValidateCodecOption(*avCodec, "crf", crfValue);
     av_dict_set(avCodecOptions.getAddress(), "crf", crfValue.c_str(), 0);
   }
 
-  if (videoStreamOptions_.preset.has_value()) {
+  if (videoStream.options.preset.has_value()) {
     av_dict_set(
         avCodecOptions.getAddress(),
         "preset",
-        videoStreamOptions_.preset.value().c_str(),
+        videoStream.options.preset.value().c_str(),
         0);
   }
 
   if (frames.device().type() == kStableCUDA) {
-    deviceInterface_->registerHardwareDeviceWithCodec(avCodecContext_.get());
-    deviceInterface_->setupHardwareFrameContextForEncoding(
-        avCodecContext_.get());
+    videoStream.deviceInterface->registerHardwareDeviceWithCodec(
+        videoStream.avCodecContext_.get());
+    videoStream.deviceInterface->setupHardwareFrameContextForEncoding(
+        videoStream.avCodecContext_.get());
   }
 
   int status = avcodec_open2(
-      avCodecContext_.get(), avCodec, avCodecOptions.getAddress());
+      videoStream.avCodecContext_.get(), avCodec, avCodecOptions.getAddress());
 
   STD_TORCH_CHECK(
       status == AVSUCCESS,
       "avcodec_open2 failed: ",
       getFFMPEGErrorStringFromErrorCode(status));
 
-  avStream_ = avformat_new_stream(avFormatContext_.get(), nullptr);
-  STD_TORCH_CHECK(avStream_ != nullptr, "Couldn't create new stream.");
+  videoStream.avStream = avformat_new_stream(avFormatContext_.get(), nullptr);
+  STD_TORCH_CHECK(
+      videoStream.avStream != nullptr, "Couldn't create new stream.");
 
   // Set the stream time base to encode correct frame timestamps
-  avStream_->time_base = avCodecContext_->time_base;
+  videoStream.avStream->time_base = videoStream.avCodecContext_->time_base;
   // Set the stream frame rate to store correct frame durations for some
   // containers (webm, mkv)
-  avStream_->r_frame_rate = avCodecContext_->framerate;
+  videoStream.avStream->r_frame_rate = videoStream.avCodecContext_->framerate;
 
   status = avcodec_parameters_from_context(
-      avStream_->codecpar, avCodecContext_.get());
+      videoStream.avStream->codecpar, videoStream.avCodecContext_.get());
   STD_TORCH_CHECK(
       status == AVSUCCESS,
       "avcodec_parameters_from_context failed: ",
@@ -1283,39 +1288,51 @@ void MultiStreamEncoder::initializeVideoStream(
 
 void MultiStreamEncoder::addFrames(const torch::stable::Tensor& frames) {
   STD_TORCH_CHECK(
-      inFrameRate_ > 0,
+      videoStream_.has_value(),
       "No video stream has been added. Call addVideoStream() first.");
-  auto validatedFrames =
-      validateFrames(frames, avCodecContext_.get(), deviceInterface_.get());
+  auto& videoStream = *videoStream_;
+  auto validatedFrames = validateFrames(
+      frames,
+      videoStream.avStream ? videoStream.avCodecContext_.get() : nullptr,
+      videoStream.deviceInterface.get());
 
   if (!headerWritten_) {
     initializeVideoStream(validatedFrames);
   }
 
+  encodeVideoFrames(validatedFrames);
+}
+
+void MultiStreamEncoder::encodeVideoFrames(
+    const torch::stable::Tensor& frames) {
+  auto& videoStream = *videoStream_;
   AutoAVPacket autoAVPacket;
   // TODO MultiStreamEncoder: Consider using accessor for potential performance
   // improvement
-  int numFrames = static_cast<int>(validatedFrames.sizes()[0]);
+  int numFrames = static_cast<int>(frames.sizes()[0]);
   for (int i = 0; i < numFrames; ++i) {
-    torch::stable::Tensor currFrame = selectRow(validatedFrames, i);
-    int frameIndex = numEncodedFrames_ + i;
-    UniqueAVFrame avFrame = deviceInterface_->convertTensorToAVFrameForEncoding(
-        currFrame, frameIndex, avCodecContext_.get());
+    torch::stable::Tensor currFrame = selectRow(frames, i);
+    int frameIndex = videoStream.numEncodedFrames + i;
+    UniqueAVFrame avFrame =
+        videoStream.deviceInterface->convertTensorToAVFrameForEncoding(
+            currFrame, frameIndex, videoStream.avCodecContext_.get());
     STD_TORCH_CHECK(
         avFrame != nullptr,
         "convertTensorToAVFrameForEncoding failed for frame ",
         frameIndex,
         " on device: ",
-        deviceTypeName(validatedFrames.device().type()));
-    encodeFrame(autoAVPacket, avFrame);
+        deviceTypeName(frames.device().type()));
+    encodeVideoFrame(autoAVPacket, avFrame);
   }
-  numEncodedFrames_ += numFrames;
+  videoStream.numEncodedFrames += numFrames;
 }
 
-void MultiStreamEncoder::encodeFrame(
+void MultiStreamEncoder::encodeVideoFrame(
     AutoAVPacket& autoAVPacket,
     const UniqueAVFrame& avFrame) {
-  auto status = avcodec_send_frame(avCodecContext_.get(), avFrame.get());
+  auto& videoStream = *videoStream_;
+  auto status =
+      avcodec_send_frame(videoStream.avCodecContext_.get(), avFrame.get());
   STD_TORCH_CHECK(
       status == AVSUCCESS,
       "Error while sending frame: ",
@@ -1323,7 +1340,8 @@ void MultiStreamEncoder::encodeFrame(
 
   while (status >= 0) {
     ReferenceAVPacket packet(autoAVPacket);
-    status = avcodec_receive_packet(avCodecContext_.get(), packet.get());
+    status =
+        avcodec_receive_packet(videoStream.avCodecContext_.get(), packet.get());
     if (status == AVERROR(EAGAIN) || status == AVERROR_EOF) {
       if (status == AVERROR_EOF) {
         // Flush remaining buffered packets
@@ -1344,12 +1362,21 @@ void MultiStreamEncoder::encodeFrame(
     // https://github.com/pytorch/audio/blob/b6a3368a45aaafe05f1a6a9f10c68adc5e944d9e/src/libtorio/ffmpeg/stream_writer/encoder.cpp#L46
     // Setting packet->duration to 1 allows the last frame to be properly
     // encoded, and needs to be set before calling av_packet_rescale_ts.
-    if (packet->duration == 0) {
+    // Some fragmented muxing paths can surface negative durations here as well.
+    if (packet->duration <= 0) {
       packet->duration = 1;
     }
+    if (packet->pts == AV_NOPTS_VALUE) {
+      packet->pts = packet->dts;
+    }
+    if (packet->dts == AV_NOPTS_VALUE) {
+      packet->dts = packet->pts;
+    }
     av_packet_rescale_ts(
-        packet.get(), avCodecContext_->time_base, avStream_->time_base);
-    packet->stream_index = avStream_->index;
+        packet.get(),
+        videoStream.avCodecContext_->time_base,
+        videoStream.avStream->time_base);
+    packet->stream_index = videoStream.avStream->index;
 
     status = av_interleaved_write_frame(avFormatContext_.get(), packet.get());
     STD_TORCH_CHECK(
@@ -1360,9 +1387,10 @@ void MultiStreamEncoder::encodeFrame(
 }
 
 void MultiStreamEncoder::flushBuffers() {
-  AutoAVPacket autoAVPacket;
-  // Send null frame to signal end of input
-  encodeFrame(autoAVPacket, UniqueAVFrame(nullptr));
+  if (videoStream_.has_value() && videoStream_->avStream != nullptr) {
+    AutoAVPacket videoAVPacket;
+    encodeVideoFrame(videoAVPacket, UniqueAVFrame(nullptr));
+  }
 }
 
 void MultiStreamEncoder::close() {

--- a/src/torchcodec/_core/Encoder.cpp
+++ b/src/torchcodec/_core/Encoder.cpp
@@ -1372,6 +1372,7 @@ void MultiStreamEncoder::encodeVideoFrame(
 void MultiStreamEncoder::flushBuffers() {
   if (videoStream_.has_value() && videoStream_->avStream != nullptr) {
     AutoAVPacket videoAVPacket;
+    // Send null frame to signal end of input
     encodeVideoFrame(videoAVPacket, UniqueAVFrame(nullptr));
   }
 }

--- a/src/torchcodec/_core/Encoder.cpp
+++ b/src/torchcodec/_core/Encoder.cpp
@@ -1293,24 +1293,21 @@ void MultiStreamEncoder::addFrames(const torch::stable::Tensor& frames) {
       videoStream_.has_value(),
       "No video stream has been added. Call addVideoStream() first.");
   auto validatedFrames = validateFrames(
-      frames,
-      videoStream_->avStream ? videoStream_->avCodecContext.get() : nullptr,
-      deviceInterface_.get());
+      frames, videoStream_->avCodecContext.get(), deviceInterface_.get());
 
   if (!headerWritten_) {
     initializeVideoStream(validatedFrames);
   }
 
-  auto& videoStream = *videoStream_;
   AutoAVPacket autoAVPacket;
   // TODO MultiStreamEncoder: Consider using accessor for potential performance
   // improvement
   int numFrames = static_cast<int>(validatedFrames.sizes()[0]);
   for (int i = 0; i < numFrames; ++i) {
     torch::stable::Tensor currFrame = selectRow(validatedFrames, i);
-    int frameIndex = videoStream.numEncodedFrames + i;
+    int frameIndex = videoStream_->numEncodedFrames + i;
     UniqueAVFrame avFrame = deviceInterface_->convertTensorToAVFrameForEncoding(
-        currFrame, frameIndex, videoStream.avCodecContext.get());
+        currFrame, frameIndex, videoStream_->avCodecContext.get());
     STD_TORCH_CHECK(
         avFrame != nullptr,
         "convertTensorToAVFrameForEncoding failed for frame ",
@@ -1319,15 +1316,14 @@ void MultiStreamEncoder::addFrames(const torch::stable::Tensor& frames) {
         deviceTypeName(validatedFrames.device().type()));
     encodeVideoFrame(autoAVPacket, avFrame);
   }
-  videoStream.numEncodedFrames += numFrames;
+  videoStream_->numEncodedFrames += numFrames;
 }
 
 void MultiStreamEncoder::encodeVideoFrame(
     AutoAVPacket& autoAVPacket,
     const UniqueAVFrame& avFrame) {
-  auto& videoStream = *videoStream_;
   auto status =
-      avcodec_send_frame(videoStream.avCodecContext.get(), avFrame.get());
+      avcodec_send_frame(videoStream_->avCodecContext.get(), avFrame.get());
   STD_TORCH_CHECK(
       status == AVSUCCESS,
       "Error while sending frame: ",
@@ -1335,8 +1331,8 @@ void MultiStreamEncoder::encodeVideoFrame(
 
   while (status >= 0) {
     ReferenceAVPacket packet(autoAVPacket);
-    status =
-        avcodec_receive_packet(videoStream.avCodecContext.get(), packet.get());
+    status = avcodec_receive_packet(
+        videoStream_->avCodecContext.get(), packet.get());
     if (status == AVERROR(EAGAIN) || status == AVERROR_EOF) {
       if (status == AVERROR_EOF) {
         // Flush remaining buffered packets
@@ -1362,9 +1358,9 @@ void MultiStreamEncoder::encodeVideoFrame(
     }
     av_packet_rescale_ts(
         packet.get(),
-        videoStream.avCodecContext->time_base,
-        videoStream.avStream->time_base);
-    packet->stream_index = videoStream.avStream->index;
+        videoStream_->avCodecContext->time_base,
+        videoStream_->avStream->time_base);
+    packet->stream_index = videoStream_->avStream->index;
 
     status = av_interleaved_write_frame(avFormatContext_.get(), packet.get());
     STD_TORCH_CHECK(

--- a/src/torchcodec/_core/Encoder.h
+++ b/src/torchcodec/_core/Encoder.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <map>
+#include <optional>
 #include <string>
 #include "AVIOContextHolder.h"
 #include "DeviceInterface.h"
@@ -203,18 +204,25 @@ class FORCE_PUBLIC_VISIBILITY MultiStreamEncoder {
   void close();
 
  private:
+  struct VideoStream {
+    double inFrameRate = 0;
+    VideoStreamOptions options;
+    UniqueAVCodecContext avCodecContext_;
+    AVStream* avStream = nullptr;
+    std::unique_ptr<DeviceInterface> deviceInterface;
+    int numEncodedFrames = 0;
+  };
+
   void initializeVideoStream(const torch::stable::Tensor& frames);
-  void encodeFrame(AutoAVPacket& autoAVPacket, const UniqueAVFrame& avFrame);
+  void encodeVideoFrames(const torch::stable::Tensor& frames);
+  void encodeVideoFrame(
+      AutoAVPacket& autoAVPacket,
+      const UniqueAVFrame& avFrame);
   void flushBuffers();
 
   UniqueEncodingAVFormatContext avFormatContext_;
-  UniqueAVCodecContext avCodecContext_;
-  AVStream* avStream_ = nullptr;
-  double inFrameRate_ = 0;
-  VideoStreamOptions videoStreamOptions_;
-  std::unique_ptr<DeviceInterface> deviceInterface_;
+  std::optional<VideoStream> videoStream_;
   bool headerWritten_ = false;
-  int numEncodedFrames_ = 0;
   UniqueAVDictionary avFormatOptions_;
 
   std::unique_ptr<AVIOContextHolder> avioContextHolder_;

--- a/src/torchcodec/_core/Encoder.h
+++ b/src/torchcodec/_core/Encoder.h
@@ -207,14 +207,12 @@ class FORCE_PUBLIC_VISIBILITY MultiStreamEncoder {
   struct VideoStream {
     double inFrameRate = 0;
     VideoStreamOptions options;
-    UniqueAVCodecContext avCodecContext_;
+    UniqueAVCodecContext avCodecContext;
     AVStream* avStream = nullptr;
-    std::unique_ptr<DeviceInterface> deviceInterface;
     int numEncodedFrames = 0;
   };
 
   void initializeVideoStream(const torch::stable::Tensor& frames);
-  void encodeVideoFrames(const torch::stable::Tensor& frames);
   void encodeVideoFrame(
       AutoAVPacket& autoAVPacket,
       const UniqueAVFrame& avFrame);
@@ -222,6 +220,7 @@ class FORCE_PUBLIC_VISIBILITY MultiStreamEncoder {
 
   UniqueEncodingAVFormatContext avFormatContext_;
   std::optional<VideoStream> videoStream_;
+  std::unique_ptr<DeviceInterface> deviceInterface_;
   bool headerWritten_ = false;
   UniqueAVDictionary avFormatOptions_;
 


### PR DESCRIPTION
This PR takes us one step closer to https://github.com/meta-pytorch/torchcodec/pull/1335 by refactoring the many video related member variables into the `VideoStream` struct.  
This will allow us to support multiple video streams in the future, and cleans up the variables in the header so we can add audio-related member variables in the future.
* Additionally,  `encodeFrame()` is renamed  to `encodeVideoFrame()`.