### PR TITLE
Rename CI jobs

### DIFF
--- a/.github/workflows/linux_cuda_aarch64_wheel.yaml
+++ b/.github/workflows/linux_cuda_aarch64_wheel.yaml
@@ -1,4 +1,4 @@
-name: Build and test Linux CUDA aarch64 wheels
+name: Linux CUDA aarch64
 
 on:
   pull_request:

--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -1,4 +1,4 @@
-name: Build and test Linux CUDA wheels and docs
+name: Linux CUDA x86
 
 on:
   pull_request:

--- a/.github/workflows/linux_wheel.yaml
+++ b/.github/workflows/linux_wheel.yaml
@@ -1,4 +1,4 @@
-name: Build and test Linux wheel
+name: Linux CPU x86
 
 on:
   pull_request:
@@ -41,7 +41,7 @@ jobs:
     needs: generate-matrix
     strategy:
       fail-fast: false
-    name: Build and Upload Linux wheel
+    name: Build and Upload wheel
     uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
     with:
       repository: meta-pytorch/torchcodec

--- a/.github/workflows/macos_wheel.yaml
+++ b/.github/workflows/macos_wheel.yaml
@@ -1,4 +1,4 @@
-name: Build and test MacOS wheel
+name: MacOS
 
 on:
   pull_request:
@@ -41,7 +41,7 @@ jobs:
     needs: generate-matrix
     strategy:
       fail-fast: false
-    name: Build and Upload Mac wheel
+    name: Build and Upload wheel
     uses: pytorch/test-infra/.github/workflows/build_wheels_macos.yml@main
     with:
       repository: meta-pytorch/torchcodec

--- a/.github/workflows/windows_wheel.yaml
+++ b/.github/workflows/windows_wheel.yaml
@@ -1,4 +1,4 @@
-name: Build and test Windows wheel
+name: Windows CPU
 
 on:
   pull_request:
@@ -43,7 +43,7 @@ jobs:
     needs: generate-matrix
     strategy:
       fail-fast: false
-    name: Build and Upload Windows wheel
+    name: Build and Upload wheel
     uses: pytorch/test-infra/.github/workflows/build_wheels_windows.yml@main
     with:
       repository: meta-pytorch/torchcodec


### PR DESCRIPTION
Small QoL to simplify CI job names, which are currently unnecessarily long and verbose.