### PR TITLE
Expose createDeviceInterface() as a public API

### DIFF
--- a/src/torchcodec/_core/DeviceInterface.h
+++ b/src/torchcodec/_core/DeviceInterface.h
@@ -180,7 +180,8 @@ FORCE_PUBLIC_VISIBILITY void validateDeviceInterface(
     const std::string& device,
     const std::string& variant);
 
-std::unique_ptr<DeviceInterface> createDeviceInterface(
+TORCHCODEC_THIRD_PARTY_API std::unique_ptr<DeviceInterface>
+createDeviceInterface(
     const StableDevice& device,
     const std::string_view variant = "ffmpeg");
 

--- a/test/third-party-interface/ThirdPartyInterfaceTest.cpp
+++ b/test/third-party-interface/ThirdPartyInterfaceTest.cpp
@@ -19,7 +19,12 @@ class DummyDeviceInterface : public DeviceInterface {
   void initialize(
       const AVStream* avStream,
       const UniqueDecodingAVFormatContext& avFormatCtx,
-      const SharedAVCodecContext& codecContext) override {}
+      const SharedAVCodecContext& codecContext) override {
+    // Access to CPU device interface is essential for CPU fallback
+    // implementation
+    std::unique_ptr<DeviceInterface> cpuInterface =
+        createDeviceInterface(kStableCPU);
+  }
 
   void convertAVFrameToFrameOutput(
       UniqueAVFrame& avFrame,


### PR DESCRIPTION
Fixes: https://github.com/meta-pytorch/torchcodec/issues/1345

The `createDeviceInterface()` API is needed to create CPU device interface to implement CPU fallback in the corner cases when underlying accelerator device does not support some codecs or codec features.

CC: @NicolasHug 