### PR TITLE
Add open() function to streaming encoder

### DIFF
--- a/src/torchcodec/_core/CudaDeviceInterface.cpp
+++ b/src/torchcodec/_core/CudaDeviceInterface.cpp
@@ -95,7 +95,7 @@ CudaDeviceInterface::CudaDeviceInterface(const StableDevice& device)
       device_.type() == kStableCUDA, "Unsupported device: must be CUDA");
 
   // Resolve unspecified device index (-1) to the actual current CUDA device.
-  device_ = StableDevice(kStableCUDA, getDeviceIndex(device_));
+  device_.set_index(getDeviceIndex(device_));
 
   initializeCudaContextWithPytorch(device_);
 

--- a/src/torchcodec/_core/CudaDeviceInterface.cpp
+++ b/src/torchcodec/_core/CudaDeviceInterface.cpp
@@ -94,6 +94,9 @@ CudaDeviceInterface::CudaDeviceInterface(const StableDevice& device)
   STD_TORCH_CHECK(
       device_.type() == kStableCUDA, "Unsupported device: must be CUDA");
 
+  // Resolve unspecified device index (-1) to the actual current CUDA device.
+  device_ = StableDevice(kStableCUDA, getDeviceIndex(device_));
+
   initializeCudaContextWithPytorch(device_);
 
   hardwareDeviceCtx_ = getHardwareDeviceContext(device_);

--- a/src/torchcodec/_core/Encoder.cpp
+++ b/src/torchcodec/_core/Encoder.cpp
@@ -1106,16 +1106,16 @@ void MultiStreamEncoder::addVideoStream(
     std::optional<std::string> preset,
     std::optional<std::map<std::string, std::string>> extraOptions) {
   STD_TORCH_CHECK(
-      !videoStream_.has_value(), "Only one video stream is supported.");
+      !videoStream_.has_value(),
+      "A video stream has already been added. Cannot add another.");
   STD_TORCH_CHECK(height > 0, "height must be > 0, got ", height);
   STD_TORCH_CHECK(width > 0, "width must be > 0, got ", width);
   STD_TORCH_CHECK(frameRate > 0, "frame_rate must be > 0, got ", frameRate);
-
   videoStream_.emplace();
   videoStream_->deviceInterface =
       createDeviceInterface(StableDevice(std::move(device)));
-  videoStream_->height = height;
-  videoStream_->width = width;
+  videoStream_->inHeight = height;
+  videoStream_->inWidth = width;
   videoStream_->inFrameRate = frameRate;
   videoStream_->options.codec = std::move(codec);
   videoStream_->options.pixelFormat = std::move(pixelFormat);
@@ -1172,8 +1172,9 @@ void MultiStreamEncoder::initializeVideoStream() {
       avCodecContext != nullptr, "Couldn't allocate codec context.");
   videoStream.avCodecContext.reset(avCodecContext);
 
