### PR TITLE
Encode audio through FIFO in streaming encoder

### DIFF
--- a/src/torchcodec/_core/Encoder.cpp
+++ b/src/torchcodec/_core/Encoder.cpp
@@ -1365,6 +1365,22 @@ void MultiStreamEncoder::initializeAudioStream() {
       status == AVSUCCESS,
       "avcodec_parameters_from_context failed: ",
       getFFMPEGErrorStringFromErrorCode(status));
+
+  // If a codec supports variable frame size, frame_size may not be defined, in
+  // which case we default to 256 like torchaudio.
+  audioStream.frameSize = audioStream.avCodecContext->frame_size > 0
+      ? audioStream.avCodecContext->frame_size
+      : 256;
+
+  // We always create a FIFO so that addSamples() can be called multiple times
+  // with various chunk sizes that are then buffered and encoded in frame_size
+  // sized batches.
+  auto avAudioFifo = av_audio_fifo_alloc(
+      audioStream.avCodecContext->sample_fmt,
+      audioStream.inNumChannels,
+      audioStream.frameSize * 2);
+  STD_TORCH_CHECK(avAudioFifo != nullptr, "Couldn't create AVAudioFifo.");
+  audioStream.avAudioFifo.reset(avAudioFifo);
 }
 
 void MultiStreamEncoder::open() {
@@ -1482,15 +1498,6 @@ void MultiStreamEncoder::addSamples(const torch::stable::Tensor& samples) {
       audioStream_->inNumChannels,
       " channels, got ",
       validatedSamples.sizes()[0]);
-  // TODO MultiStreamEncoder: Support multiple addSamples() calls.
-  // Codecs have frame size requirements, only the final encoded sample batch
-  // can be smaller than the frame size, so to support multiple calls without
-  // requiring the user to know about frame size, we need to encode frames
-  // through a FIFO.
-  STD_TORCH_CHECK(
-      !audioStream_->addSamplesCalled,
-      "Only one addSamples() call is currently supported.");
-  audioStream_->addSamplesCalled = true;
   encodeAudioSamples(validatedSamples);
 }
 
