### PR TITLE
Upload CPU wheel to XPU channel

### DIFF
--- a/.github/workflows/linux_wheel.yaml
+++ b/.github/workflows/linux_wheel.yaml
@@ -56,6 +56,7 @@ jobs:
       trigger-event: ${{ github.event_name }}
       build-platform: "python-build-package"
       build-command: "BUILD_AGAINST_ALL_FFMPEG_FROM_S3=1 python -m build --wheel -vvv --no-isolation"
+      also-upload-to-gpu-arch-versions: "xpu"
 
   install-and-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Should work after https://github.com/pytorch/test-infra/pull/8073.

This is an alternative to https://github.com/meta-pytorch/torchcodec/pull/1357 that I prefer because it keeps the logic within `test-infra` rather than in TC, which should make our lives easier for releases.


Closes https://github.com/meta-pytorch/torchcodec/pull/1357
Closes https://github.com/meta-pytorch/torchcodec/issues/1376


