### PR TITLE
Enable open, initialization of audio stream

### DIFF
--- a/src/torchcodec/_core/Encoder.cpp
+++ b/src/torchcodec/_core/Encoder.cpp
@@ -1124,6 +1124,33 @@ void MultiStreamEncoder::addVideoStream(
   videoStream_->options.extraOptions = std::move(extraOptions);
 }
 
+void MultiStreamEncoder::addAudioStream(
+    int sampleRate,
+    int numChannels,
+    std::optional<int> bitRate,
+    std::optional<int> desiredNumChannels,
+    std::optional<int> desiredSampleRate) {
+  STD_TORCH_CHECK(
+      !audioStream_.has_value(),
+      "An audio stream has already been added. Cannot add another.");
+  STD_TORCH_CHECK(sampleRate > 0, "sample_rate must be > 0, got ", sampleRate);
+  STD_TORCH_CHECK(
+      numChannels > 0, "num_channels must be > 0, got ", numChannels);
+  STD_TORCH_CHECK(
+      numChannels <= AV_NUM_DATA_POINTERS,
+      "num_channels must be <= ",
+      AV_NUM_DATA_POINTERS,
+      ", got ",
+      numChannels);
+
+  audioStream_ = AudioStream{};
+  audioStream_->inSampleRate = sampleRate;
+  audioStream_->inNumChannels = numChannels;
+  audioStream_->options.bitRate = bitRate;
+  audioStream_->options.numChannels = desiredNumChannels;
+  audioStream_->options.sampleRate = desiredSampleRate;
+}
+
 void MultiStreamEncoder::initializeVideoStream() {
   // TODO MultiStreamEncoder: Iterate over all video streams
   auto& videoStream = *videoStream_;
@@ -1280,12 +1307,80 @@ void MultiStreamEncoder::initializeVideoStream() {
       getFFMPEGErrorStringFromErrorCode(status));
 }
 
+void MultiStreamEncoder::initializeAudioStream() {
+  auto& audioStream = *audioStream_;
+  // We use the AVFormatContext's default codec for that
+  // specific format/container.
+  const AVCodec* avCodec =
+      avcodec_find_encoder(avFormatContext_->oformat->audio_codec);
+  STD_TORCH_CHECK(avCodec != nullptr, "Codec not found");
+
+  AVCodecContext* avCodecContext = avcodec_alloc_context3(avCodec);
+  STD_TORCH_CHECK(
+      avCodecContext != nullptr, "Couldn't allocate codec context.");
+  audioStream.avCodecContext.reset(avCodecContext);
+
+  auto desiredBitRate = audioStream.options.bitRate;
+  if (desiredBitRate.has_value()) {
+    STD_TORCH_CHECK(
+        *desiredBitRate >= 0, "bit_rate=", *desiredBitRate, " must be >= 0.");
+  }
+  // bit_rate=None defaults to 0, which is what the FFmpeg CLI seems to use as
+  // well when "-b:a" isn't specified.
+  audioStream.avCodecContext->bit_rate = desiredBitRate.value_or(0);
+
+  audioStream.outNumChannels =
+      audioStream.options.numChannels.value_or(audioStream.inNumChannels);
+  validateNumChannels(*avCodec, audioStream.outNumChannels);
+  // The avCodecContext layout defines the layout of the encoded output, it's
+  // not related to the input samples.
+  setDefaultChannelLayout(
+      audioStream.avCodecContext, audioStream.outNumChannels);
+
+  audioStream.outSampleRate =
+      audioStream.options.sampleRate.value_or(audioStream.inSampleRate);
+  validateSampleRate(*avCodec, audioStream.outSampleRate);
+  audioStream.avCodecContext->sample_rate = audioStream.outSampleRate;
+
+  // Input samples are expected to be FLTP. Not all encoders support FLTP, so we
+  // may need to convert the samples into a supported output sample format,
+  // which is what the `.sample_fmt` defines.
+  audioStream.avCodecContext->sample_fmt = findBestOutputSampleFormat(*avCodec);
+
+  int status =
+      avcodec_open2(audioStream.avCodecContext.get(), avCodec, nullptr);
+  STD_TORCH_CHECK(
+      status == AVSUCCESS,
+      "avcodec_open2 failed: ",
+      getFFMPEGErrorStringFromErrorCode(status));
+
+  // We're allocating the stream here. Streams are meant to be freed by
+  // avformat_free_context(avFormatContext), which we call in the
+  // avFormatContext_'s destructor.
+  audioStream.avStream = avformat_new_stream(avFormatContext_.get(), nullptr);
+  STD_TORCH_CHECK(
+      audioStream.avStream != nullptr, "Couldn't create new audio stream.");
+
+  status = avcodec_parameters_from_context(
+      audioStream.avStream->codecpar, audioStream.avCodecContext.get());
+  STD_TORCH_CHECK(
+      status == AVSUCCESS,
+      "avcodec_parameters_from_context failed: ",
+      getFFMPEGErrorStringFromErrorCode(status));
+}
+
 void MultiStreamEncoder::open() {
   STD_TORCH_CHECK(!headerWritten_, "open() was already called.");
   STD_TORCH_CHECK(
-      videoStream_.has_value(), "Call addVideoStream() before open().");
+      videoStream_.has_value() || audioStream_.has_value(),
+      "Call addVideoStream() or addAudioStream() before open().");
 