@@ -1498,13 +1505,8 @@ void MultiStreamEncoder::encodeAudioSamples(
     const torch::stable::Tensor& samples) {
   auto& audioStream = *audioStream_;
 
-  //  Default to 256 like in torchaudio
-  int numSamplesAllocatedPerFrame = audioStream.avCodecContext->frame_size > 0
-      ? audioStream.avCodecContext->frame_size
-      : 256;
-
   UniqueAVFrame avFrame = allocateAVFrame(
-      numSamplesAllocatedPerFrame,
+      audioStream.frameSize,
       audioStream.inSampleRate,
       audioStream.inNumChannels,
       AV_SAMPLE_FMT_FLTP);
@@ -1520,7 +1522,7 @@ void MultiStreamEncoder::encodeAudioSamples(
 
   while (numEncodedSamples < numSamples) {
     int numSamplesToEncode =
-        std::min(numSamplesAllocatedPerFrame, numSamples - numEncodedSamples);
+        std::min(audioStream.frameSize, numSamples - numEncodedSamples);
     int numBytesToEncode = numSamplesToEncode * numBytesPerSample;
 
     for (int ch = 0; ch < audioStream.inNumChannels; ch++) {
@@ -1540,7 +1542,7 @@ void MultiStreamEncoder::encodeAudioSamples(
 
     UniqueAVFrame convertedAVFrame =
         maybeConvertAudioAVFrame(avFrame, audioStream);
-    encodeAudioFrame(autoAVPacket, convertedAVFrame, audioStream);
+    encodeAudioFrameThroughFifo(autoAVPacket, convertedAVFrame, audioStream);
 
     numEncodedSamples += numSamplesToEncode;
   }
@@ -1592,6 +1594,66 @@ UniqueAVFrame MultiStreamEncoder::maybeConvertAudioAVFrame(
         "This is unexpected, please report on the TorchCodec bug tracker.");
   }
   return convertedAVFrame;
+}
+
+void MultiStreamEncoder::encodeAudioFrameThroughFifo(
+    AutoAVPacket& autoAVPacket,
+    const UniqueAVFrame& avFrame,
+    AudioStream& audioStream,
+    // flushFifo is only set to true in maybeFlushSwrAndFifo(), i.e. at the very
+    // end of the encoding process when we're flushing buffers. We also want to
+    // flush the FIFO so as to not leave any remaining samples in it.
+    bool flushFifo) {
+  if (avFrame != nullptr) {
+    int numSamplesWritten = av_audio_fifo_write(
+        audioStream.avAudioFifo.get(),
+        reinterpret_cast<void**>(avFrame->data),
+        avFrame->nb_samples);
+    STD_TORCH_CHECK(
+        numSamplesWritten == avFrame->nb_samples,
+        "Tried to write ",
+        avFrame->nb_samples,
+        " samples, but only wrote ",
+        numSamplesWritten);
+  }
+
+  UniqueAVFrame newavFrame = allocateAVFrame(
+      audioStream.frameSize,
+      audioStream.avCodecContext->sample_rate,
+      audioStream.inNumChannels,
+      audioStream.avCodecContext->sample_fmt);
+
+  // Explaining the while bound:
+  // - if we're not flushing the FIFO, i.e. in most cases, we want to pull
+  //   exactly `frame_size` samples from the FIFO, so we have to stop before it
+  //   contains less than `frame_size` samples.
+  // - if we're flushing the FIFO, we want to read from the FIFO until the very
+  //   last sample it contains.
+  //
+  // In both cases, for as long as we can, we're trying to pull exactly
+  // `frame_size` samples from the FIFO and send each `frame_size`-sized avFrame
+  // to encodeAudioFrame(). Only the very last avFrame of the encoding process
+  // is allowed to contain less than frame_size samples. That only happens when
+  // flushFifo is true.
+  while (av_audio_fifo_size(audioStream.avAudioFifo.get()) >=
+         (flushFifo ? 1 : audioStream.frameSize)) {
+    int samplesToRead = std::min(
+        av_audio_fifo_size(audioStream.avAudioFifo.get()),
+        newavFrame->nb_samples);
+    int numSamplesRead = av_audio_fifo_read(
+        audioStream.avAudioFifo.get(),
+        reinterpret_cast<void**>(newavFrame->data),
+        samplesToRead);
+    STD_TORCH_CHECK(
+        numSamplesRead == samplesToRead,
+        "Tried to read ",
+        samplesToRead,
+        " samples, but only read ",
+        numSamplesRead);
+
+    newavFrame->nb_samples = numSamplesRead;
+    encodeAudioFrame(autoAVPacket, newavFrame, audioStream);
+  }
 }
 
 void MultiStreamEncoder::encodeAudioFrame(
@@ -1647,43 +1709,41 @@ void MultiStreamEncoder::encodeAudioFrame(
   }
 }
 
-void MultiStreamEncoder::maybeFlushAudioSwrBuffers(
+void MultiStreamEncoder::maybeFlushSwrAndFifo(
     AutoAVPacket& autoAVPacket,
     AudioStream& audioStream) {
-  // Similar to the decoder's method with the same name, but for encoding this
-  // time. That is, when sample conversion is involved, libswresample may have
-  // buffered some samples that we now need to flush and send to the encoder.
-  if (audioStream.swrContext == nullptr) {
-    return;
+  // When sample conversion is involved, libswresample may have buffered some
+  // samples that we need to flush into the FIFO before draining it.
+  UniqueAVFrame swrFrame(nullptr);
+  if (audioStream.swrContext != nullptr) {
+    int numRemainingSamples = // this is an upper bound
+        swr_get_out_samples(audioStream.swrContext.get(), 0);
+    if (numRemainingSamples > 0) {
+      swrFrame = allocateAVFrame(
+          numRemainingSamples,
+          audioStream.inSampleRate,
+          audioStream.inNumChannels,
+          audioStream.avCodecContext->sample_fmt);
+      int actualNumRemainingSamples = swr_convert(
+          audioStream.swrContext.get(),
+          swrFrame->data,
+          swrFrame->nb_samples,
+          nullptr,
+          0);
+      swrFrame->nb_samples = actualNumRemainingSamples;
+    }
   }
 
-  int numRemainingSamples = // this is an upper bound
-      swr_get_out_samples(audioStream.swrContext.get(), 0);
-  if (numRemainingSamples == 0) {
-    return;
-  }
-
-  UniqueAVFrame avFrame = allocateAVFrame(
-      numRemainingSamples,
-      audioStream.inSampleRate,
-      audioStream.inNumChannels,
-      audioStream.avCodecContext->sample_fmt);
-  int actualNumRemainingSamples = swr_convert(
-      audioStream.swrContext.get(),
-      avFrame->data,
-      avFrame->nb_samples,
-      nullptr,
-      0);
-  avFrame->nb_samples = actualNumRemainingSamples;
-
-  encodeAudioFrame(autoAVPacket, avFrame, audioStream);
+  // Flush any remaining swr samples into the FIFO, then drain it.
+  encodeAudioFrameThroughFifo(
+      autoAVPacket, swrFrame, audioStream, /*flushFifo=*/true);
 }
 
 void MultiStreamEncoder::flushBuffers() {
   if (audioStream_.has_value() && audioStream_->avStream != nullptr) {
     AutoAVPacket audioAVPacket;
     auto& audioStream = *audioStream_;
-    maybeFlushAudioSwrBuffers(audioAVPacket, audioStream);
+    maybeFlushSwrAndFifo(audioAVPacket, audioStream);
     encodeAudioFrame(audioAVPacket, UniqueAVFrame(nullptr), audioStream);
   }
   if (videoStream_.has_value() && videoStream_->avStream != nullptr) {

--- a/src/torchcodec/_core/Encoder.h
+++ b/src/torchcodec/_core/Encoder.h
@@ -227,12 +227,13 @@ class FORCE_PUBLIC_VISIBILITY MultiStreamEncoder {
   struct AudioStream {
     int inSampleRate = -1;
     int inNumChannels = -1;
+    int frameSize = -1;
     int64_t lastEncodedAVFramePts = 0;
-    bool addSamplesCalled = false;
     AudioStreamOptions options;
     UniqueAVCodecContext avCodecContext;
     AVStream* avStream = nullptr;
     UniqueSwrContext swrContext;
+    UniqueAVAudioFifo avAudioFifo;
   };
 
   void initializeVideoStream();
@@ -244,11 +245,16 @@ class FORCE_PUBLIC_VISIBILITY MultiStreamEncoder {
   UniqueAVFrame maybeConvertAudioAVFrame(
       const UniqueAVFrame& avFrame,
       AudioStream& audioStream);
+  void encodeAudioFrameThroughFifo(
+      AutoAVPacket& autoAVPacket,
+      const UniqueAVFrame& avFrame,
+      AudioStream& audioStream,
+      bool flushFifo = false);
   void encodeAudioFrame(
       AutoAVPacket& autoAVPacket,
       const UniqueAVFrame& avFrame,
       AudioStream& audioStream);
-  void maybeFlushAudioSwrBuffers(
+  void maybeFlushSwrAndFifo(
       AutoAVPacket& autoAVPacket,
       AudioStream& audioStream);
   void flushBuffers();

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1601,6 +1601,8 @@ class TestMultiStreamEncoderOps:
         assert decoded_audio.data.shape[0] == source_samples.shape[0]
         # Codecs for lossy audio formats (not WAV or FLAC) can add padding which causes
         # sample count to differ, so we only compare the smaller sample count.
+        # TODO MultiStreamEncoder: The previous AudioEncoder didn't need
+        # padding after introducing a FIFO. Investigate why this is needed.
         num_samples_to_compare = min(
             decoded_audio.data.shape[1], source_samples.shape[1]
         )

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1523,7 +1523,12 @@ class TestMultiStreamEncoderOps:
             encoder, sample_rate=sample_rate, num_channels=num_channels
         )
         streaming_encoder_open(encoder)
-        streaming_encoder_add_samples(encoder, samples)
+        chunk_lengths = [1, 50, 1000, 0, 25]
+        offset = 0
+        for length in chunk_lengths:
+            streaming_encoder_add_samples(encoder, samples[:, offset : offset + length])
+            offset += length
+        streaming_encoder_add_samples(encoder, samples[:, offset:])
         streaming_encoder_close(encoder)
 
         source = self._get_decoder_source(encoder_output)
@@ -1572,10 +1577,12 @@ class TestMultiStreamEncoderOps:
             num_channels=source_samples.shape[0],
         )
         streaming_encoder_open(encoder)
-        half = source_frames.shape[0] // 2
-        streaming_encoder_add_frames(encoder, source_frames[:half])
-        streaming_encoder_add_samples(encoder, source_samples)
-        streaming_encoder_add_frames(encoder, source_frames[half:])
+        half_frames = source_frames.shape[0] // 2
+        half_samples = source_samples.shape[1] // 2
+        streaming_encoder_add_frames(encoder, source_frames[:half_frames])
+        streaming_encoder_add_samples(encoder, source_samples[:, :half_samples])
+        streaming_encoder_add_frames(encoder, source_frames[half_frames:])
+        streaming_encoder_add_samples(encoder, source_samples[:, half_samples:])
         streaming_encoder_close(encoder)
 
         source = self._get_decoder_source(encoder_output)
@@ -1603,18 +1610,6 @@ class TestMultiStreamEncoderOps:
             percentage=96 if format == "mkv" else 99,
             atol=0.1 if format == "mkv" else 0.01,
         )
-
-    @pytest.mark.parametrize("method", ("to_file", "to_file_like"))
-    def test_add_samples_twice_errors(self, tmp_path, method):
-        encoder, _ = self._create_encoder(method, tmp_path, "wav")
-        streaming_encoder_add_audio_stream(encoder, sample_rate=44100, num_channels=1)
-        streaming_encoder_open(encoder)
-        streaming_encoder_add_samples(encoder, torch.randn(1, 1000))
-        with pytest.raises(
-            RuntimeError,
-            match="Only one addSamples\\(\\) call is currently supported",
-        ):
-            streaming_encoder_add_samples(encoder, torch.randn(1, 1000))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR enables multiple `addSamples()` calls with varying frame sizes by implementing a FIFO.

* `MultiStreamEncoder::initializeAudioStream()` is updated to *always* create the FIFO ([diffing](https://www.internalfb.com/intern/diffing/?paste_number=2313544584))
	* `outputNumChannels` and `outputSampleRate` are still supported yet.
	* The FIFO is necessary to allow `addSamples()` to be called multiple times with an arbitrary number of samples (also called `frame_size`).
* `MultiStreamEncoder::encodeAudioFrameThroughFifo()` writes frames to the FIFO then encodes samples in batches of length `frame_size` ([diffing](https://www.internalfb.com/intern/diffing/?paste_number=2313569866))
* `MultiStreamEncoder::maybeFlushSwrAndFifo()`: flushes the swr if frames remain, and always flushes the FIFO ([diffing](https://www.internalfb.com/intern/diffing/?paste_number=2313575790)).
	* Currently, output number of samples always matches the input number of samples, so the swr buffer will always be empty. 
	
### Testing
* `test_add_audio_stream_and_encode_samples` is updated to encode varying frame lengths.
* `test_add_audio_and_video_streams_and_encode` is updated to interleave `addSamples()` and `addFrames()` calls.