### PR TITLE
Security: Unsafe pointer laundering through integer handle for file-like contexts

### DIFF
--- a/src/torchcodec/_core/pybind_ops.cpp
+++ b/src/torchcodec/_core/pybind_ops.cpp
@@ -39,10 +39,21 @@ namespace facebook::torchcodec {
 //       custom_ops.cpp and we do another cast on that side to get a pointer
 //       again. We want to investigate if we can do something cleaner by
 //       defining proper pybind objects.
-int64_t create_file_like_context(py::object file_like, bool is_for_writing) {
+py::capsule create_file_like_context(py::object file_like, bool is_for_writing) {
   AVIOFileLikeContext* context =
       new AVIOFileLikeContext(file_like, is_for_writing);
-  return reinterpret_cast<int64_t>(context);
+  return py::capsule(
+      context,
+      "torchcodec.AVIOFileLikeContext",
+      [](PyObject* capsule) {
+        void* ptr =
+            PyCapsule_GetPointer(capsule, "torchcodec.AVIOFileLikeContext");
+        if (ptr == nullptr) {
+          PyErr_Clear();
+          return;
+        }
+        delete reinterpret_cast<AVIOFileLikeContext*>(ptr);
+      });
 }
 
 #ifndef PYBIND_OPS_MODULE_NAME


### PR DESCRIPTION
## Summary

Security: Unsafe pointer laundering through integer handle for file-like contexts

## Problem

**Severity**: `High` | **File**: `src/torchcodec/_core/pybind_ops.cpp:L37`

The pybind bridge allocates `AVIOFileLikeContext` with `new` and returns its raw pointer cast to `int64_t` (`reinterpret_cast<int64_t>(context)`). The code comment explicitly notes this pointer is later cast back on another path. This design allows forged/stale integer handles to be passed across the Python/C++ boundary, which can lead to invalid pointer dereference, use-after-free, or memory corruption if handle integrity is not strictly enforced everywhere. Integerized raw pointers are a fragile ownership model for security-sensitive native interfaces.

## Solution

Replace integer pointer handles with a safer ownership mechanism: use `py::capsule` with a destructor, or maintain a native handle registry (opaque IDs) with lifetime tracking and validation. Reject unknown/expired handles before dereferencing, and avoid exposing raw addresses to Python.

## Changes

- `src/torchcodec/_core/pybind_ops.cpp` (modified)