-  int outHeight = videoStream.height;
-  int outWidth = videoStream.width;
+  // TODO MultiStreamEncoder: Allow output height and width to be set
+  int outHeight = videoStream.inHeight;
+  int outWidth = videoStream.inWidth;
   AVPixelFormat outPixelFormat = AV_PIX_FMT_NONE;
 
   if (videoStream.options.pixelFormat.has_value()) {

--- a/src/torchcodec/_core/Encoder.cpp
+++ b/src/torchcodec/_core/Encoder.cpp
@@ -569,6 +569,7 @@ torch::stable::Tensor validateFrames(
         framesDevice.index());
   }
   if (avCodecContext) {
+    // TODO MultiStreamEncoder: Enable tensors in NHWC shape
     STD_TORCH_CHECK(
         static_cast<int>(frames.sizes()[2]) == avCodecContext->height &&
             static_cast<int>(frames.sizes()[3]) == avCodecContext->width,
@@ -1105,8 +1106,7 @@ void MultiStreamEncoder::addVideoStream(
     std::optional<std::string> preset,
     std::optional<std::map<std::string, std::string>> extraOptions) {
   STD_TORCH_CHECK(
-      !videoStream_.has_value(),
-      "A video stream has already been added. Cannot add another.");
+      !videoStream_.has_value(), "Only one video stream is supported.");
   STD_TORCH_CHECK(height > 0, "height must be > 0, got ", height);
   STD_TORCH_CHECK(width > 0, "width must be > 0, got ", width);
   STD_TORCH_CHECK(frameRate > 0, "frame_rate must be > 0, got ", frameRate);
@@ -1172,8 +1172,6 @@ void MultiStreamEncoder::initializeVideoStream() {
       avCodecContext != nullptr, "Couldn't allocate codec context.");
   videoStream.avCodecContext.reset(avCodecContext);
 
-  // Store dimensions of input frames
-  // TODO MultiStreamEncoder: Enable tensors in NHWC shape
   int outHeight = videoStream.height;
   int outWidth = videoStream.width;
   AVPixelFormat outPixelFormat = AV_PIX_FMT_NONE;
@@ -1282,10 +1280,9 @@ void MultiStreamEncoder::initializeVideoStream() {
 }
 
 void MultiStreamEncoder::open() {
-  STD_TORCH_CHECK(!opened_, "Encoder is already open.");
+  STD_TORCH_CHECK(!headerWritten_, "open() was already called.");
   STD_TORCH_CHECK(
-      videoStream_.has_value(),
-      "No streams have been added. Call addVideoStream() before open().");
+      videoStream_.has_value(), "Call addVideoStream() before open().");
 
   initializeVideoStream();
 
@@ -1295,12 +1292,11 @@ void MultiStreamEncoder::open() {
       status == AVSUCCESS,
       "Error in avformat_write_header: ",
       getFFMPEGErrorStringFromErrorCode(status));
-  opened_ = true;
+  headerWritten_ = true;
 }
 
 void MultiStreamEncoder::addFrames(const torch::stable::Tensor& frames) {
-  STD_TORCH_CHECK(
-      opened_, "Encoder is not open. Call open() after adding streams.");
+  STD_TORCH_CHECK(headerWritten_, "Call open() before addFrames().");
   auto validatedFrames = validateFrames(
       frames, videoStream_->avCodecContext.get(), deviceInterface_.get());
 
@@ -1390,7 +1386,7 @@ void MultiStreamEncoder::close() {
   // TODO MultiStreamEncoder: Revisit if "closed_" flag is useful
   closed_ = true;
 
-  if (opened_) {
+  if (headerWritten_) {
     flushBuffers();
 
     int status = av_write_trailer(avFormatContext_.get());

--- a/src/torchcodec/_core/Encoder.cpp
+++ b/src/torchcodec/_core/Encoder.cpp
@@ -1095,7 +1095,10 @@ MultiStreamEncoder::MultiStreamEncoder(
 }
 
 void MultiStreamEncoder::addVideoStream(
+    int height,
+    int width,
     double frameRate,
+    std::optional<std::string> device,
     std::optional<std::string> codec,
     std::optional<std::string> pixelFormat,
     std::optional<double> crf,
@@ -1104,8 +1107,16 @@ void MultiStreamEncoder::addVideoStream(
   STD_TORCH_CHECK(
       !videoStream_.has_value(),
       "A video stream has already been added. Cannot add another.");
+  STD_TORCH_CHECK(height > 0, "height must be > 0, got ", height);
+  STD_TORCH_CHECK(width > 0, "width must be > 0, got ", width);
   STD_TORCH_CHECK(frameRate > 0, "frame_rate must be > 0, got ", frameRate);
+
+  std::string deviceStr = device.value_or("cpu");
+  deviceInterface_ = createDeviceInterface(StableDevice(std::move(deviceStr)));
+
   videoStream_.emplace();
+  videoStream_->height = height;
+  videoStream_->width = width;
   videoStream_->inFrameRate = frameRate;
   videoStream_->options.codec = std::move(codec);
   videoStream_->options.pixelFormat = std::move(pixelFormat);
@@ -1114,13 +1125,10 @@ void MultiStreamEncoder::addVideoStream(
   videoStream_->options.extraOptions = std::move(extraOptions);
 }
 
-void MultiStreamEncoder::initializeVideoStream(
-    const torch::stable::Tensor& frames) {
+void MultiStreamEncoder::initializeVideoStream() {
   auto& videoStream = *videoStream_;
-  auto tensorDevice = frames.device();
-  deviceInterface_ = createDeviceInterface(StableDevice(
-      static_cast<StableDeviceType>(tensorDevice.type()),
-      tensorDevice.index()));
+  auto deviceType = deviceInterface_->device().type();
+
   const AVCodec* avCodec = nullptr;
   // If codec arg is provided, find codec using logic similar to FFmpeg:
   // https://github.com/FFmpeg/FFmpeg/blob/master/fftools/ffmpeg_opt.c#L804-L835
@@ -1166,20 +1174,14 @@ void MultiStreamEncoder::initializeVideoStream(
 
   // Store dimensions of input frames
   // TODO MultiStreamEncoder: Enable tensors in NHWC shape
-  auto sizes = frames.sizes();
-  int inHeight = static_cast<int>(sizes[2]);
-  int inWidth = static_cast<int>(sizes[3]);
-
-  // Always use input dimensions as output dimensions
-  // TODO MultiStreamEncoder: Allow height and width to be set
-  int outWidth = inWidth;
-  int outHeight = inHeight;
+  int outHeight = videoStream.height;
+  int outWidth = videoStream.width;
   AVPixelFormat outPixelFormat = AV_PIX_FMT_NONE;
 
   if (videoStream.options.pixelFormat.has_value()) {
     // TODO-MultiStreamEncoder: (P2) Enable pixel formats to be set by user on
     // GPU and handled with the appropriate NPP function on GPU.
-    if (frames.device().type() == kStableCUDA) {
+    if (deviceType == kStableCUDA) {
       STD_TORCH_CHECK(
           false,
           "Video encoding on GPU currently only supports the nv12 pixel format. "
@@ -1188,7 +1190,7 @@ void MultiStreamEncoder::initializeVideoStream(
     outPixelFormat =
         validatePixelFormat(*avCodec, videoStream.options.pixelFormat.value());
   } else {
-    if (frames.device().type() == kStableCUDA) {
+    if (deviceType == kStableCUDA) {
       // Default to nv12 pixel format when encoding on GPU.
       outPixelFormat = DeviceInterface::CUDA_ENCODING_PIXEL_FORMAT;
     } else {
@@ -1246,7 +1248,7 @@ void MultiStreamEncoder::initializeVideoStream(
         0);
   }
 
-  if (frames.device().type() == kStableCUDA) {
+  if (deviceType == kStableCUDA) {
     deviceInterface_->registerHardwareDeviceWithCodec(
         videoStream.avCodecContext.get());
     deviceInterface_->setupHardwareFrameContextForEncoding(
@@ -1277,26 +1279,30 @@ void MultiStreamEncoder::initializeVideoStream(
       status == AVSUCCESS,
       "avcodec_parameters_from_context failed: ",
       getFFMPEGErrorStringFromErrorCode(status));
+}
 
-  status = avformat_write_header(
+void MultiStreamEncoder::open() {
+  STD_TORCH_CHECK(!opened_, "Encoder is already open.");
+  STD_TORCH_CHECK(
+      videoStream_.has_value(),
+      "No streams have been added. Call addVideoStream() before open().");
+
+  initializeVideoStream();
+
+  int status = avformat_write_header(
       avFormatContext_.get(), avFormatOptions_.getAddress());
   STD_TORCH_CHECK(
       status == AVSUCCESS,
       "Error in avformat_write_header: ",
       getFFMPEGErrorStringFromErrorCode(status));
-  headerWritten_ = true;
+  opened_ = true;
 }
 
 void MultiStreamEncoder::addFrames(const torch::stable::Tensor& frames) {
   STD_TORCH_CHECK(
-      videoStream_.has_value(),
-      "No video stream has been added. Call addVideoStream() first.");
+      opened_, "Encoder is not open. Call open() after adding streams.");
   auto validatedFrames = validateFrames(
       frames, videoStream_->avCodecContext.get(), deviceInterface_.get());
-
-  if (!headerWritten_) {
-    initializeVideoStream(validatedFrames);
-  }
 
   AutoAVPacket autoAVPacket;
   // TODO MultiStreamEncoder: Consider using accessor for potential performance
@@ -1384,7 +1390,7 @@ void MultiStreamEncoder::close() {
   // TODO MultiStreamEncoder: Revisit if "closed_" flag is useful
   closed_ = true;
 
-  if (headerWritten_) {
+  if (opened_) {
     flushBuffers();
 
     int status = av_write_trailer(avFormatContext_.get());

--- a/src/torchcodec/_core/Encoder.cpp
+++ b/src/torchcodec/_core/Encoder.cpp
@@ -1099,7 +1099,7 @@ void MultiStreamEncoder::addVideoStream(
     int height,
     int width,
     double frameRate,
-    std::optional<std::string> device,
+    std::string device,
     std::optional<std::string> codec,
     std::optional<std::string> pixelFormat,
     std::optional<double> crf,
@@ -1111,10 +1111,9 @@ void MultiStreamEncoder::addVideoStream(
   STD_TORCH_CHECK(width > 0, "width must be > 0, got ", width);
   STD_TORCH_CHECK(frameRate > 0, "frame_rate must be > 0, got ", frameRate);
 
-  std::string deviceStr = device.value_or("cpu");
-  deviceInterface_ = createDeviceInterface(StableDevice(std::move(deviceStr)));
-
   videoStream_.emplace();
+  videoStream_->deviceInterface =
+      createDeviceInterface(StableDevice(std::move(device)));
   videoStream_->height = height;
   videoStream_->width = width;
   videoStream_->inFrameRate = frameRate;
@@ -1126,8 +1125,9 @@ void MultiStreamEncoder::addVideoStream(
 }
 
 void MultiStreamEncoder::initializeVideoStream() {
+  // TODO MultiStreamEncoder: Iterate over all video streams
   auto& videoStream = *videoStream_;
-  auto deviceType = deviceInterface_->device().type();
+  auto deviceType = videoStream.deviceInterface->device().type();
 
   const AVCodec* avCodec = nullptr;
   // If codec arg is provided, find codec using logic similar to FFmpeg:
@@ -1150,7 +1150,7 @@ void MultiStreamEncoder::initializeVideoStream() {
         "Output format is null, unable to find default codec.");
     // Try to substitute the default codec with its hardware equivalent
     // This will return std::nullopt when device is CPU.
-    auto hwCodec = deviceInterface_->findCodec(
+    auto hwCodec = videoStream.deviceInterface->findCodec(
         avFormatContext_->oformat->video_codec, /*isDecoder=*/false);
     if (hwCodec.has_value()) {
       avCodec = hwCodec.value();
@@ -1247,9 +1247,9 @@ void MultiStreamEncoder::initializeVideoStream() {
   }
 
   if (deviceType == kStableCUDA) {
-    deviceInterface_->registerHardwareDeviceWithCodec(
+    videoStream.deviceInterface->registerHardwareDeviceWithCodec(
         videoStream.avCodecContext.get());
-    deviceInterface_->setupHardwareFrameContextForEncoding(
+    videoStream.deviceInterface->setupHardwareFrameContextForEncoding(
         videoStream.avCodecContext.get());
   }
 
@@ -1296,9 +1296,12 @@ void MultiStreamEncoder::open() {
 }
 
 void MultiStreamEncoder::addFrames(const torch::stable::Tensor& frames) {
+  // TODO MultiStreamEncoder: Specify which video stream to add frames to
   STD_TORCH_CHECK(headerWritten_, "Call open() before addFrames().");
   auto validatedFrames = validateFrames(
-      frames, videoStream_->avCodecContext.get(), deviceInterface_.get());
+      frames,
+      videoStream_->avCodecContext.get(),
+      videoStream_->deviceInterface.get());
 
   AutoAVPacket autoAVPacket;
   // TODO MultiStreamEncoder: Consider using accessor for potential performance
@@ -1307,8 +1310,9 @@ void MultiStreamEncoder::addFrames(const torch::stable::Tensor& frames) {
   for (int i = 0; i < numFrames; ++i) {
     torch::stable::Tensor currFrame = selectRow(validatedFrames, i);
     int frameIndex = videoStream_->numEncodedFrames + i;
-    UniqueAVFrame avFrame = deviceInterface_->convertTensorToAVFrameForEncoding(
-        currFrame, frameIndex, videoStream_->avCodecContext.get());
+    UniqueAVFrame avFrame =
+        videoStream_->deviceInterface->convertTensorToAVFrameForEncoding(
+            currFrame, frameIndex, videoStream_->avCodecContext.get());
     STD_TORCH_CHECK(
         avFrame != nullptr,
         "convertTensorToAVFrameForEncoding failed for frame ",

--- a/src/torchcodec/_core/Encoder.h
+++ b/src/torchcodec/_core/Encoder.h
@@ -193,18 +193,24 @@ class FORCE_PUBLIC_VISIBILITY MultiStreamEncoder {
       std::unique_ptr<AVIOContextHolder> avioContextHolder);
 
   void addVideoStream(
+      int height,
+      int width,
       double frameRate,
+      std::optional<std::string> device = std::nullopt,
       std::optional<std::string> codec = std::nullopt,
       std::optional<std::string> pixelFormat = std::nullopt,
       std::optional<double> crf = std::nullopt,
       std::optional<std::string> preset = std::nullopt,
       std::optional<std::map<std::string, std::string>> extraOptions =
           std::nullopt);
+  void open();
   void addFrames(const torch::stable::Tensor& frames);
   void close();
 
  private:
   struct VideoStream {
+    int height = 0;
+    int width = 0;
     double inFrameRate = 0;
     VideoStreamOptions options;
     UniqueAVCodecContext avCodecContext;
@@ -212,7 +218,7 @@ class FORCE_PUBLIC_VISIBILITY MultiStreamEncoder {
     int numEncodedFrames = 0;
   };
 
-  void initializeVideoStream(const torch::stable::Tensor& frames);
+  void initializeVideoStream();
   void encodeVideoFrame(
       AutoAVPacket& autoAVPacket,
       const UniqueAVFrame& avFrame);
@@ -221,7 +227,7 @@ class FORCE_PUBLIC_VISIBILITY MultiStreamEncoder {
   UniqueEncodingAVFormatContext avFormatContext_;
   std::optional<VideoStream> videoStream_;
   std::unique_ptr<DeviceInterface> deviceInterface_;
-  bool headerWritten_ = false;
+  bool opened_ = false;
   UniqueAVDictionary avFormatOptions_;
 
   std::unique_ptr<AVIOContextHolder> avioContextHolder_;

--- a/src/torchcodec/_core/Encoder.h
+++ b/src/torchcodec/_core/Encoder.h
@@ -196,7 +196,7 @@ class FORCE_PUBLIC_VISIBILITY MultiStreamEncoder {
       int height,
       int width,
       double frameRate,
-      std::optional<std::string> device = std::nullopt,
+      std::string device = "cpu",
       std::optional<std::string> codec = std::nullopt,
       std::optional<std::string> pixelFormat = std::nullopt,
       std::optional<double> crf = std::nullopt,
@@ -216,6 +216,7 @@ class FORCE_PUBLIC_VISIBILITY MultiStreamEncoder {
     UniqueAVCodecContext avCodecContext;
     AVStream* avStream = nullptr;
     int numEncodedFrames = 0;
+    std::unique_ptr<DeviceInterface> deviceInterface;
   };
 
   void initializeVideoStream();
@@ -226,7 +227,6 @@ class FORCE_PUBLIC_VISIBILITY MultiStreamEncoder {
 
   UniqueEncodingAVFormatContext avFormatContext_;
   std::optional<VideoStream> videoStream_;
-  std::unique_ptr<DeviceInterface> deviceInterface_;
   bool headerWritten_ = false;
   UniqueAVDictionary avFormatOptions_;
 

--- a/src/torchcodec/_core/Encoder.h
+++ b/src/torchcodec/_core/Encoder.h
@@ -227,7 +227,7 @@ class FORCE_PUBLIC_VISIBILITY MultiStreamEncoder {
   UniqueEncodingAVFormatContext avFormatContext_;
   std::optional<VideoStream> videoStream_;
   std::unique_ptr<DeviceInterface> deviceInterface_;
-  bool opened_ = false;
+  bool headerWritten_ = false;
   UniqueAVDictionary avFormatOptions_;
 
   std::unique_ptr<AVIOContextHolder> avioContextHolder_;

--- a/src/torchcodec/_core/Encoder.h
+++ b/src/torchcodec/_core/Encoder.h
@@ -209,8 +209,8 @@ class FORCE_PUBLIC_VISIBILITY MultiStreamEncoder {
 
  private:
   struct VideoStream {
-    int height = 0;
-    int width = 0;
+    int inHeight = 0;
+    int inWidth = 0;
     double inFrameRate = 0;
     VideoStreamOptions options;
     UniqueAVCodecContext avCodecContext;

--- a/src/torchcodec/_core/__init__.py
+++ b/src/torchcodec/_core/__init__.py
@@ -45,4 +45,5 @@ from .ops import (
     streaming_encoder_add_frames,
     streaming_encoder_add_video_stream,
     streaming_encoder_close,
+    streaming_encoder_open,
 )

--- a/src/torchcodec/_core/custom_ops.cpp
+++ b/src/torchcodec/_core/custom_ops.cpp
@@ -93,7 +93,8 @@ STABLE_TORCH_LIBRARY(torchcodec_ns, m) {
       "create_streaming_encoder_to_file_like(str format, int file_like_context) -> Tensor");
   m.def("streaming_encoder_close(Tensor(a!) encoder) -> ()");
   m.def(
-      "streaming_encoder_add_video_stream(Tensor(a!) encoder, float frame_rate, str? codec=None, str? pixel_format=None, float? crf=None, str? preset=None, str[]? extra_options=None) -> ()");
+      "streaming_encoder_add_video_stream(Tensor(a!) encoder, int height, int width, float frame_rate, str? device=None, str? codec=None, str? pixel_format=None, float? crf=None, str? preset=None, str[]? extra_options=None) -> ()");
+  m.def("streaming_encoder_open(Tensor(a!) encoder) -> ()");
   m.def(
       "streaming_encoder_add_frames(Tensor(a!) encoder, Tensor frames) -> ()");
   m.def("set_nvdec_cache_capacity(int capacity) -> ()");
@@ -1198,7 +1199,10 @@ void streaming_encoder_close(torch::stable::Tensor& encoder) {
 
 void streaming_encoder_add_video_stream(
     torch::stable::Tensor& encoder,
+    int64_t height,
+    int64_t width,
     double frame_rate,
+    std::optional<std::string> device = std::nullopt,
     std::optional<std::string> codec = std::nullopt,
     std::optional<std::string> pixel_format = std::nullopt,
     std::optional<double> crf = std::nullopt,
@@ -1209,12 +1213,19 @@ void streaming_encoder_add_video_stream(
     extraOptionsMap = unflattenExtraOptions(extra_options.value());
   }
   unwrapTensorToGetMultiStreamEncoder(encoder)->addVideoStream(
+      static_cast<int>(height),
+      static_cast<int>(width),
       frame_rate,
+      std::move(device),
       std::move(codec),
       std::move(pixel_format),
       crf,
       std::move(preset),
       std::move(extraOptionsMap));
+}
+
+void streaming_encoder_open(torch::stable::Tensor& encoder) {
+  unwrapTensorToGetMultiStreamEncoder(encoder)->open();
 }
 
 void streaming_encoder_add_frames(
@@ -1302,6 +1313,7 @@ STABLE_TORCH_LIBRARY_IMPL(torchcodec_ns, BackendSelect, m) {
   m.impl(
       "streaming_encoder_add_video_stream",
       TORCH_BOX(&streaming_encoder_add_video_stream));
+  m.impl("streaming_encoder_open", TORCH_BOX(&streaming_encoder_open));
   m.impl(
       "streaming_encoder_add_frames", TORCH_BOX(&streaming_encoder_add_frames));
   m.impl("set_nvdec_cache_capacity", TORCH_BOX(&set_nvdec_cache_capacity));
@@ -1357,6 +1369,7 @@ STABLE_TORCH_LIBRARY_IMPL(torchcodec_ns, CPU, m) {
   m.impl(
       "streaming_encoder_add_video_stream",
       TORCH_BOX(&streaming_encoder_add_video_stream));
+  m.impl("streaming_encoder_open", TORCH_BOX(&streaming_encoder_open));
   m.impl(
       "streaming_encoder_add_frames", TORCH_BOX(&streaming_encoder_add_frames));
 }

--- a/src/torchcodec/_core/custom_ops.cpp
+++ b/src/torchcodec/_core/custom_ops.cpp
@@ -93,7 +93,7 @@ STABLE_TORCH_LIBRARY(torchcodec_ns, m) {
       "create_streaming_encoder_to_file_like(str format, int file_like_context) -> Tensor");
   m.def("streaming_encoder_close(Tensor(a!) encoder) -> ()");
   m.def(
-      "streaming_encoder_add_video_stream(Tensor(a!) encoder, int height, int width, float frame_rate, str? device=None, str? codec=None, str? pixel_format=None, float? crf=None, str? preset=None, str[]? extra_options=None) -> ()");
+      "streaming_encoder_add_video_stream(Tensor(a!) encoder, int height, int width, float frame_rate, str device=\"cpu\", str? codec=None, str? pixel_format=None, float? crf=None, str? preset=None, str[]? extra_options=None) -> ()");
   m.def("streaming_encoder_open(Tensor(a!) encoder) -> ()");
   m.def(
       "streaming_encoder_add_frames(Tensor(a!) encoder, Tensor frames) -> ()");
@@ -1202,7 +1202,7 @@ void streaming_encoder_add_video_stream(
     int64_t height,
     int64_t width,
     double frame_rate,
-    std::optional<std::string> device = std::nullopt,
+    std::string device = "cpu",
     std::optional<std::string> codec = std::nullopt,
     std::optional<std::string> pixel_format = std::nullopt,
     std::optional<double> crf = std::nullopt,

--- a/src/torchcodec/_core/ops.py
+++ b/src/torchcodec/_core/ops.py
@@ -146,6 +146,7 @@ streaming_encoder_close = torch.ops.torchcodec_ns.streaming_encoder_close.defaul
 streaming_encoder_add_video_stream = (
     torch.ops.torchcodec_ns.streaming_encoder_add_video_stream.default
 )
+streaming_encoder_open = torch.ops.torchcodec_ns.streaming_encoder_open.default
 streaming_encoder_add_frames = (
     torch.ops.torchcodec_ns.streaming_encoder_add_frames.default
 )
@@ -631,13 +632,21 @@ def streaming_encoder_close_abstract(encoder: torch.Tensor) -> None:
 @register_fake("torchcodec_ns::streaming_encoder_add_video_stream")
 def streaming_encoder_add_video_stream_abstract(
     encoder: torch.Tensor,
+    height: int,
+    width: int,
     frame_rate: float,
+    device: str | None = None,
     codec: str | None = None,
     pixel_format: str | None = None,
     crf: float | None = None,
     preset: str | None = None,
     extra_options: list[str] | None = None,
 ) -> None:
+    return
+
+
+@register_fake("torchcodec_ns::streaming_encoder_open")
+def streaming_encoder_open_abstract(encoder: torch.Tensor) -> None:
     return
 
 

--- a/src/torchcodec/_core/ops.py
+++ b/src/torchcodec/_core/ops.py
@@ -635,7 +635,7 @@ def streaming_encoder_add_video_stream_abstract(
     height: int,
     width: int,
     frame_rate: float,
-    device: str | None = None,
+    device: str = "cpu",
     codec: str | None = None,
     pixel_format: str | None = None,
     crf: float | None = None,

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1193,10 +1193,9 @@ class TestMultiStreamEncoderOps:
         percentage, atol = (96, 2) if device == "cuda" else (99, 2)
 
         encoder, encoder_output = self._create_encoder(method, tmp_path, format)
-        h, w = source_frames.shape[2], source_frames.shape[3]
         add_video_stream_kwargs = {
-            "height": h,
-            "width": w,
+            "height": source_frames.shape[2],
+            "width": source_frames.shape[3],
             "frame_rate": frame_rate,
             "device": device,
         }
@@ -1271,11 +1270,10 @@ class TestMultiStreamEncoderOps:
         else:
             extra_options.extend(["tune", "zerolatency"])
             pixel_format, crf = "yuv444p", 0
-        h, w = source_frames.shape[2], source_frames.shape[3]
         streaming_encoder_add_video_stream(
             encoder,
-            height=h,
-            width=w,
+            height=source_frames.shape[2],
+            width=source_frames.shape[3],
             frame_rate=frame_rate,
             device=device,
             pixel_format=pixel_format,
@@ -1313,7 +1311,7 @@ class TestMultiStreamEncoderOps:
         streaming_encoder_add_video_stream(
             encoder, height=64, width=64, frame_rate=30.0
         )
-        with pytest.raises(RuntimeError, match="Only one video stream is supported"):
+        with pytest.raises(RuntimeError, match="already been added"):
             streaming_encoder_add_video_stream(
                 encoder, height=64, width=64, frame_rate=24.0
             )
@@ -1322,7 +1320,7 @@ class TestMultiStreamEncoderOps:
     @pytest.mark.parametrize(
         "device", ("cpu", pytest.param("cuda", marks=pytest.mark.needs_cuda))
     )
-    def test_add_frames_different_sizes_errors(self, tmp_path, method, device):
+    def test_add_frames_mismatched_dimensions_errors(self, tmp_path, method, device):
         encoder, _ = self._create_encoder(method, tmp_path, "mp4")
         streaming_encoder_add_video_stream(
             encoder, height=256, width=256, frame_rate=30.0, device=device

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -34,6 +34,7 @@ from torchcodec._core import (
     streaming_encoder_add_frames,
     streaming_encoder_add_video_stream,
     streaming_encoder_close,
+    streaming_encoder_open,
 )
 from torchcodec._core.ops import (
     _add_video_stream,
@@ -1192,13 +1193,20 @@ class TestMultiStreamEncoderOps:
         percentage, atol = (96, 2) if device == "cuda" else (99, 2)
 
         encoder, encoder_output = self._create_encoder(method, tmp_path, format)
-        add_video_stream_kwargs = {"frame_rate": frame_rate}
+        h, w = source_frames.shape[2], source_frames.shape[3]
+        add_video_stream_kwargs = {
+            "height": h,
+            "width": w,
+            "frame_rate": frame_rate,
+            "device": device,
+        }
         if device == "cpu":
             add_video_stream_kwargs["pixel_format"] = "yuv444p"
             add_video_stream_kwargs["crf"] = 0
         else:
             add_video_stream_kwargs["extra_options"] = ["qp", "1"]
         streaming_encoder_add_video_stream(encoder, **add_video_stream_kwargs)
+        streaming_encoder_open(encoder)
         streaming_encoder_add_frames(encoder, source_frames[:5])
         streaming_encoder_add_frames(encoder, source_frames[5:])
         streaming_encoder_close(encoder)
@@ -1263,13 +1271,18 @@ class TestMultiStreamEncoderOps:
         else:
             extra_options.extend(["tune", "zerolatency"])
             pixel_format, crf = "yuv444p", 0
+        h, w = source_frames.shape[2], source_frames.shape[3]
         streaming_encoder_add_video_stream(
             encoder,
+            height=h,
+            width=w,
             frame_rate=frame_rate,
+            device=device,
             pixel_format=pixel_format,
             crf=crf,
             extra_options=extra_options,
         )
+        streaming_encoder_open(encoder)
         # Here, we decode the available fragmented mp4 frames before calling close()
         for batch in [source_frames[:5], source_frames[5:]]:
             streaming_encoder_add_frames(encoder, batch)
@@ -1297,9 +1310,13 @@ class TestMultiStreamEncoderOps:
     @pytest.mark.parametrize("method", ("to_file", "to_file_like"))
     def test_add_video_stream_twice_errors(self, tmp_path, method):
         encoder, _ = self._create_encoder(method, tmp_path, "mp4")
-        streaming_encoder_add_video_stream(encoder, frame_rate=30.0)
+        streaming_encoder_add_video_stream(
+            encoder, height=64, width=64, frame_rate=30.0
+        )
         with pytest.raises(RuntimeError, match="already been added"):
-            streaming_encoder_add_video_stream(encoder, frame_rate=24.0)
+            streaming_encoder_add_video_stream(
+                encoder, height=64, width=64, frame_rate=24.0
+            )
 
     @pytest.mark.parametrize("method", ("to_file", "to_file_like"))
     @pytest.mark.parametrize(
@@ -1307,7 +1324,17 @@ class TestMultiStreamEncoderOps:
     )
     def test_add_frames_different_sizes_errors(self, tmp_path, method, device):
         encoder, _ = self._create_encoder(method, tmp_path, "mp4")
-        streaming_encoder_add_video_stream(encoder, frame_rate=30.0)
+        streaming_encoder_add_video_stream(
+            encoder, height=256, width=256, frame_rate=30.0, device=device
+        )
+        streaming_encoder_open(encoder)
+        # addFrames with wrong size errors
+        frames_128 = torch.randint(0, 256, (2, 3, 128, 128), dtype=torch.uint8).to(
+            device
+        )
+        with pytest.raises(RuntimeError, match="same dimensions"):
+            streaming_encoder_add_frames(encoder, frames_128)
+        # addFrames with different size than first also errors
         frames_256 = torch.randint(0, 256, (2, 3, 256, 256), dtype=torch.uint8).to(
             device
         )
@@ -1322,7 +1349,10 @@ class TestMultiStreamEncoderOps:
     @pytest.mark.parametrize("method", ("to_file", "to_file_like"))
     def test_add_frames_different_devices_errors(self, tmp_path, method):
         encoder, _ = self._create_encoder(method, tmp_path, "mp4")
-        streaming_encoder_add_video_stream(encoder, frame_rate=30.0)
+        streaming_encoder_add_video_stream(
+            encoder, height=64, width=64, frame_rate=30.0
+        )
+        streaming_encoder_open(encoder)
         cpu_frames = torch.randint(0, 256, (2, 3, 64, 64), dtype=torch.uint8)
         cuda_frames = cpu_frames.to("cuda")
         streaming_encoder_add_frames(encoder, cpu_frames)
@@ -1333,11 +1363,30 @@ class TestMultiStreamEncoderOps:
     @pytest.mark.parametrize(
         "device", ("cpu", pytest.param("cuda", marks=pytest.mark.needs_cuda))
     )
-    def test_add_frames_without_stream_errors(self, tmp_path, method, device):
+    def test_add_frames_without_open_errors(self, tmp_path, method, device):
         encoder, _ = self._create_encoder(method, tmp_path, "mp4")
+        streaming_encoder_add_video_stream(
+            encoder, height=64, width=64, frame_rate=30.0, device=device
+        )
         frames = torch.randint(0, 256, (5, 3, 64, 64), dtype=torch.uint8).to(device)
-        with pytest.raises(RuntimeError, match="No video stream"):
+        with pytest.raises(RuntimeError, match="not open"):
             streaming_encoder_add_frames(encoder, frames)
+
+    @pytest.mark.parametrize("method", ("to_file", "to_file_like"))
+    def test_open_without_stream_errors(self, tmp_path, method):
+        encoder, _ = self._create_encoder(method, tmp_path, "mp4")
+        with pytest.raises(RuntimeError, match="No streams have been added"):
+            streaming_encoder_open(encoder)
+
+    @pytest.mark.parametrize("method", ("to_file", "to_file_like"))
+    def test_open_twice_errors(self, tmp_path, method):
+        encoder, _ = self._create_encoder(method, tmp_path, "mp4")
+        streaming_encoder_add_video_stream(
+            encoder, height=64, width=64, frame_rate=30.0
+        )
+        streaming_encoder_open(encoder)
+        with pytest.raises(RuntimeError, match="already open"):
+            streaming_encoder_open(encoder)
 
 
 if __name__ == "__main__":

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1313,7 +1313,7 @@ class TestMultiStreamEncoderOps:
         streaming_encoder_add_video_stream(
             encoder, height=64, width=64, frame_rate=30.0
         )
-        with pytest.raises(RuntimeError, match="already been added"):
+        with pytest.raises(RuntimeError, match="Only one video stream is supported"):
             streaming_encoder_add_video_stream(
                 encoder, height=64, width=64, frame_rate=24.0
             )
@@ -1369,13 +1369,17 @@ class TestMultiStreamEncoderOps:
             encoder, height=64, width=64, frame_rate=30.0, device=device
         )
         frames = torch.randint(0, 256, (5, 3, 64, 64), dtype=torch.uint8).to(device)
-        with pytest.raises(RuntimeError, match="not open"):
+        with pytest.raises(
+            RuntimeError, match="Call open\\(\\) before addFrames\\(\\)"
+        ):
             streaming_encoder_add_frames(encoder, frames)
 
     @pytest.mark.parametrize("method", ("to_file", "to_file_like"))
     def test_open_without_stream_errors(self, tmp_path, method):
         encoder, _ = self._create_encoder(method, tmp_path, "mp4")
-        with pytest.raises(RuntimeError, match="No streams have been added"):
+        with pytest.raises(
+            RuntimeError, match="Call addVideoStream\\(\\) before open\\(\\)"
+        ):
             streaming_encoder_open(encoder)
 
     @pytest.mark.parametrize("method", ("to_file", "to_file_like"))
@@ -1385,7 +1389,7 @@ class TestMultiStreamEncoderOps:
             encoder, height=64, width=64, frame_rate=30.0
         )
         streaming_encoder_open(encoder)
-        with pytest.raises(RuntimeError, match="already open"):
+        with pytest.raises(RuntimeError, match="open\\(\\) was already called"):
             streaming_encoder_open(encoder)
 
 


### PR DESCRIPTION
As discussed offline, streaming encoder will need an explicit `open()` function once all the streams have been added.
Some additional consequences of this change:
* When calling `addVideoStream()`, `height` / `width` must be provided. 
* When calling `addVideoStream()`, `device` must also be provided and defaults to CPU.
  * See in line comment, this requires a small tweak in `CudaDeviceInterface`.
* The encoder is more stateful, so errors are raised when the encoding functions are not called in the correct order (`addVideoStream()` -> `open()` -> `addFrames()`).

In preparation of adding a second stream, other changes:
* `deviceInterface` is now a member of the `VideoStream` struct. Each video stream will need its own device interface, and audio streams do not use device interface.

### Testing
The ops tests are updated to use the new `open()` function:
```py
encoder = self._create_encoder(...)
streaming_encoder_add_video_stream(encoder, height=64, width=64, frame_rate=30)
streaming_encoder_open(encoder)
streaming_encoder_add_frames(encoder, frames)
streaming_encoder_close(encoder)
```