### PR TITLE
Add aarch64 CPU wheels

### DIFF
--- a/.github/workflows/linux_aarch64_wheel.yaml
+++ b/.github/workflows/linux_aarch64_wheel.yaml
@@ -1,0 +1,110 @@
+name: Build and test Linux aarch64 wheel
+
+on:
+  pull_request:
+  push:
+    branches:
+      - nightly
+      - main
+      - release/*
+    tags:
+        - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
+  cancel-in-progress: true
+
+permissions:
+  id-token: write
+  contents: write
+
+defaults:
+  run:
+    shell: bash -l -eo pipefail {0}
+
+jobs:
+
+  generate-matrix:
+    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
+    with:
+      package-type: wheel
+      os: linux-aarch64
+      test-infra-repository: pytorch/test-infra
+      test-infra-ref: main
+      with-xpu: disable
+      with-rocm: disable
+      with-cuda: disable
+      build-python-only: "disable"
+
+  build:
+    needs: generate-matrix
+    strategy:
+      fail-fast: false
+    name: Build and Upload Linux aarch64 wheel
+    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
+    with:
+      repository: meta-pytorch/torchcodec
+      ref: ""
+      test-infra-repository: pytorch/test-infra
+      test-infra-ref: main
+      build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
+      pre-script: packaging/pre_build_script.sh
+      post-script: packaging/post_build_script.sh
+      smoke-test-script: packaging/fake_smoke_test.py
+      package-name: torchcodec
+      trigger-event: ${{ github.event_name }}
+      architecture: aarch64
+      build-platform: "python-build-package"
+      build-command: "BUILD_AGAINST_ALL_FFMPEG_FROM_S3=1 python -m build --wheel -vvv --no-isolation"
+
+  install-and-test:
+    runs-on: linux.arm64.2xlarge
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10']
+        ffmpeg-version-for-tests: ['7.0.1']
+    needs: build
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v6
+
+      - name: Remove src/ folder
+        run: bash packaging/remove_src.sh
+
+      - name: Setup conda env
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          auto-update-conda: true
+          # Using miniforge instead of miniconda ensures that the default
+          # conda channel is conda-forge instead of main/default. This ensures
+          # ABI consistency between dependencies:
+          # https://conda-forge.org/docs/user/transitioning_from_defaults/
+          miniforge-version: latest
+          activate-environment: test
+          python-version: ${{ matrix.python-version }}
+
+      - name: Update pip
+        run: python -m pip install --upgrade pip
+
+      - name: Install PyTorch
+        run: bash packaging/install_pytorch.sh cpu "torch torchvision"
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: meta-pytorch_torchcodec__${{ matrix.python-version }}_cpu_aarch64
+          path: dist/
+
+      - name: Install torchcodec from the wheel
+        run: bash packaging/install_torchcodec_wheel.sh
+
+      - name: Install ffmpeg, post build
+        run: bash packaging/install_ffmpeg.sh ${{ matrix.ffmpeg-version-for-tests }}
+
+      - name: Install test dependencies
+        run: bash packaging/install_test_dependencies.sh
+
+      - name: Run Python tests
+        run: |
+          pytest --override-ini="addopts=-v" test

--- a/.github/workflows/linux_aarch64_wheel.yaml
+++ b/.github/workflows/linux_aarch64_wheel.yaml
@@ -1,4 +1,4 @@
-name: Build and test Linux aarch64 wheel
+name: Linux CPU aarch64
 
 on:
   pull_request:

--- a/packaging/update_ci_for_release.sh
+++ b/packaging/update_ci_for_release.sh
@@ -18,6 +18,7 @@ done
 #    This must NOT touch install-and-test-third-party-interface or build-docs.
 WHEEL_FILES=(
     "${WORKFLOW_DIR}/linux_wheel.yaml"
+    "${WORKFLOW_DIR}/linux_aarch64_wheel.yaml"
     "${WORKFLOW_DIR}/linux_cuda_wheel.yaml"
     "${WORKFLOW_DIR}/linux_cuda_aarch64_wheel.yaml"
     "${WORKFLOW_DIR}/macos_wheel.yaml"


### PR DESCRIPTION
Received enough signals for us to own CPU-only aarch64 wheels.
For anyone reading this: We'll release torchcodec 0.12.0 in the next few days *without* these wheels (today is may 14th). The aarch64 wheels will be shipped either with 0.12.1 or with 0.13.0 in the next few *weeks*.