-  initializeVideoStream();
+  if (videoStream_.has_value()) {
+    initializeVideoStream();
+  }
+  if (audioStream_.has_value()) {
+    initializeAudioStream();
+  }
 
   int status = avformat_write_header(
       avFormatContext_.get(), avFormatOptions_.getAddress());

--- a/src/torchcodec/_core/Encoder.cpp
+++ b/src/torchcodec/_core/Encoder.cpp
@@ -1133,6 +1133,9 @@ void MultiStreamEncoder::addAudioStream(
   STD_TORCH_CHECK(
       !audioStream_.has_value(),
       "An audio stream has already been added. Cannot add another.");
+  STD_TORCH_CHECK(sampleRate > 0, "sample_rate must be > 0, got ", sampleRate);
+  STD_TORCH_CHECK(
+      numChannels > 0, "num_channels must be > 0, got ", numChannels);
 
   audioStream_ = AudioStream{};
   audioStream_->inSampleRate = sampleRate;

--- a/src/torchcodec/_core/Encoder.cpp
+++ b/src/torchcodec/_core/Encoder.cpp
@@ -1133,15 +1133,6 @@ void MultiStreamEncoder::addAudioStream(
   STD_TORCH_CHECK(
       !audioStream_.has_value(),
       "An audio stream has already been added. Cannot add another.");
-  STD_TORCH_CHECK(sampleRate > 0, "sample_rate must be > 0, got ", sampleRate);
-  STD_TORCH_CHECK(
-      numChannels > 0, "num_channels must be > 0, got ", numChannels);
-  STD_TORCH_CHECK(
-      numChannels <= AV_NUM_DATA_POINTERS,
-      "num_channels must be <= ",
-      AV_NUM_DATA_POINTERS,
-      ", got ",
-      numChannels);
 
   audioStream_ = AudioStream{};
   audioStream_->inSampleRate = sampleRate;

--- a/src/torchcodec/_core/Encoder.cpp
+++ b/src/torchcodec/_core/Encoder.cpp
@@ -1127,9 +1127,7 @@ void MultiStreamEncoder::addVideoStream(
 void MultiStreamEncoder::addAudioStream(
     int sampleRate,
     int numChannels,
-    std::optional<int> bitRate,
-    std::optional<int> desiredNumChannels,
-    std::optional<int> desiredSampleRate) {
+    std::optional<int> bitRate) {
   STD_TORCH_CHECK(
       !audioStream_.has_value(),
       "An audio stream has already been added. Cannot add another.");
@@ -1141,8 +1139,6 @@ void MultiStreamEncoder::addAudioStream(
   audioStream_->inSampleRate = sampleRate;
   audioStream_->inNumChannels = numChannels;
   audioStream_->options.bitRate = bitRate;
-  audioStream_->options.numChannels = desiredNumChannels;
-  audioStream_->options.sampleRate = desiredSampleRate;
 }
 
 void MultiStreamEncoder::initializeVideoStream() {
@@ -1323,18 +1319,13 @@ void MultiStreamEncoder::initializeAudioStream() {
   // well when "-b:a" isn't specified.
   audioStream.avCodecContext->bit_rate = desiredBitRate.value_or(0);
 
-  audioStream.outNumChannels =
-      audioStream.options.numChannels.value_or(audioStream.inNumChannels);
-  validateNumChannels(*avCodec, audioStream.outNumChannels);
-  // The avCodecContext layout defines the layout of the encoded output, it's
-  // not related to the input samples.
+  // TODO MultiStreamEncoder: support output numChannels and sampleRate
+  validateNumChannels(*avCodec, audioStream.inNumChannels);
   setDefaultChannelLayout(
-      audioStream.avCodecContext, audioStream.outNumChannels);
+      audioStream.avCodecContext, audioStream.inNumChannels);
 
-  audioStream.outSampleRate =
-      audioStream.options.sampleRate.value_or(audioStream.inSampleRate);
-  validateSampleRate(*avCodec, audioStream.outSampleRate);
-  audioStream.avCodecContext->sample_rate = audioStream.outSampleRate;
+  validateSampleRate(*avCodec, audioStream.inSampleRate);
+  audioStream.avCodecContext->sample_rate = audioStream.inSampleRate;
 
   // Input samples are expected to be FLTP. Not all encoders support FLTP, so we
   // may need to convert the samples into a supported output sample format,

--- a/src/torchcodec/_core/Encoder.h
+++ b/src/torchcodec/_core/Encoder.h
@@ -203,6 +203,12 @@ class FORCE_PUBLIC_VISIBILITY MultiStreamEncoder {
       std::optional<std::string> preset = std::nullopt,
       std::optional<std::map<std::string, std::string>> extraOptions =
           std::nullopt);
+  void addAudioStream(
+      int sampleRate,
+      int numChannels,
+      std::optional<int> bitRate = std::nullopt,
+      std::optional<int> desiredNumChannels = std::nullopt,
+      std::optional<int> desiredSampleRate = std::nullopt);
   void open();
   void addFrames(const torch::stable::Tensor& frames);
   void close();
@@ -219,14 +225,26 @@ class FORCE_PUBLIC_VISIBILITY MultiStreamEncoder {
     std::unique_ptr<DeviceInterface> deviceInterface;
   };
 
+  struct AudioStream {
+    int inSampleRate = -1;
+    int inNumChannels = -1;
+    int outSampleRate = -1;
+    int outNumChannels = -1;
+    AudioStreamOptions options;
+    UniqueAVCodecContext avCodecContext;
+    AVStream* avStream = nullptr;
+  };
+
   void initializeVideoStream();
   void encodeVideoFrame(
       AutoAVPacket& autoAVPacket,
       const UniqueAVFrame& avFrame);
+  void initializeAudioStream();
   void flushBuffers();
 
   UniqueEncodingAVFormatContext avFormatContext_;
   std::optional<VideoStream> videoStream_;
+  std::optional<AudioStream> audioStream_;
   bool headerWritten_ = false;
   UniqueAVDictionary avFormatOptions_;
 

--- a/src/torchcodec/_core/Encoder.h
+++ b/src/torchcodec/_core/Encoder.h
@@ -206,9 +206,7 @@ class FORCE_PUBLIC_VISIBILITY MultiStreamEncoder {
   void addAudioStream(
       int sampleRate,
       int numChannels,
-      std::optional<int> bitRate = std::nullopt,
-      std::optional<int> desiredNumChannels = std::nullopt,
-      std::optional<int> desiredSampleRate = std::nullopt);
+      std::optional<int> bitRate = std::nullopt);
   void open();
   void addFrames(const torch::stable::Tensor& frames);
   void close();
@@ -228,8 +226,6 @@ class FORCE_PUBLIC_VISIBILITY MultiStreamEncoder {
   struct AudioStream {
     int inSampleRate = -1;
     int inNumChannels = -1;
-    int outSampleRate = -1;
-    int outNumChannels = -1;
     AudioStreamOptions options;
     UniqueAVCodecContext avCodecContext;
     AVStream* avStream = nullptr;

--- a/src/torchcodec/_core/__init__.py
+++ b/src/torchcodec/_core/__init__.py
@@ -42,6 +42,7 @@ from .ops import (
     get_wav_metadata_from_decoder,
     get_wav_samples_in_range,
     set_nvdec_cache_capacity,
+    streaming_encoder_add_audio_stream,
     streaming_encoder_add_frames,
     streaming_encoder_add_video_stream,
     streaming_encoder_close,

--- a/src/torchcodec/_core/custom_ops.cpp
+++ b/src/torchcodec/_core/custom_ops.cpp
@@ -1261,17 +1261,9 @@ void streaming_encoder_add_audio_stream(
   unwrapTensorToGetMultiStreamEncoder(encoder)->addAudioStream(
       validateInt64ToInt(sample_rate, "sample_rate"),
       validateInt64ToInt(num_channels, "num_channels"),
-      bit_rate.has_value()
-          ? std::optional<int>(validateInt64ToInt(*bit_rate, "bit_rate"))
-          : std::nullopt,
-      desired_num_channels.has_value()
-          ? std::optional<int>(validateInt64ToInt(
-                *desired_num_channels, "desired_num_channels"))
-          : std::nullopt,
-      desired_sample_rate.has_value()
-          ? std::optional<int>(
-                validateInt64ToInt(*desired_sample_rate, "desired_sample_rate"))
-          : std::nullopt);
+      validateOptionalInt64ToInt(bit_rate, "bit_rate"),
+      validateOptionalInt64ToInt(desired_num_channels, "desired_num_channels"),
+      validateOptionalInt64ToInt(desired_sample_rate, "desired_sample_rate"));
 }
 
 void streaming_encoder_add_frames(

--- a/src/torchcodec/_core/custom_ops.cpp
+++ b/src/torchcodec/_core/custom_ops.cpp
@@ -94,6 +94,8 @@ STABLE_TORCH_LIBRARY(torchcodec_ns, m) {
   m.def("streaming_encoder_close(Tensor(a!) encoder) -> ()");
   m.def(
       "streaming_encoder_add_video_stream(Tensor(a!) encoder, int height, int width, float frame_rate, str device=\"cpu\", str? codec=None, str? pixel_format=None, float? crf=None, str? preset=None, str[]? extra_options=None) -> ()");
+  m.def(
+      "streaming_encoder_add_audio_stream(Tensor(a!) encoder, int sample_rate, int num_channels, int? bit_rate=None, int? desired_num_channels=None, int? desired_sample_rate=None) -> ()");
   m.def("streaming_encoder_open(Tensor(a!) encoder) -> ()");
   m.def(
       "streaming_encoder_add_frames(Tensor(a!) encoder, Tensor frames) -> ()");
@@ -1249,6 +1251,29 @@ void streaming_encoder_open(torch::stable::Tensor& encoder) {
   unwrapTensorToGetMultiStreamEncoder(encoder)->open();
 }
 
+void streaming_encoder_add_audio_stream(
+    torch::stable::Tensor& encoder,
+    int64_t sample_rate,
+    int64_t num_channels,
+    std::optional<int64_t> bit_rate = std::nullopt,
+    std::optional<int64_t> desired_num_channels = std::nullopt,
+    std::optional<int64_t> desired_sample_rate = std::nullopt) {
+  unwrapTensorToGetMultiStreamEncoder(encoder)->addAudioStream(
+      validateInt64ToInt(sample_rate, "sample_rate"),
+      validateInt64ToInt(num_channels, "num_channels"),
+      bit_rate.has_value()
+          ? std::optional<int>(validateInt64ToInt(*bit_rate, "bit_rate"))
+          : std::nullopt,
+      desired_num_channels.has_value()
+          ? std::optional<int>(validateInt64ToInt(
+                *desired_num_channels, "desired_num_channels"))
+          : std::nullopt,
+      desired_sample_rate.has_value()
+          ? std::optional<int>(
+                validateInt64ToInt(*desired_sample_rate, "desired_sample_rate"))
+          : std::nullopt);
+}
+
 void streaming_encoder_add_frames(
     torch::stable::Tensor& encoder,
     const torch::stable::Tensor& frames) {
@@ -1334,6 +1359,9 @@ STABLE_TORCH_LIBRARY_IMPL(torchcodec_ns, BackendSelect, m) {
   m.impl(
       "streaming_encoder_add_video_stream",
       TORCH_BOX(&streaming_encoder_add_video_stream));
+  m.impl(
+      "streaming_encoder_add_audio_stream",
+      TORCH_BOX(&streaming_encoder_add_audio_stream));
   m.impl("streaming_encoder_open", TORCH_BOX(&streaming_encoder_open));
   m.impl(
       "streaming_encoder_add_frames", TORCH_BOX(&streaming_encoder_add_frames));
@@ -1390,6 +1418,9 @@ STABLE_TORCH_LIBRARY_IMPL(torchcodec_ns, CPU, m) {
   m.impl(
       "streaming_encoder_add_video_stream",
       TORCH_BOX(&streaming_encoder_add_video_stream));
+  m.impl(
+      "streaming_encoder_add_audio_stream",
+      TORCH_BOX(&streaming_encoder_add_audio_stream));
   m.impl("streaming_encoder_open", TORCH_BOX(&streaming_encoder_open));
   m.impl(
       "streaming_encoder_add_frames", TORCH_BOX(&streaming_encoder_add_frames));

--- a/src/torchcodec/_core/custom_ops.cpp
+++ b/src/torchcodec/_core/custom_ops.cpp
@@ -95,7 +95,7 @@ STABLE_TORCH_LIBRARY(torchcodec_ns, m) {
   m.def(
       "streaming_encoder_add_video_stream(Tensor(a!) encoder, int height, int width, float frame_rate, str device=\"cpu\", str? codec=None, str? pixel_format=None, float? crf=None, str? preset=None, str[]? extra_options=None) -> ()");
   m.def(
-      "streaming_encoder_add_audio_stream(Tensor(a!) encoder, int sample_rate, int num_channels, int? bit_rate=None, int? desired_num_channels=None, int? desired_sample_rate=None) -> ()");
+      "streaming_encoder_add_audio_stream(Tensor(a!) encoder, int sample_rate, int num_channels, int? bit_rate=None) -> ()");
   m.def("streaming_encoder_open(Tensor(a!) encoder) -> ()");
   m.def(
       "streaming_encoder_add_frames(Tensor(a!) encoder, Tensor frames) -> ()");
@@ -1255,15 +1255,11 @@ void streaming_encoder_add_audio_stream(
     torch::stable::Tensor& encoder,
     int64_t sample_rate,
     int64_t num_channels,
-    std::optional<int64_t> bit_rate = std::nullopt,
-    std::optional<int64_t> desired_num_channels = std::nullopt,
-    std::optional<int64_t> desired_sample_rate = std::nullopt) {
+    std::optional<int64_t> bit_rate = std::nullopt) {
   unwrapTensorToGetMultiStreamEncoder(encoder)->addAudioStream(
       validateInt64ToInt(sample_rate, "sample_rate"),
       validateInt64ToInt(num_channels, "num_channels"),
-      validateOptionalInt64ToInt(bit_rate, "bit_rate"),
-      validateOptionalInt64ToInt(desired_num_channels, "desired_num_channels"),
-      validateOptionalInt64ToInt(desired_sample_rate, "desired_sample_rate"));
+      validateOptionalInt64ToInt(bit_rate, "bit_rate"));
 }
 
 void streaming_encoder_add_frames(

--- a/src/torchcodec/_core/ops.py
+++ b/src/torchcodec/_core/ops.py
@@ -148,6 +148,9 @@ streaming_encoder_close = torch.ops.torchcodec_ns.streaming_encoder_close.defaul
 streaming_encoder_add_video_stream = (
     torch.ops.torchcodec_ns.streaming_encoder_add_video_stream.default
 )
+streaming_encoder_add_audio_stream = (
+    torch.ops.torchcodec_ns.streaming_encoder_add_audio_stream.default
+)
 streaming_encoder_open = torch.ops.torchcodec_ns.streaming_encoder_open.default
 streaming_encoder_add_frames = (
     torch.ops.torchcodec_ns.streaming_encoder_add_frames.default
@@ -645,6 +648,18 @@ def streaming_encoder_add_video_stream_abstract(
     crf: float | None = None,
     preset: str | None = None,
     extra_options: list[str] | None = None,
+) -> None:
+    return
+
+
+@register_fake("torchcodec_ns::streaming_encoder_add_audio_stream")
+def streaming_encoder_add_audio_stream_abstract(
+    encoder: torch.Tensor,
+    sample_rate: int,
+    num_channels: int,
+    bit_rate: int | None = None,
+    desired_num_channels: int | None = None,
+    desired_sample_rate: int | None = None,
 ) -> None:
     return
 

--- a/src/torchcodec/_core/ops.py
+++ b/src/torchcodec/_core/ops.py
@@ -658,8 +658,6 @@ def streaming_encoder_add_audio_stream_abstract(
     sample_rate: int,
     num_channels: int,
     bit_rate: int | None = None,
-    desired_num_channels: int | None = None,
-    desired_sample_rate: int | None = None,
 ) -> None:
     return
 

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1274,7 +1274,6 @@ class TestMultiStreamEncoderOps:
         )
         streaming_encoder_open(encoder)
         streaming_encoder_close(encoder)
-        streaming_encoder_close(encoder)  # double close is a no-op
 
     def test_create_invalid_path(self):
         with pytest.raises(RuntimeError, match="make sure it's a valid path"):

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -31,6 +31,7 @@ from torchcodec._core import (
     get_frames_in_range,
     get_json_metadata,
     get_next_frame,
+    streaming_encoder_add_audio_stream,
     streaming_encoder_add_frames,
     streaming_encoder_add_video_stream,
     streaming_encoder_close,
@@ -1261,6 +1262,20 @@ class TestMultiStreamEncoderOps:
             decoded_frames, source_frames.cpu(), percentage=percentage, atol=atol
         )
 
+    @pytest.mark.parametrize("method", ("to_file", "to_file_like"))
+    def test_add_audio_stream_and_open_close(self, tmp_path, method):
+        encoder, encoder_output = self._create_encoder(method, tmp_path, "wav")
+        streaming_encoder_add_audio_stream(
+            encoder,
+            sample_rate=44100,
+            num_channels=2,
+            desired_num_channels=1,
+            desired_sample_rate=16000,
+        )
+        streaming_encoder_open(encoder)
+        streaming_encoder_close(encoder)
+        streaming_encoder_close(encoder)  # double close is a no-op
+
     def test_create_invalid_path(self):
         with pytest.raises(RuntimeError, match="make sure it's a valid path"):
             create_streaming_encoder_to_file("/nonexistent/dir/test.mp4")
@@ -1371,6 +1386,15 @@ class TestMultiStreamEncoderOps:
             )
 
     @pytest.mark.parametrize("method", ("to_file", "to_file_like"))
+    def test_add_audio_stream_twice_errors(self, tmp_path, method):
+        encoder, _ = self._create_encoder(method, tmp_path, "mp4")
+        streaming_encoder_add_audio_stream(encoder, sample_rate=44100, num_channels=2)
+        with pytest.raises(RuntimeError, match="already been added"):
+            streaming_encoder_add_audio_stream(
+                encoder, sample_rate=16000, num_channels=1
+            )
+
+    @pytest.mark.parametrize("method", ("to_file", "to_file_like"))
     @pytest.mark.parametrize(
         "device",
         (
@@ -1442,7 +1466,8 @@ class TestMultiStreamEncoderOps:
     def test_open_without_stream_errors(self, tmp_path, method):
         encoder, _ = self._create_encoder(method, tmp_path, "mp4")
         with pytest.raises(
-            RuntimeError, match="Call addVideoStream\\(\\) before open\\(\\)"
+            RuntimeError,
+            match="Call addVideoStream\\(\\) or addAudioStream\\(\\) before open\\(\\)",
         ):
             streaming_encoder_open(encoder)
 
@@ -1454,6 +1479,30 @@ class TestMultiStreamEncoderOps:
         )
         streaming_encoder_open(encoder)
         with pytest.raises(RuntimeError, match="open\\(\\) was already called"):
+            streaming_encoder_open(encoder)
+
+    @pytest.mark.parametrize("method", ("to_file", "to_file_like"))
+    def test_add_audio_stream_invalid_bit_rate_errors(self, tmp_path, method):
+        encoder, _ = self._create_encoder(method, tmp_path, "mp4")
+        streaming_encoder_add_audio_stream(
+            encoder,
+            sample_rate=44100,
+            num_channels=2,
+            bit_rate=-1,
+        )
+        with pytest.raises(RuntimeError, match="bit_rate=-1 must be >= 0"):
+            streaming_encoder_open(encoder)
+
+    @pytest.mark.parametrize("method", ("to_file", "to_file_like"))
+    def test_add_audio_stream_invalid_sample_rate_errors(self, tmp_path, method):
+        encoder, _ = self._create_encoder(method, tmp_path, "mp4")
+        streaming_encoder_add_audio_stream(
+            encoder,
+            sample_rate=44100,
+            num_channels=2,
+            desired_sample_rate=12345,
+        )
+        with pytest.raises(RuntimeError, match="invalid sample rate=12345"):
             streaming_encoder_open(encoder)
 
 

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1494,6 +1494,21 @@ class TestMultiStreamEncoderOps:
             streaming_encoder_open(encoder)
 
     @pytest.mark.parametrize("method", ("to_file", "to_file_like"))
+    def test_add_audio_stream_invalid_num_channels_errors(self, tmp_path, method):
+        encoder, _ = self._create_encoder(method, tmp_path, "mp4")
+        streaming_encoder_add_audio_stream(
+            encoder,
+            sample_rate=44100,
+            num_channels=2,
+            desired_num_channels=100,
+        )
+        with pytest.raises(
+            RuntimeError,
+            match="Desired number of channels.*is not supported|avcodec_open2 failed",
+        ):
+            streaming_encoder_open(encoder)
+
+    @pytest.mark.parametrize("method", ("to_file", "to_file_like"))
     def test_add_audio_stream_invalid_sample_rate_errors(self, tmp_path, method):
         encoder, _ = self._create_encoder(method, tmp_path, "mp4")
         streaming_encoder_add_audio_stream(

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1269,8 +1269,6 @@ class TestMultiStreamEncoderOps:
             encoder,
             sample_rate=44100,
             num_channels=2,
-            desired_num_channels=1,
-            desired_sample_rate=16000,
         )
         streaming_encoder_open(encoder)
         streaming_encoder_close(encoder)
@@ -1490,33 +1488,6 @@ class TestMultiStreamEncoderOps:
             bit_rate=-1,
         )
         with pytest.raises(RuntimeError, match="bit_rate=-1 must be >= 0"):
-            streaming_encoder_open(encoder)
-
-    @pytest.mark.parametrize("method", ("to_file", "to_file_like"))
-    def test_add_audio_stream_invalid_num_channels_errors(self, tmp_path, method):
-        encoder, _ = self._create_encoder(method, tmp_path, "mp4")
-        streaming_encoder_add_audio_stream(
-            encoder,
-            sample_rate=44100,
-            num_channels=2,
-            desired_num_channels=100,
-        )
-        with pytest.raises(
-            RuntimeError,
-            match="Desired number of channels.*is not supported|avcodec_open2 failed",
-        ):
-            streaming_encoder_open(encoder)
-
-    @pytest.mark.parametrize("method", ("to_file", "to_file_like"))
-    def test_add_audio_stream_invalid_sample_rate_errors(self, tmp_path, method):
-        encoder, _ = self._create_encoder(method, tmp_path, "mp4")
-        streaming_encoder_add_audio_stream(
-            encoder,
-            sample_rate=44100,
-            num_channels=2,
-            desired_sample_rate=12345,
-        )
-        with pytest.raises(RuntimeError, match="invalid sample rate=12345"):
             streaming_encoder_open(encoder)
 
 


### PR DESCRIPTION
This PR extends `MultiStreamEncoder` to open and initialize an audio stream. It does not support encoding samples yet.

* `MultiStreamEncoder::addAudioStream()`: 
  * This function stores audio stream parameters in the member variable `audioStream_`. 
  * We currently enforce that only one audio stream can be added.
* `MultiStreamEncoder::initializeAudioStream()`: 
  * This function is mostly duplicated from [`AudioEncoder::initializeEncoder()`](https://github.com/Dan-Flores/torchcodec/blob/3c865b251bc90678621d5249083ea651c477ee8d/src/torchcodec/_core/Encoder.cpp#L176), see [this diffing view](https://www.internalfb.com/intern/diffing/?paste_number=2304181997) for a direct comparison.
  * It validates the input encoding parameters, calls `avcodec_open2` and `avformat_new_stream` to enable encoding.


Testing is limited at the moment, since we do not support writing samples yet. 
* `test_add_audio_stream_and_open_close` checks that the new function calls work. In future PRs we will update this test to write samples similar to `test_add_video_stream_and_encode_frames`.