### PR TITLE
Resolve error by using VideoStream{} init

### DIFF
--- a/src/torchcodec/_core/Encoder.cpp
+++ b/src/torchcodec/_core/Encoder.cpp
@@ -1111,7 +1111,7 @@ void MultiStreamEncoder::addVideoStream(
   STD_TORCH_CHECK(height > 0, "height must be > 0, got ", height);
   STD_TORCH_CHECK(width > 0, "width must be > 0, got ", width);
   STD_TORCH_CHECK(frameRate > 0, "frame_rate must be > 0, got ", frameRate);
-  videoStream_.emplace();
+  videoStream_ = VideoStream{};
   videoStream_->deviceInterface =
       createDeviceInterface(StableDevice(std::move(device)));
   videoStream_->inHeight = height;


### PR DESCRIPTION
This PR resolves this internal error:
```
note: candidate template ignored: requirement 'is_constructible_v<VideoStream>' was not satisfied [with _Args = <>]
  868 |         emplace(_Args&&... __args)
      |         ^
```

[`VideoStream`](https://github.com/meta-pytorch/torchcodec/blob/08b86ea42bed555c2de52440417b651530b5e71a/src/torchcodec/_core/Encoder.h#L211) is a struct that does not declare any constructors. This is one of the properties that makes it an [aggregate](https://en.cppreference.com/cpp/language/aggregate_initialization). Aggregates can be initialized using braces: `VideoStream{}`.

The `is_constructible_v<VideoStream>` check used by `emplace()` in the internal C++ toolchain checks if an object is constructible by parentheses. This fails and raises an error. Newer C++ versions allow [parenthesized aggregate initialization](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p0960r3.html), so this error does not occur in some environments.
