### PR TITLE
Switch default cuda backend to betacuda

### DIFF
--- a/src/torchcodec/_core/BetaCudaDeviceInterface.cpp
+++ b/src/torchcodec/_core/BetaCudaDeviceInterface.cpp
@@ -892,8 +892,8 @@ void BetaCudaDeviceInterface::convertAVFrameToFrameOutput(
     // preAllocatedOutputTensor has post-rotation dimensions, but NV12->RGB
     // conversion outputs pre-rotation dimensions, so we can't use it as the
     // conversion destination or validate it against the frame shape.
-    // Once we support native transforms on the beta CUDA interface, rotation
-    // should be handled as part of the transform pipeline instead.
+    // Once we support native transforms on the default CUDA interface,
+    // rotation should be handled as part of the transform pipeline instead.
     frameOutput.data = convertNV12FrameToRGB(
         gpuFrame,
         device_,

--- a/src/torchcodec/_core/BetaCudaDeviceInterface.cpp
+++ b/src/torchcodec/_core/BetaCudaDeviceInterface.cpp
@@ -68,8 +68,8 @@ static DecoderCapsCache& getDecoderCapsCache() {
   return cache;
 }
 
-static bool g_cuda_beta = registerDeviceInterface(
-    DeviceInterfaceKey(kStableCUDA, /*variant=*/"beta"),
+static bool g_cuda_default = registerDeviceInterface(
+    DeviceInterfaceKey(kStableCUDA, /*variant=*/"default"),
     [](const StableDevice& device) {
       return new BetaCudaDeviceInterface(device);
     });
@@ -265,7 +265,8 @@ void cudaBufferFreeCallback(void* opaque, [[maybe_unused]] uint8_t* data) {
 
 BetaCudaDeviceInterface::BetaCudaDeviceInterface(const StableDevice& device)
     : DeviceInterface(device) {
-  STD_TORCH_CHECK(g_cuda_beta, "BetaCudaDeviceInterface was not registered!");
+  STD_TORCH_CHECK(
+      g_cuda_default, "BetaCudaDeviceInterface was not registered!");
   STD_TORCH_CHECK(
       device_.type() == kStableCUDA, "Unsupported device: must be CUDA");
 

--- a/src/torchcodec/_core/BetaCudaDeviceInterface.cpp
+++ b/src/torchcodec/_core/BetaCudaDeviceInterface.cpp
@@ -68,6 +68,7 @@ static DecoderCapsCache& getDecoderCapsCache() {
   return cache;
 }
 
+// TODO: rename private variant "default" to "nvdec" to match public name.
 static bool g_cuda_default = registerDeviceInterface(
     DeviceInterfaceKey(kStableCUDA, /*variant=*/"default"),
     [](const StableDevice& device) {

--- a/src/torchcodec/_core/CudaDeviceInterface.cpp
+++ b/src/torchcodec/_core/CudaDeviceInterface.cpp
@@ -16,7 +16,7 @@ namespace facebook::torchcodec {
 namespace {
 
 static bool g_cuda = registerDeviceInterface(
-    DeviceInterfaceKey(kStableCUDA),
+    DeviceInterfaceKey(kStableCUDA, /*variant=*/"ffmpeg"),
     [](const StableDevice& device) { return new CudaDeviceInterface(device); });
 
 // We reuse cuda contexts across VideoDeoder instances. This is because

--- a/src/torchcodec/_core/DeviceInterface.h
+++ b/src/torchcodec/_core/DeviceInterface.h
@@ -182,7 +182,7 @@ FORCE_PUBLIC_VISIBILITY void validateDeviceInterface(
 
 std::unique_ptr<DeviceInterface> createDeviceInterface(
     const StableDevice& device,
-    const std::string_view variant = "ffmpeg");
+    const std::string_view variant = "default");
 
 torch::stable::Tensor rgbAVFrameToTensor(const UniqueAVFrame& avFrame);
 

--- a/src/torchcodec/_core/DeviceInterface.h
+++ b/src/torchcodec/_core/DeviceInterface.h
@@ -21,7 +21,7 @@ namespace facebook::torchcodec {
 // Key for device interface registration with device type + variant support
 struct DeviceInterfaceKey {
   StableDeviceType deviceType;
-  std::string_view variant = "ffmpeg"; // e.g., "ffmpeg", "beta", etc.
+  std::string_view variant = "default"; // e.g., "default", "ffmpeg"
 
   bool operator<(const DeviceInterfaceKey& other) const {
     if (deviceType != other.deviceType) {

--- a/src/torchcodec/_core/Encoder.cpp
+++ b/src/torchcodec/_core/Encoder.cpp
@@ -706,6 +706,14 @@ void sortCodecOptions(
     }
   }
 }
+
+// The default CUDA interface is decode-only; encoders need the FFmpeg-based
+// one.
+std::unique_ptr<DeviceInterface> createEncoderDeviceInterface(
+    const StableDevice& device) {
+  return createDeviceInterface(
+      device, device.type() == kStableCUDA ? "ffmpeg" : "default");
+}
 } // namespace
 
 VideoEncoder::~VideoEncoder() {
@@ -777,7 +785,7 @@ VideoEncoder::VideoEncoder(
 void VideoEncoder::initializeEncoder(
     const VideoStreamOptions& videoStreamOptions) {
   auto tensorDevice = frames_.device();
-  deviceInterface_ = createDeviceInterface(StableDevice(
+  deviceInterface_ = createEncoderDeviceInterface(StableDevice(
       static_cast<StableDeviceType>(tensorDevice.type()),
       tensorDevice.index()));
   const AVCodec* avCodec = nullptr;
@@ -1113,7 +1121,7 @@ void MultiStreamEncoder::addVideoStream(
   STD_TORCH_CHECK(frameRate > 0, "frame_rate must be > 0, got ", frameRate);
   videoStream_.emplace();
   videoStream_->deviceInterface =
-      createDeviceInterface(StableDevice(std::move(device)));
+      createEncoderDeviceInterface(StableDevice(std::move(device)));
   videoStream_->inHeight = height;
   videoStream_->inWidth = width;
   videoStream_->inFrameRate = frameRate;

--- a/src/torchcodec/_core/Encoder.cpp
+++ b/src/torchcodec/_core/Encoder.cpp
@@ -707,13 +707,6 @@ void sortCodecOptions(
   }
 }
 
-// The default CUDA interface is decode-only; encoders need the FFmpeg-based
-// one.
-std::unique_ptr<DeviceInterface> createEncoderDeviceInterface(
-    const StableDevice& device) {
-  return createDeviceInterface(
-      device, device.type() == kStableCUDA ? "ffmpeg" : "default");
-}
 } // namespace
 
 VideoEncoder::~VideoEncoder() {
@@ -785,9 +778,12 @@ VideoEncoder::VideoEncoder(
 void VideoEncoder::initializeEncoder(
     const VideoStreamOptions& videoStreamOptions) {
   auto tensorDevice = frames_.device();
-  deviceInterface_ = createEncoderDeviceInterface(StableDevice(
-      static_cast<StableDeviceType>(tensorDevice.type()),
-      tensorDevice.index()));
+  StableDevice stableDevice(
+      static_cast<StableDeviceType>(tensorDevice.type()), tensorDevice.index());
+  // The default CUDA interface is decode-only; encoders need the FFmpeg-based
+  // one.
+  deviceInterface_ = createDeviceInterface(
+      stableDevice, stableDevice.type() == kStableCUDA ? "ffmpeg" : "default");
   const AVCodec* avCodec = nullptr;
   // If codec arg is provided, find codec using logic similar to FFmpeg:
   // https://github.com/FFmpeg/FFmpeg/blob/master/fftools/ffmpeg_opt.c#L804-L835
@@ -1120,8 +1116,11 @@ void MultiStreamEncoder::addVideoStream(
   STD_TORCH_CHECK(width > 0, "width must be > 0, got ", width);
   STD_TORCH_CHECK(frameRate > 0, "frame_rate must be > 0, got ", frameRate);
   videoStream_.emplace();
-  videoStream_->deviceInterface =
-      createEncoderDeviceInterface(StableDevice(std::move(device)));
+  StableDevice stableDevice(std::move(device));
+  // The default CUDA interface is decode-only; encoders need the FFmpeg-based
+  // one.
+  videoStream_->deviceInterface = createDeviceInterface(
+      stableDevice, stableDevice.type() == kStableCUDA ? "ffmpeg" : "default");
   videoStream_->inHeight = height;
   videoStream_->inWidth = width;
   videoStream_->inFrameRate = frameRate;

--- a/src/torchcodec/_core/Encoder.cpp
+++ b/src/torchcodec/_core/Encoder.cpp
@@ -1115,7 +1115,7 @@ void MultiStreamEncoder::addVideoStream(
   STD_TORCH_CHECK(height > 0, "height must be > 0, got ", height);
   STD_TORCH_CHECK(width > 0, "width must be > 0, got ", width);
   STD_TORCH_CHECK(frameRate > 0, "frame_rate must be > 0, got ", frameRate);
-  videoStream_.emplace();
+  videoStream_ = VideoStream{};
   StableDevice stableDevice(std::move(device));
   // The default CUDA interface is decode-only; encoders need the FFmpeg-based
   // one.

--- a/src/torchcodec/_core/NVCUVIDRuntimeLoader.cpp
+++ b/src/torchcodec/_core/NVCUVIDRuntimeLoader.cpp
@@ -72,8 +72,8 @@ namespace facebook::torchcodec {
 // address of the actual code section. If all went well, by now, we can safely
 // call dl_cuvidCreateVideoParser(...);
 // All of that happens at runtime *after* import time, when the first instance
-// of the Beta CUDA interface is created, i.e. only when the user explicitly
-// requests it.
+// of the default CUDA interface is created, i.e. only when the user requests
+// CUDA decoding.
 //
 // At the bottom of this file we have an `extern "C"` section with function
 // definitions like:
@@ -83,12 +83,12 @@ namespace facebook::torchcodec {
 //  CUVIDPARSERPARAMS* parserParams)  {...}
 //
 // These are the actual functions that are compiled against and called by the
-// Beta CUDA interface code. Crucially, these functions signature match exactly
+// default CUDA interface code. Crucially, these functions signature match exactly
 // the NVCUVID functions (as defined in cuviddec.h). Inside of
 // cuvidCreateVideoParser(...) we simply call the dl_cuvidCreateVideoParser
 // function [pointer] that we dynamically loaded earlier.
 //
-// At runtime, within the Beta CUDA interface code we have a fallback mechanism
+// At runtime, within the default CUDA interface code we have a fallback mechanism
 // to switch back to the CPU backend if any of the NVCUVID functions are not
 // available, or if libnvcuvid.so itself couldn't be found. This is what FFmpeg
 // does too.

--- a/src/torchcodec/_core/SingleStreamDecoder.cpp
+++ b/src/torchcodec/_core/SingleStreamDecoder.cpp
@@ -643,7 +643,7 @@ void SingleStreamDecoder::addAudioStream(
   // https://github.com/pytorch/torchcodec/issues/1253 and
   // https://github.com/pytorch/torchcodec/pull/1254
   addStream(
-      streamIndex, AVMEDIA_TYPE_AUDIO, StableDevice(kStableCPU), "ffmpeg", 1);
+      streamIndex, AVMEDIA_TYPE_AUDIO, StableDevice(kStableCPU), "default", 1);
 
   auto& streamInfo = streamInfos_[activeStreamIndex_];
   streamInfo.audioStreamOptions = audioStreamOptions;

--- a/src/torchcodec/_core/SingleStreamDecoder.h
+++ b/src/torchcodec/_core/SingleStreamDecoder.h
@@ -323,7 +323,7 @@ class FORCE_PUBLIC_VISIBILITY SingleStreamDecoder {
       int streamIndex,
       AVMediaType mediaType,
       const StableDevice& device = StableDevice(kStableCPU),
-      const std::string_view deviceVariant = "ffmpeg",
+      const std::string_view deviceVariant = "default",
       std::optional<int> ffmpegThreadCount = std::nullopt);
 
   // Returns the "best" stream index for a given media type. The "best" is

--- a/src/torchcodec/_core/StreamOptions.h
+++ b/src/torchcodec/_core/StreamOptions.h
@@ -50,8 +50,8 @@ struct VideoStreamOptions {
   // Note: This is not used for video encoding, because device is determined by
   // the device of the input frame tensor.
   StableDevice device = StableDevice(kStableCPU);
-  // Device variant (e.g., "ffmpeg", "beta", etc.)
-  std::string_view deviceVariant = "ffmpeg";
+  // Device variant (e.g., "default", "ffmpeg")
+  std::string_view deviceVariant = "default";
 
   // Controls the dtype of decoded frame tensors. Default UINT8 preserves
   // existing behavior; FLOAT32 and AUTO are used for high-bit-depth output

--- a/src/torchcodec/_core/_decoder_utils.py
+++ b/src/torchcodec/_core/_decoder_utils.py
@@ -163,7 +163,7 @@ def create_video_decoder(
     dimension_order: str = "NCHW",
     num_ffmpeg_threads: int = 1,
     device: str,
-    device_variant: str = "ffmpeg",
+    device_variant: str = "default",
     transforms: Sequence[DecoderTransform | nn.Module] | None = None,
     custom_frame_mappings: tuple[Tensor, Tensor, Tensor] | None = None,
 ) -> tuple[Tensor, int, VideoStreamMetadata]:

--- a/src/torchcodec/_core/custom_ops.cpp
+++ b/src/torchcodec/_core/custom_ops.cpp
@@ -57,9 +57,9 @@ STABLE_TORCH_LIBRARY(torchcodec_ns, m) {
   m.def(
       "_create_from_file_like(int file_like_context, str? seek_mode=None) -> Tensor");
   m.def(
-      "_add_video_stream(Tensor(a!) decoder, *, int? num_threads=None, str? dimension_order=None, int? stream_index=None, str device=\"cpu\", str device_variant=\"ffmpeg\", str transform_specs=\"\", Tensor? custom_frame_mappings_pts=None, Tensor? custom_frame_mappings_duration=None, Tensor? custom_frame_mappings_keyframe_indices=None, str? color_conversion_library=None, str? output_dtype=None) -> ()");
+      "_add_video_stream(Tensor(a!) decoder, *, int? num_threads=None, str? dimension_order=None, int? stream_index=None, str device=\"cpu\", str device_variant=\"default\", str transform_specs=\"\", Tensor? custom_frame_mappings_pts=None, Tensor? custom_frame_mappings_duration=None, Tensor? custom_frame_mappings_keyframe_indices=None, str? color_conversion_library=None, str? output_dtype=None) -> ()");
   m.def(
-      "add_video_stream(Tensor(a!) decoder, *, int? num_threads=None, str? dimension_order=None, int? stream_index=None, str device=\"cpu\", str device_variant=\"ffmpeg\", str transform_specs=\"\", Tensor? custom_frame_mappings_pts=None, Tensor? custom_frame_mappings_duration=None, Tensor? custom_frame_mappings_keyframe_indices=None, str? output_dtype=None) -> ()");
+      "add_video_stream(Tensor(a!) decoder, *, int? num_threads=None, str? dimension_order=None, int? stream_index=None, str device=\"cpu\", str device_variant=\"default\", str transform_specs=\"\", Tensor? custom_frame_mappings_pts=None, Tensor? custom_frame_mappings_duration=None, Tensor? custom_frame_mappings_keyframe_indices=None, str? output_dtype=None) -> ()");
   m.def(
       "add_audio_stream(Tensor(a!) decoder, *, int? stream_index=None, int? sample_rate=None, int? num_channels=None) -> ()");
   m.def("seek_to_pts(Tensor(a!) decoder, float seconds) -> ()");
@@ -500,7 +500,7 @@ void _add_video_stream(
     std::optional<std::string> dimension_order = std::nullopt,
     std::optional<int64_t> stream_index = std::nullopt,
     std::string device = "cpu",
-    std::string device_variant = "ffmpeg",
+    std::string device_variant = "default",
     std::string transform_specs = "",
     std::optional<torch::stable::Tensor> custom_frame_mappings_pts =
         std::nullopt,
@@ -592,7 +592,7 @@ void add_video_stream(
     std::optional<std::string> dimension_order = std::nullopt,
     std::optional<int64_t> stream_index = std::nullopt,
     std::string device = "cpu",
-    std::string device_variant = "ffmpeg",
+    std::string device_variant = "default",
     std::string transform_specs = "",
     std::optional<torch::stable::Tensor> custom_frame_mappings_pts =
         std::nullopt,

--- a/src/torchcodec/_core/ops.py
+++ b/src/torchcodec/_core/ops.py
@@ -79,7 +79,7 @@ def add_video_stream(
     dimension_order: str | None = None,
     stream_index: int | None = None,
     device: str = "cpu",
-    device_variant: str = "ffmpeg",
+    device_variant: str = "default",
     transform_specs: str = "",
     custom_frame_mappings: (
         tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None
@@ -411,7 +411,7 @@ def _add_video_stream_abstract(
     dimension_order: str | None = None,
     stream_index: int | None = None,
     device: str = "cpu",
-    device_variant: str = "ffmpeg",
+    device_variant: str = "default",
     transform_specs: str = "",
     custom_frame_mappings_pts: torch.Tensor | None = None,
     custom_frame_mappings_duration: torch.Tensor | None = None,
@@ -430,7 +430,7 @@ def add_video_stream_abstract(
     dimension_order: str | None = None,
     stream_index: int | None = None,
     device: str = "cpu",
-    device_variant: str = "ffmpeg",
+    device_variant: str = "default",
     transform_specs: str = "",
     custom_frame_mappings_pts: torch.Tensor | None = None,
     custom_frame_mappings_duration: torch.Tensor | None = None,

--- a/src/torchcodec/decoders/_decoder_utils.py
+++ b/src/torchcodec/decoders/_decoder_utils.py
@@ -14,7 +14,7 @@ from torchcodec import _core
 
 # Thread-local and async-safe storage for the current CUDA backend
 _CUDA_BACKEND: contextvars.ContextVar[str] = contextvars.ContextVar(
-    "_CUDA_BACKEND", default="ffmpeg"
+    "_CUDA_BACKEND", default="default"
 )
 
 
@@ -24,14 +24,8 @@ def set_cuda_backend(backend: str) -> Generator[None, None, None]:
 
     This context manager allows you to specify which CUDA backend implementation
     to use when creating :class:`~torchcodec.decoders.VideoDecoder` instances
-    with CUDA devices.
-
-    .. note::
-        **We recommend trying the "beta" backend instead of the default "ffmpeg"
-        backend!** The beta backend is faster, and will eventually become the
-        default in future versions. It may have rough edges that we'll polish
-        over time, but it's already quite stable and ready for adoption. Let us
-        know what you think!
+    with CUDA devices. The "default" backend is used unless this context manager
+    is active.
 
     Only the creation of the decoder needs to be inside the context manager, the
     decoding methods can be called outside of it. You still need to pass
@@ -42,21 +36,23 @@ def set_cuda_backend(backend: str) -> Generator[None, None, None]:
     This is thread-safe and async-safe.
 
     Args:
-        backend (str): The CUDA backend to use. Can be "ffmpeg" (default) or
-            "beta". We recommend trying "beta" as it's faster!
+        backend (str): The CUDA backend to use. Can be "default" or "ffmpeg".
 
     Example:
-        >>> with set_cuda_backend("beta"):
+        >>> with set_cuda_backend("ffmpeg"):
         ...     decoder = VideoDecoder("video.mp4", device="cuda")
         ...
         ... # Only the decoder creation needs to be part of the context manager.
-        ... # Decoder will now the beta CUDA implementation:
+        ... # Decoder will use the FFmpeg CUDA implementation:
         ... decoder.get_frame_at(0)
     """
     backend = backend.lower()
-    if backend not in ("ffmpeg", "beta"):
+    # "beta" is kept as a backwards-compatible alias for "default".
+    if backend == "beta":
+        backend = "default"
+    if backend not in ("default", "ffmpeg"):
         raise ValueError(
-            f"Invalid CUDA backend ({backend}). Supported values are 'ffmpeg' and 'beta'."
+            f"Invalid CUDA backend ({backend}). Supported values are 'default' and 'ffmpeg'."
         )
 
     previous_state = _CUDA_BACKEND.set(backend)

--- a/src/torchcodec/decoders/_decoder_utils.py
+++ b/src/torchcodec/decoders/_decoder_utils.py
@@ -24,8 +24,14 @@ def set_cuda_backend(backend: str) -> Generator[None, None, None]:
 
     This context manager allows you to specify which CUDA backend implementation
     to use when creating :class:`~torchcodec.decoders.VideoDecoder` instances
-    with CUDA devices. The "default" backend is used unless this context manager
-    is active.
+    with CUDA devices.
+
+    .. note::
+        **We recommend trying the "beta" backend instead of the default "ffmpeg"
+        backend!** The beta backend is faster, and will eventually become the
+        default in future versions. It may have rough edges that we'll polish
+        over time, but it's already quite stable and ready for adoption. Let us
+        know what you think!
 
     Only the creation of the decoder needs to be inside the context manager, the
     decoding methods can be called outside of it. You still need to pass
@@ -36,14 +42,15 @@ def set_cuda_backend(backend: str) -> Generator[None, None, None]:
     This is thread-safe and async-safe.
 
     Args:
-        backend (str): The CUDA backend to use. Can be "default" or "ffmpeg".
+        backend (str): The CUDA backend to use. Can be "ffmpeg" (default) or
+            "beta". We recommend trying "beta" as it's faster!
 
     Example:
-        >>> with set_cuda_backend("ffmpeg"):
+        >>> with set_cuda_backend("beta"):
         ...     decoder = VideoDecoder("video.mp4", device="cuda")
         ...
         ... # Only the decoder creation needs to be part of the context manager.
-        ... # Decoder will use the FFmpeg CUDA implementation:
+        ... # Decoder will now the beta CUDA implementation:
         ... decoder.get_frame_at(0)
     """
     backend = backend.lower()

--- a/src/torchcodec/decoders/_decoder_utils.py
+++ b/src/torchcodec/decoders/_decoder_utils.py
@@ -54,13 +54,13 @@ def set_cuda_backend(backend: str) -> Generator[None, None, None]:
         ... decoder.get_frame_at(0)
     """
     backend = backend.lower()
-    # "beta" is kept as a backwards-compatible alias for "default".
-    if backend == "beta":
-        backend = "default"
-    if backend not in ("default", "ffmpeg"):
+    if backend not in ("nvdec", "ffmpeg"):
         raise ValueError(
-            f"Invalid CUDA backend ({backend}). Supported values are 'default' and 'ffmpeg'."
+            f"Invalid CUDA backend ({backend}). Supported values are 'nvdec' and 'ffmpeg'."
         )
+    # "nvdec" is the public-facing name; internally the variant is "default".
+    if backend == "nvdec":
+        backend = "default"
 
     previous_state = _CUDA_BACKEND.set(backend)
     try:

--- a/src/torchcodec/decoders/_video_decoder.py
+++ b/src/torchcodec/decoders/_video_decoder.py
@@ -37,7 +37,7 @@ class CpuFallbackStatus:
 
     status_known: bool = False
     """Whether the fallback status has been determined.
-    For the Beta CUDA backend (see :func:`~torchcodec.decoders.set_cuda_backend`),
+    For the default CUDA backend (see :func:`~torchcodec.decoders.set_cuda_backend`),
     this is always ``True`` immediately after decoder creation.
     For the FFmpeg CUDA backend, this becomes ``True`` after decoding
     the first frame."""
@@ -61,7 +61,7 @@ class CpuFallbackStatus:
         elif self._video_not_supported:
             reasons.append("Video not supported")
         elif self._is_fallback:
-            reasons.append("Unknown reason - try the Beta interface to know more!")
+            reasons.append("Unknown reason - try the default interface to know more!")
 
         if reasons:
             return (
@@ -108,8 +108,8 @@ class VideoDecoder:
             Default: 1.
         device (str or torch.device, optional): The device to use for decoding.
             If ``None`` (default), uses the current default device.
-            If you pass a CUDA device, we recommend trying the "beta" CUDA
-            backend which is faster! See :func:`~torchcodec.decoders.set_cuda_backend`.
+            See :func:`~torchcodec.decoders.set_cuda_backend` to control the
+            CUDA backend implementation.
         seek_mode (str, optional): Determines if frame access will be "exact" or
             "approximate". Exact guarantees that requesting frame i will always
             return frame i, but doing so requires an initial :term:`scan` of the
@@ -234,8 +234,8 @@ class VideoDecoder:
 
         self._cpu_fallback = CpuFallbackStatus()
         if device.startswith("cuda"):
-            if device_variant == "beta":
-                self._cpu_fallback._backend = "Beta CUDA"
+            if device_variant == "default":
+                self._cpu_fallback._backend = "CUDA"
             else:
                 self._cpu_fallback._backend = "FFmpeg CUDA"
         else:
@@ -250,9 +250,9 @@ class VideoDecoder:
         # either when:
         # - this @property has never been called before
         # - no frame has been decoded yet on the FFmpeg interface.
-        # Note that for the beta interface, we're able to know the fallback status
-        # right when the VideoDecoder is instantiated, but the status_known
-        # attribute is initialized to False.
+        # Note that for the default interface, we're able to know the fallback
+        # status right when the VideoDecoder is instantiated, but the
+        # status_known attribute is initialized to False.
         if not self._cpu_fallback.status_known:
             backend_details = core._get_backend_details(self._decoder)
 
@@ -261,8 +261,8 @@ class VideoDecoder:
 
                 if "CPU fallback" in backend_details:
                     self._cpu_fallback._is_fallback = True
-                    if self._cpu_fallback._backend == "Beta CUDA":
-                        # Only the beta interface can provide details.
+                    if self._cpu_fallback._backend == "CUDA":
+                        # Only the default (NVDEC) interface can provide details.
                         # if it's not that nvcuvid is missing, it must be video-specific
                         if "NVCUVID not available" in backend_details:
                             self._cpu_fallback._nvcuvid_unavailable = True

--- a/src/torchcodec/decoders/_video_decoder.py
+++ b/src/torchcodec/decoders/_video_decoder.py
@@ -37,7 +37,7 @@ class CpuFallbackStatus:
 
     status_known: bool = False
     """Whether the fallback status has been determined.
-    For the default CUDA backend (see :func:`~torchcodec.decoders.set_cuda_backend`),
+    For the Beta CUDA backend (see :func:`~torchcodec.decoders.set_cuda_backend`),
     this is always ``True`` immediately after decoder creation.
     For the FFmpeg CUDA backend, this becomes ``True`` after decoding
     the first frame."""
@@ -108,8 +108,8 @@ class VideoDecoder:
             Default: 1.
         device (str or torch.device, optional): The device to use for decoding.
             If ``None`` (default), uses the current default device.
-            See :func:`~torchcodec.decoders.set_cuda_backend` to control the
-            CUDA backend implementation.
+            If you pass a CUDA device, we recommend trying the "beta" CUDA
+            backend which is faster! See :func:`~torchcodec.decoders.set_cuda_backend`.
         seek_mode (str, optional): Determines if frame access will be "exact" or
             "approximate". Exact guarantees that requesting frame i will always
             return frame i, but doing so requires an initial :term:`scan` of the

--- a/test/test_decoders.py
+++ b/test/test_decoders.py
@@ -238,6 +238,7 @@ class TestVideoDecoder:
     @pytest.mark.parametrize("device", all_supported_devices())
     @pytest.mark.parametrize("seek_mode", ("exact", "approximate"))
     def test_getitem_slice(self, device, seek_mode):
+        device_param = device  # make_video_decoder shadows `device` below
         decoder, device = make_video_decoder(
             NASA_VIDEO.path, device=device, seek_mode=seek_mode
         )
@@ -387,7 +388,7 @@ class TestVideoDecoder:
             ]
         )
         for sliced, ref in zip(all_frames, decoder):
-            if not (device == "cuda:ffmpeg" and ffmpeg_major_version == 4):
+            if not (device_param == "cuda:ffmpeg" and ffmpeg_major_version == 4):
                 # TODO: remove the "if".
                 # See https://github.com/pytorch/torchcodec/issues/428
                 assert_frames_equal(sliced, ref)

--- a/test/test_decoders.py
+++ b/test/test_decoders.py
@@ -1472,7 +1472,7 @@ class TestVideoDecoder:
 
     @needs_cuda
     def test_bt2020_10bit_video(self):
-        # Test ensuring result consistency between CPU and beta CUDA (NVDEC)
+        # Test ensuring result consistency between CPU and default CUDA (NVDEC)
         # decoder on a BT.2020 10-bit video (limited range). This is a
         # non-regression test for BT.2020 color conversion support.
         #
@@ -1482,12 +1482,11 @@ class TestVideoDecoder:
         # NVDEC decodes 10-bit natively (converting to 8-bit NV12), then our
         # BT.2020 color twist matrix handles the YUV->RGB conversion.
         #
-        # TODO investigate CPU vs BetaCUDA mismatch on BT.2020 10-bit.
+        # TODO investigate CPU vs default CUDA (NVDEC) mismatch on BT.2020 10-bit.
         # See PR #1267 for details.
         asset = BT2020_LIMITED_RANGE_10BIT
 
-        with set_cuda_backend("beta"):
-            decoder_gpu = VideoDecoder(asset.path, device="cuda")
+        decoder_gpu = VideoDecoder(asset.path, device="cuda")
         decoder_cpu = VideoDecoder(asset.path, device="cpu")
 
         for frame_index in (0, 10, 20, 5):
@@ -1502,10 +1501,9 @@ class TestVideoDecoder:
         (BT601_FULL_RANGE, BT601_LIMITED_RANGE),
     )
     def test_bt601_colorspace(self, asset):
-        # Test ensuring result consistency between CPU and beta CUDA (NVDEC)
+        # Test ensuring result consistency between CPU and default CUDA (NVDEC)
         # decoder on BT.601 videos with full and limited range.
-        with set_cuda_backend("beta"):
-            decoder_gpu = VideoDecoder(asset.path, device="cuda")
+        decoder_gpu = VideoDecoder(asset.path, device="cuda")
         decoder_cpu = VideoDecoder(asset.path, device="cpu")
 
         for frame_index in (0, 10, 20, 5):
@@ -1691,8 +1689,8 @@ class TestVideoDecoder:
     #   assert_tensor_close_on_at_least or something like that.
     # - unskip equality assertion checks for MPEG4 asset. The frames are decoded
     #   fine, it's the color conversion that's different. The frame from the
-    #   BETA interface is mapped to 709 by the matrix coefficient using NVCUVID
-    #   while the one from the default interface is 601.
+    #   default (NVDEC) interface is mapped to 709 by the matrix coefficient
+    #   using NVCUVID while the one from the FFmpeg CUDA interface is 601.
 
     @needs_cuda
     @pytest.mark.parametrize(
@@ -1715,14 +1713,14 @@ class TestVideoDecoder:
     )
     @pytest.mark.parametrize("contiguous_indices", (True, False))
     @pytest.mark.parametrize("seek_mode", ("exact", "approximate"))
-    def test_beta_cuda_interface_get_frame_at(
+    def test_default_cuda_interface_get_frame_at(
         self, asset, contiguous_indices, seek_mode
     ):
-        ref_decoder = VideoDecoder(asset.path, device="cuda", seek_mode=seek_mode)
-        with set_cuda_backend("beta"):
-            beta_decoder = VideoDecoder(asset.path, device="cuda", seek_mode=seek_mode)
+        with set_cuda_backend("ffmpeg"):
+            ref_decoder = VideoDecoder(asset.path, device="cuda", seek_mode=seek_mode)
+        default_decoder = VideoDecoder(asset.path, device="cuda", seek_mode=seek_mode)
 
-        assert ref_decoder.metadata == beta_decoder.metadata
+        assert ref_decoder.metadata == default_decoder.metadata
 
         if contiguous_indices:
             indices = range(len(ref_decoder))
@@ -1731,15 +1729,15 @@ class TestVideoDecoder:
 
         for frame_index in indices:
             ref_frame = ref_decoder.get_frame_at(frame_index)
-            beta_frame = beta_decoder.get_frame_at(frame_index)
+            default_frame = default_decoder.get_frame_at(frame_index)
             # TODONVDEC P1 see above
             if ffmpeg_major_version > 4 and asset is not TEST_SRC_2_720P_MPEG4:
                 torch.testing.assert_close(
-                    beta_frame.data, ref_frame.data, rtol=0, atol=0
+                    default_frame.data, ref_frame.data, rtol=0, atol=0
                 )
 
-            assert beta_frame.pts_seconds == ref_frame.pts_seconds
-            assert beta_frame.duration_seconds == ref_frame.duration_seconds
+            assert default_frame.pts_seconds == ref_frame.pts_seconds
+            assert default_frame.duration_seconds == ref_frame.duration_seconds
 
     @needs_cuda
     @pytest.mark.parametrize(
@@ -1762,14 +1760,14 @@ class TestVideoDecoder:
     )
     @pytest.mark.parametrize("contiguous_indices", (True, False))
     @pytest.mark.parametrize("seek_mode", ("exact", "approximate"))
-    def test_beta_cuda_interface_get_frames_at(
+    def test_default_cuda_interface_get_frames_at(
         self, asset, contiguous_indices, seek_mode
     ):
-        ref_decoder = VideoDecoder(asset.path, device="cuda", seek_mode=seek_mode)
-        with set_cuda_backend("beta"):
-            beta_decoder = VideoDecoder(asset.path, device="cuda", seek_mode=seek_mode)
+        with set_cuda_backend("ffmpeg"):
+            ref_decoder = VideoDecoder(asset.path, device="cuda", seek_mode=seek_mode)
+        default_decoder = VideoDecoder(asset.path, device="cuda", seek_mode=seek_mode)
 
-        assert ref_decoder.metadata == beta_decoder.metadata
+        assert ref_decoder.metadata == default_decoder.metadata
 
         if contiguous_indices:
             indices = range(len(ref_decoder))
@@ -1778,15 +1776,15 @@ class TestVideoDecoder:
         indices = list(indices)
 
         ref_frames = ref_decoder.get_frames_at(indices)
-        beta_frames = beta_decoder.get_frames_at(indices)
+        default_frames = default_decoder.get_frames_at(indices)
         # TODONVDEC P1 see above
         if ffmpeg_major_version > 4 and asset is not TEST_SRC_2_720P_MPEG4:
             torch.testing.assert_close(
-                beta_frames.data, ref_frames.data, rtol=0, atol=0
+                default_frames.data, ref_frames.data, rtol=0, atol=0
             )
-        torch.testing.assert_close(beta_frames.pts_seconds, ref_frames.pts_seconds)
+        torch.testing.assert_close(default_frames.pts_seconds, ref_frames.pts_seconds)
         torch.testing.assert_close(
-            beta_frames.duration_seconds, ref_frames.duration_seconds
+            default_frames.duration_seconds, ref_frames.duration_seconds
         )
 
     @needs_cuda
@@ -1809,27 +1807,27 @@ class TestVideoDecoder:
         ),
     )
     @pytest.mark.parametrize("seek_mode", ("exact", "approximate"))
-    def test_beta_cuda_interface_get_frame_played_at(self, asset, seek_mode):
-        ref_decoder = VideoDecoder(asset.path, device="cuda", seek_mode=seek_mode)
-        with set_cuda_backend("beta"):
-            beta_decoder = VideoDecoder(asset.path, device="cuda", seek_mode=seek_mode)
+    def test_default_cuda_interface_get_frame_played_at(self, asset, seek_mode):
+        with set_cuda_backend("ffmpeg"):
+            ref_decoder = VideoDecoder(asset.path, device="cuda", seek_mode=seek_mode)
+        default_decoder = VideoDecoder(asset.path, device="cuda", seek_mode=seek_mode)
 
-        assert ref_decoder.metadata == beta_decoder.metadata
+        assert ref_decoder.metadata == default_decoder.metadata
 
         timestamps = torch.linspace(
             0, ref_decoder.metadata.duration_seconds - 1e-4, steps=10
         )
         for pts in timestamps:
             ref_frame = ref_decoder.get_frame_played_at(pts)
-            beta_frame = beta_decoder.get_frame_played_at(pts)
+            default_frame = default_decoder.get_frame_played_at(pts)
             # TODONVDEC P1 see above
             if ffmpeg_major_version > 4 and asset is not TEST_SRC_2_720P_MPEG4:
                 torch.testing.assert_close(
-                    beta_frame.data, ref_frame.data, rtol=0, atol=0
+                    default_frame.data, ref_frame.data, rtol=0, atol=0
                 )
 
-            assert beta_frame.pts_seconds == ref_frame.pts_seconds
-            assert beta_frame.duration_seconds == ref_frame.duration_seconds
+            assert default_frame.pts_seconds == ref_frame.pts_seconds
+            assert default_frame.duration_seconds == ref_frame.duration_seconds
 
     @needs_cuda
     @pytest.mark.parametrize(
@@ -1851,27 +1849,27 @@ class TestVideoDecoder:
         ),
     )
     @pytest.mark.parametrize("seek_mode", ("exact", "approximate"))
-    def test_beta_cuda_interface_get_frames_played_at(self, asset, seek_mode):
-        ref_decoder = VideoDecoder(asset.path, device="cuda", seek_mode=seek_mode)
-        with set_cuda_backend("beta"):
-            beta_decoder = VideoDecoder(asset.path, device="cuda", seek_mode=seek_mode)
+    def test_default_cuda_interface_get_frames_played_at(self, asset, seek_mode):
+        with set_cuda_backend("ffmpeg"):
+            ref_decoder = VideoDecoder(asset.path, device="cuda", seek_mode=seek_mode)
+        default_decoder = VideoDecoder(asset.path, device="cuda", seek_mode=seek_mode)
 
-        assert ref_decoder.metadata == beta_decoder.metadata
+        assert ref_decoder.metadata == default_decoder.metadata
 
         timestamps = torch.linspace(
             0, ref_decoder.metadata.duration_seconds - 1e-4, steps=10
         ).tolist()
 
         ref_frames = ref_decoder.get_frames_played_at(timestamps)
-        beta_frames = beta_decoder.get_frames_played_at(timestamps)
+        default_frames = default_decoder.get_frames_played_at(timestamps)
         # TODONVDEC P1 see above
         if ffmpeg_major_version > 4 and asset is not TEST_SRC_2_720P_MPEG4:
             torch.testing.assert_close(
-                beta_frames.data, ref_frames.data, rtol=0, atol=0
+                default_frames.data, ref_frames.data, rtol=0, atol=0
             )
-        torch.testing.assert_close(beta_frames.pts_seconds, ref_frames.pts_seconds)
+        torch.testing.assert_close(default_frames.pts_seconds, ref_frames.pts_seconds)
         torch.testing.assert_close(
-            beta_frames.duration_seconds, ref_frames.duration_seconds
+            default_frames.duration_seconds, ref_frames.duration_seconds
         )
 
     @needs_cuda
@@ -1894,12 +1892,12 @@ class TestVideoDecoder:
         ),
     )
     @pytest.mark.parametrize("seek_mode", ("exact", "approximate"))
-    def test_beta_cuda_interface_backwards(self, asset, seek_mode):
-        ref_decoder = VideoDecoder(asset.path, device="cuda", seek_mode=seek_mode)
-        with set_cuda_backend("beta"):
-            beta_decoder = VideoDecoder(asset.path, device="cuda", seek_mode=seek_mode)
+    def test_default_cuda_interface_backwards(self, asset, seek_mode):
+        with set_cuda_backend("ffmpeg"):
+            ref_decoder = VideoDecoder(asset.path, device="cuda", seek_mode=seek_mode)
+        default_decoder = VideoDecoder(asset.path, device="cuda", seek_mode=seek_mode)
 
-        assert ref_decoder.metadata == beta_decoder.metadata
+        assert ref_decoder.metadata == default_decoder.metadata
 
         for frame_index in [0, 1, 2, 1, 0, 100, 10, 50, 20, 200, 150, 150, 150, 389, 2]:
             # This is ugly, but OK: the indices values above are relevant for
@@ -1910,26 +1908,27 @@ class TestVideoDecoder:
             frame_index = min(frame_index, len(ref_decoder) - 1)
 
             ref_frame = ref_decoder.get_frame_at(frame_index)
-            beta_frame = beta_decoder.get_frame_at(frame_index)
+            default_frame = default_decoder.get_frame_at(frame_index)
             # TODONVDEC P1 see above
             if ffmpeg_major_version > 4 and asset is not TEST_SRC_2_720P_MPEG4:
                 torch.testing.assert_close(
-                    beta_frame.data, ref_frame.data, rtol=0, atol=0
+                    default_frame.data, ref_frame.data, rtol=0, atol=0
                 )
 
-            assert beta_frame.pts_seconds == ref_frame.pts_seconds
-            assert beta_frame.duration_seconds == ref_frame.duration_seconds
+            assert default_frame.pts_seconds == ref_frame.pts_seconds
+            assert default_frame.duration_seconds == ref_frame.duration_seconds
 
     @needs_cuda
-    def test_beta_cuda_interface_cpu_fallback(self):
-        # Non-regression test for the CPU fallback behavior of the BETA CUDA
+    def test_default_cuda_interface_cpu_fallback(self):
+        # Non-regression test for the CPU fallback behavior of the default CUDA
         # interface.
         # We know that the H265_VIDEO asset isn't supported by NVDEC, its
         # dimensions are too small. We also know that the FFmpeg CUDA interface
         # fallbacks to the CPU path in such cases. We assert that we fall back
         # to the CPU path, too.
 
-        ref_dec = VideoDecoder(H265_VIDEO.path, device="cuda")
+        with set_cuda_backend("ffmpeg"):
+            ref_dec = VideoDecoder(H265_VIDEO.path, device="cuda")
 
         # Before accessing any frames, status should be unknown
         assert not ref_dec.cpu_fallback.status_known
@@ -1940,20 +1939,20 @@ class TestVideoDecoder:
         assert ref_dec.cpu_fallback.status_known
         assert ref_dec.cpu_fallback
 
-        with set_cuda_backend("beta"):
-            beta_dec = VideoDecoder(H265_VIDEO.path, device="cuda")
+        default_dec = VideoDecoder(H265_VIDEO.path, device="cuda")
 
-        assert "Beta CUDA" in str(beta_dec.cpu_fallback)
-        # For beta interface, status is known immediately
-        assert beta_dec.cpu_fallback.status_known
-        assert beta_dec.cpu_fallback
+        assert "CUDA" in str(default_dec.cpu_fallback)
+        assert "FFmpeg CUDA" not in str(default_dec.cpu_fallback)
+        # For the default interface, status is known immediately
+        assert default_dec.cpu_fallback.status_known
+        assert default_dec.cpu_fallback
 
-        beta_frame = beta_dec.get_frame_at(0)
+        default_frame = default_dec.get_frame_at(0)
 
-        assert psnr(ref_frame.data, beta_frame.data) > 25
+        assert psnr(ref_frame.data, default_frame.data) > 25
 
     @needs_cuda
-    def test_beta_cuda_interface_error(self):
+    def test_default_cuda_interface_error(self):
         with pytest.raises(RuntimeError, match="torch_parse_device_string"):
             VideoDecoder(NASA_VIDEO.path, device="cuda:0:bad_variant")
 
@@ -1968,34 +1967,39 @@ class TestVideoDecoder:
         # set_cuda_backend() is meant to be used as a context manager. Using it
         # as a global call does nothing because the "context" is exited right
         # away. This is a good thing, we prefer users to use it as a CM only.
-        set_cuda_backend("beta")
-        assert _get_cuda_backend() == "ffmpeg"  # Not changed to "beta".
+        set_cuda_backend("ffmpeg")
+        assert _get_cuda_backend() == "default"  # Not changed to "ffmpeg".
 
         # Case insensitive
-        with set_cuda_backend("BETA"):
-            assert _get_cuda_backend() == "beta"
+        with set_cuda_backend("FFMPEG"):
+            assert _get_cuda_backend() == "ffmpeg"
 
-        # Check that the default is the ffmpeg backend
-        assert _get_cuda_backend() == "ffmpeg"
+        # "beta" is a backwards-compatible alias for "default".
+        with set_cuda_backend("beta"):
+            assert _get_cuda_backend() == "default"
+
+        # Check that the default backend is "default" (i.e. NVDEC)
+        assert _get_cuda_backend() == "default"
         dec = VideoDecoder(H265_VIDEO.path, device="cuda")
-        assert "FFmpeg CUDA" in str(dec.cpu_fallback)
+        assert "CUDA" in str(dec.cpu_fallback)
+        assert "FFmpeg CUDA" not in str(dec.cpu_fallback)
 
-        # Check the setting "beta" effectively uses the BETA backend.
-        # We also show that the affects decoder creation only. When the decoder
+        # Check that setting "ffmpeg" effectively uses the FFmpeg CUDA backend.
+        # We also show that this affects decoder creation only. When the decoder
         # is created with a given backend, it stays in this backend for the rest
         # of its life. This is normal and intended.
-        with set_cuda_backend("beta"):
-            dec = VideoDecoder(H265_VIDEO.path, device="cuda")
-        assert _get_cuda_backend() == "ffmpeg"
-        assert "Beta CUDA" in str(dec.cpu_fallback)
         with set_cuda_backend("ffmpeg"):
-            assert "Beta CUDA" in str(dec.cpu_fallback)
+            dec = VideoDecoder(H265_VIDEO.path, device="cuda")
+        assert _get_cuda_backend() == "default"
+        assert "FFmpeg CUDA" in str(dec.cpu_fallback)
+        with set_cuda_backend("default"):
+            assert "FFmpeg CUDA" in str(dec.cpu_fallback)
 
         # Hacky way to ensure passing "cuda:1" is supported by both backends. We
         # just check that there's an error when passing cuda:N where N is too
         # high.
         bad_device_number = torch.cuda.device_count() + 1
-        for backend in ("ffmpeg", "beta"):
+        for backend in ("ffmpeg", "default"):
             with pytest.raises(RuntimeError, match="torch_call_dispatcher"):
                 with set_cuda_backend(backend):
                     VideoDecoder(H265_VIDEO.path, device=f"cuda:{bad_device_number}")
@@ -2032,8 +2036,7 @@ class TestVideoDecoder:
     def test_nvdec_cache_capacity_eviction(self):
 
         def create_decoder():
-            with set_cuda_backend("beta"):
-                dec = VideoDecoder(NASA_VIDEO.path, device="cuda")
+            dec = VideoDecoder(NASA_VIDEO.path, device="cuda")
             dec[0]
             del dec
             gc.collect()
@@ -2068,10 +2071,10 @@ class TestVideoDecoder:
 
     @pytest.mark.parametrize("dimension_order", ["NCHW", "NHWC"])
     @pytest.mark.parametrize(
-        # We are skipping over cuda because we do not support rotation metadata
-        # for the FFmpeg CUDA interface.
+        # We are skipping over cuda:ffmpeg because we do not support rotation
+        # metadata for the FFmpeg CUDA interface.
         "device",
-        ("cpu", pytest.param("cuda:beta", marks=pytest.mark.needs_cuda)),
+        ("cpu", pytest.param("cuda", marks=pytest.mark.needs_cuda)),
     )
     def test_rotation_applied_to_frames(self, dimension_order, device):
         """Test that rotation is correctly applied to decoded frames.
@@ -2216,22 +2219,22 @@ class TestVideoDecoder:
         # because its dimensions are too small
         decoder, _ = make_video_decoder(H265_VIDEO.path, device=device)
 
-        if "beta" in device:
-            # For beta interface, status is known immediately
-            assert decoder.cpu_fallback.status_known
-            assert decoder.cpu_fallback
-            # Beta interface provides the specific reason for fallback
-            assert "Video not supported" in str(decoder.cpu_fallback)
-        else:
+        if "ffmpeg" in device:
             # For FFmpeg interface, status is unknown until first frame is decoded
             assert not decoder.cpu_fallback.status_known
             decoder.get_frame_at(0)
             assert decoder.cpu_fallback.status_known
             assert decoder.cpu_fallback
             # FFmpeg interface doesn't know the specific reason
-            assert "Unknown reason - try the Beta interface to know more" in str(
+            assert "Unknown reason - try the default interface to know more" in str(
                 decoder.cpu_fallback
             )
+        else:
+            # For the default interface, status is known immediately
+            assert decoder.cpu_fallback.status_known
+            assert decoder.cpu_fallback
+            # The default interface provides the specific reason for fallback
+            assert "Video not supported" in str(decoder.cpu_fallback)
 
     @needs_cuda
     @pytest.mark.parametrize("device", cuda_devices())

--- a/test/test_decoders.py
+++ b/test/test_decoders.py
@@ -1520,12 +1520,19 @@ class TestVideoDecoder:
         # results.
         # TODO see other TODO below in test_10bit_videos_cpu: we should validate
         # the frames against a reference.
+        #
+        # This test exercises the FFmpeg CUDA interface specifically: its CPU
+        # fallback delegates directly to CpuDeviceInterface, so the output
+        # matches a pure CPU decoder bit-for-bit. The default (NVDEC) interface
+        # has a different fallback path that round-trips through GPU NV12 (an
+        # 8-bit format) and produces different output for 10-bit content.
 
         # We know from previous tests that the H264_10BITS video isn't supported
         # by NVDEC, so NVDEC decodes it on the CPU.
         asset = H264_10BITS
 
-        decoder_gpu = VideoDecoder(asset.path, device="cuda")
+        with set_cuda_backend("ffmpeg"):
+            decoder_gpu = VideoDecoder(asset.path, device="cuda")
         decoder_cpu = VideoDecoder(asset.path)
 
         frame_indices = [0, 10, 20, 5]

--- a/test/test_decoders.py
+++ b/test/test_decoders.py
@@ -387,7 +387,7 @@ class TestVideoDecoder:
             ]
         )
         for sliced, ref in zip(all_frames, decoder):
-            if not (device == "cuda" and ffmpeg_major_version == 4):
+            if not (device == "cuda:ffmpeg" and ffmpeg_major_version == 4):
                 # TODO: remove the "if".
                 # See https://github.com/pytorch/torchcodec/issues/428
                 assert_frames_equal(sliced, ref)
@@ -633,7 +633,7 @@ class TestVideoDecoder:
 
     @pytest.mark.parametrize("device", all_supported_devices())
     def test_get_frame_at_av1(self, device):
-        if device == "cuda" and ffmpeg_major_version == 4:
+        if device == "cuda:ffmpeg" and ffmpeg_major_version == 4:
             return
 
         if "cuda" in device and in_fbcode():
@@ -1147,7 +1147,7 @@ class TestVideoDecoder:
 
         # All duplicated frames should have the same content as frame 0
         frame0_data = decoder.get_frame_at(0).data
-        if not (device == "cuda" and ffmpeg_major_version == 4):
+        if not (device == "cuda:ffmpeg" and ffmpeg_major_version == 4):
             for i in range(len(frames_high_fps)):
                 torch.testing.assert_close(
                     frames_high_fps.data[i], frame0_data, atol=0, rtol=0
@@ -1159,7 +1159,7 @@ class TestVideoDecoder:
             start_seconds, stop_seconds, fps=None
         )
         assert len(frames_no_fps) == len(frames_none_fps)
-        if not (device == "cuda" and ffmpeg_major_version == 4):
+        if not (device == "cuda:ffmpeg" and ffmpeg_major_version == 4):
             torch.testing.assert_close(
                 frames_no_fps.data, frames_none_fps.data, atol=0, rtol=0
             )
@@ -1245,7 +1245,7 @@ class TestVideoDecoder:
         assert len(all_frames) == len(frames_in_range)
         # Use strict bitwise equality, except for FFmpeg 4 + CUDA FFmpeg
         # interface which has known issues (see #428)
-        if not (device == "cuda" and ffmpeg_major_version == 4):
+        if not (device == "cuda:ffmpeg" and ffmpeg_major_version == 4):
             torch.testing.assert_close(
                 all_frames.data, frames_in_range.data, atol=0, rtol=0
             )
@@ -1260,7 +1260,7 @@ class TestVideoDecoder:
         assert len(all_frames_with_fps) == len(frames_in_range_with_fps)
         # Use strict bitwise equality, except for FFmpeg 4 + CUDA FFmpeg
         # interface which has known issues (see #428)
-        if not (device == "cuda" and ffmpeg_major_version == 4):
+        if not (device == "cuda:ffmpeg" and ffmpeg_major_version == 4):
             torch.testing.assert_close(
                 all_frames_with_fps.data, frames_in_range_with_fps.data, atol=0, rtol=0
             )

--- a/test/test_decoders.py
+++ b/test/test_decoders.py
@@ -1982,8 +1982,8 @@ class TestVideoDecoder:
         with set_cuda_backend("FFMPEG"):
             assert _get_cuda_backend() == "ffmpeg"
 
-        # "beta" is a backwards-compatible alias for "default".
-        with set_cuda_backend("beta"):
+        # "nvdec" is the public-facing name for the default CUDA backend.
+        with set_cuda_backend("nvdec"):
             assert _get_cuda_backend() == "default"
 
         # Check that the default backend is "default" (i.e. NVDEC)
@@ -2000,14 +2000,14 @@ class TestVideoDecoder:
             dec = VideoDecoder(H265_VIDEO.path, device="cuda")
         assert _get_cuda_backend() == "default"
         assert "FFmpeg CUDA" in str(dec.cpu_fallback)
-        with set_cuda_backend("default"):
+        with set_cuda_backend("nvdec"):
             assert "FFmpeg CUDA" in str(dec.cpu_fallback)
 
         # Hacky way to ensure passing "cuda:1" is supported by both backends. We
         # just check that there's an error when passing cuda:N where N is too
         # high.
         bad_device_number = torch.cuda.device_count() + 1
-        for backend in ("ffmpeg", "default"):
+        for backend in ("ffmpeg", "nvdec"):
             with pytest.raises(RuntimeError, match="torch_call_dispatcher"):
                 with set_cuda_backend(backend):
                     VideoDecoder(H265_VIDEO.path, device=f"cuda:{bad_device_number}")

--- a/test/utils.py
+++ b/test/utils.py
@@ -34,53 +34,53 @@ def needs_ffmpeg_cli(test_item):
     return pytest.mark.needs_ffmpeg_cli(test_item)
 
 
-# This is a special device string that we use to test the "beta" CUDA backend.
-# It only exists here, in this test utils file. Public and core APIs have no
-# idea that this is how we're tesing them. That is, that's not a supported
-# `device` parameter for the VideoDecoder or for the _core APIs.
+# This is a special device string that we use to test the legacy "ffmpeg" CUDA
+# backend. It only exists here, in this test utils file. Public and core APIs
+# have no idea that this is how we're testing them. That is, that's not a
+# supported `device` parameter for the VideoDecoder or for the _core APIs.
 # Tests using all_supported_devices() will get this device string, and the test
 # need to clean it up by calling either make_video_decoder for VideoDecoder, or
 # unsplit_device_str for core APIs.
-_CUDA_BETA_DEVICE_STR = "cuda:beta"
+_CUDA_FFMPEG_DEVICE_STR = "cuda:ffmpeg"
 
 
 def all_supported_devices():
     return (
         "cpu",
         pytest.param("cuda", marks=pytest.mark.needs_cuda),
-        pytest.param(_CUDA_BETA_DEVICE_STR, marks=pytest.mark.needs_cuda),
+        pytest.param(_CUDA_FFMPEG_DEVICE_STR, marks=pytest.mark.needs_cuda),
     )
 
 
 def cuda_devices():
     return (
         pytest.param("cuda", marks=pytest.mark.needs_cuda),
-        pytest.param(_CUDA_BETA_DEVICE_STR, marks=pytest.mark.needs_cuda),
+        pytest.param(_CUDA_FFMPEG_DEVICE_STR, marks=pytest.mark.needs_cuda),
     )
 
 
 def unsplit_device_str(device_str: str) -> str:
     # helper meant to be used as
     # device, device_variant = unsplit_device_str(device)
-    # when `device` comes from all_supported_devices() and may be _CUDA_BETA_DEVICE_STR.
+    # when `device` comes from all_supported_devices() and may be _CUDA_FFMPEG_DEVICE_STR.
     # It is used:
-    # - before calling `.to(device)` where device can't be _CUDA_BETA_DEVICE_STR.
+    # - before calling `.to(device)` where device can't be _CUDA_FFMPEG_DEVICE_STR.
     # - before calling add_video_stream(device=device, device_variant=device_variant)
-    if device_str == _CUDA_BETA_DEVICE_STR:
-        return "cuda", "beta"
+    if device_str == _CUDA_FFMPEG_DEVICE_STR:
+        return "cuda", "ffmpeg"
     else:
-        return device_str, "ffmpeg"
+        return device_str, "default"
 
 
 def make_video_decoder(*args, **kwargs) -> tuple[VideoDecoder, str]:
     # Helper to create a VideoDecoder with the right cuda backend if needed.
     # kwargs is expected to have a "device" key which comes from
-    # all_supported_devices(), and can be _CUDA_BETA_DEVICE_STR.
+    # all_supported_devices(), and can be _CUDA_FFMPEG_DEVICE_STR.
     device = kwargs.pop("device", "cpu")
-    if device == _CUDA_BETA_DEVICE_STR:
-        clean_device, backend = "cuda", "beta"
+    if device == _CUDA_FFMPEG_DEVICE_STR:
+        clean_device, backend = "cuda", "ffmpeg"
     else:
-        clean_device, backend = device, "ffmpeg"
+        clean_device, backend = device, "default"
 
     # set_cuda_backend is a no-op if the device is "cpu", so we can use it
     # unconditionally.

--- a/test/utils.py
+++ b/test/utils.py
@@ -45,23 +45,17 @@ _CUDA_FFMPEG_DEVICE_STR = "cuda:ffmpeg"
 
 
 def all_supported_devices():
-    # Note: the legacy FFmpeg CUDA path is listed before plain "cuda" (the new
-    # NVDEC default) so that when both run in the same process, FFmpeg CUDA
-    # runs first — matching the test ordering used before BetaCuda became the
-    # default. NVDEC state appears to pollute later FFmpeg CUDA runs, causing
-    # otherwise-deterministic tests to drift.
     return (
         "cpu",
-        pytest.param(_CUDA_FFMPEG_DEVICE_STR, marks=pytest.mark.needs_cuda),
         pytest.param("cuda", marks=pytest.mark.needs_cuda),
+        pytest.param(_CUDA_FFMPEG_DEVICE_STR, marks=pytest.mark.needs_cuda),
     )
 
 
 def cuda_devices():
-    # See note in all_supported_devices() about ordering.
     return (
-        pytest.param(_CUDA_FFMPEG_DEVICE_STR, marks=pytest.mark.needs_cuda),
         pytest.param("cuda", marks=pytest.mark.needs_cuda),
+        pytest.param(_CUDA_FFMPEG_DEVICE_STR, marks=pytest.mark.needs_cuda),
     )
 
 

--- a/test/utils.py
+++ b/test/utils.py
@@ -45,17 +45,23 @@ _CUDA_FFMPEG_DEVICE_STR = "cuda:ffmpeg"
 
 
 def all_supported_devices():
+    # Note: the legacy FFmpeg CUDA path is listed before plain "cuda" (the new
+    # NVDEC default) so that when both run in the same process, FFmpeg CUDA
+    # runs first — matching the test ordering used before BetaCuda became the
+    # default. NVDEC state appears to pollute later FFmpeg CUDA runs, causing
+    # otherwise-deterministic tests to drift.
     return (
         "cpu",
-        pytest.param("cuda", marks=pytest.mark.needs_cuda),
         pytest.param(_CUDA_FFMPEG_DEVICE_STR, marks=pytest.mark.needs_cuda),
+        pytest.param("cuda", marks=pytest.mark.needs_cuda),
     )
 
 
 def cuda_devices():
+    # See note in all_supported_devices() about ordering.
     return (
-        pytest.param("cuda", marks=pytest.mark.needs_cuda),
         pytest.param(_CUDA_FFMPEG_DEVICE_STR, marks=pytest.mark.needs_cuda),
+        pytest.param("cuda", marks=pytest.mark.needs_cuda),
     )
 
 

--- a/test/utils.py
+++ b/test/utils.py
@@ -80,7 +80,7 @@ def make_video_decoder(*args, **kwargs) -> tuple[VideoDecoder, str]:
     if device == _CUDA_FFMPEG_DEVICE_STR:
         clean_device, backend = "cuda", "ffmpeg"
     else:
-        clean_device, backend = device, "default"
+        clean_device, backend = device, "nvdec"
 
     # set_cuda_backend is a no-op if the device is "cpu", so we can use it
     # unconditionally.


### PR DESCRIPTION
Related Issue: #1336

Switches the public default for CUDA decoding from the FFmpeg-based interface to the NVDEC-based one (previously called "beta"). Renames `"beta"` → `"default"` through every layer of the stack; `"beta"` still works as a BC alias on the public API.

```python
VideoDecoder("...", device="cuda")            # BetaCuda (was: FFmpeg CUDA)
with set_cuda_backend("ffmpeg"):              # only way to get FFmpeg CUDA now
    VideoDecoder("...", device="cuda")
```

### What changed

- Contextvar + `_core` defaults switched to `"default"`; `set_cuda_backend()` accepts `"default"`/`"ffmpeg"`/`"beta"` (alias).
- C++ registry: NVDEC under `(CUDA, "default")`, ffmpeg CUDA explicit under `(CUDA, "ffmpeg")`, CPU under `(CPU, "default")`. Registry default-variant switched to `"default"` so internal callers (encoder, audio path, `createDeviceInterface()`) resolve correctly.
- Fallback-status string `"Beta CUDA"` → `"CUDA"`.
- Tests: `_CUDA_BETA_DEVICE_STR` → `_CUDA_FFMPEG_DEVICE_STR`; cross-backend refs now use `set_cuda_backend("ffmpeg")`; `test_beta_cuda_interface_*` → `test_default_cuda_interface_*`.

### Followup PRs
- Modify docs (`examples/decoding/*.py`)
