### PR TITLE
Add basic Python API for streaming encoder

### DIFF
--- a/src/torchcodec/encoders/_multi_stream_encoder.py
+++ b/src/torchcodec/encoders/_multi_stream_encoder.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 from typing import Any
 
-import torch
 from torch import Tensor
 
 from torchcodec import _core
@@ -12,12 +11,6 @@ class _VideoStream:
         self._encoder_tensor = encoder_tensor
 
     def write(self, frames: Tensor) -> None:
-        if frames.ndim == 3:
-            frames = frames.unsqueeze(0)
-        if frames.ndim != 4:
-            raise ValueError(f"Expected 3D or 4D frames, got {frames.shape = }.")
-        if frames.dtype != torch.uint8:
-            raise ValueError(f"Expected uint8 frames, got {frames.dtype = }.")
         _core.streaming_encoder_add_frames(self._encoder_tensor, frames)
 
 
@@ -26,20 +19,12 @@ class _AudioStream:
         self._encoder_tensor = encoder_tensor
 
     def write(self, samples: Tensor) -> None:
-        if samples.ndim == 1:
-            samples = samples.unsqueeze(0)
-        if samples.ndim != 2:
-            raise ValueError(f"Expected 1D or 2D samples, got {samples.shape = }.")
-        if samples.dtype != torch.float32:
-            raise ValueError(f"Expected float32 samples, got {samples.dtype = }.")
         _core.streaming_encoder_add_samples(self._encoder_tensor, samples)
 
 
 class StreamingEncoder:
     def __init__(self, dest: str | Path):
         self._encoder_tensor = _core.create_streaming_encoder_to_file(str(dest))
-        self._opened = False
-        self._closed = False
 
     def add_video(
         self,
@@ -54,8 +39,6 @@ class StreamingEncoder:
         preset: str | int | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> _VideoStream:
-        if self._opened:
-            raise RuntimeError("Cannot add streams after open() has been called.")
         preset = str(preset) if isinstance(preset, int) else preset
         _core.streaming_encoder_add_video_stream(
             self._encoder_tensor,
@@ -80,8 +63,6 @@ class StreamingEncoder:
         num_channels: int,
         bit_rate: int | None = None,
     ) -> _AudioStream:
-        if self._opened:
-            raise RuntimeError("Cannot add streams after open() has been called.")
         _core.streaming_encoder_add_audio_stream(
             self._encoder_tensor,
             sample_rate=sample_rate,
@@ -91,13 +72,7 @@ class StreamingEncoder:
         return _AudioStream(self._encoder_tensor)
 
     def open(self) -> None:
-        if self._opened:
-            raise RuntimeError("Encoder is already open.")
-        self._opened = True
         _core.streaming_encoder_open(self._encoder_tensor)
 
     def close(self) -> None:
-        if self._closed:
-            return
-        self._closed = True
         _core.streaming_encoder_close(self._encoder_tensor)

--- a/src/torchcodec/encoders/_multi_stream_encoder.py
+++ b/src/torchcodec/encoders/_multi_stream_encoder.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from typing import Any
 
 from torch import Tensor
@@ -23,8 +22,13 @@ class _AudioStream:
 
 
 class StreamingEncoder:
-    def __init__(self, dest: str | Path):
-        self._encoder_tensor = _core.create_streaming_encoder_to_file(str(dest))
+    def __init__(self, dest, *, format: str | None = None):
+        if format is not None:
+            self._encoder_tensor = _core.create_streaming_encoder_to_file_like(
+                format, dest
+            )
+        else:
+            self._encoder_tensor = _core.create_streaming_encoder_to_file(str(dest))
 
     def add_video(
         self,

--- a/src/torchcodec/encoders/_multi_stream_encoder.py
+++ b/src/torchcodec/encoders/_multi_stream_encoder.py
@@ -1,0 +1,103 @@
+from pathlib import Path
+from typing import Any
+
+import torch
+from torch import Tensor
+
+from torchcodec import _core
+
+
+class _VideoStream:
+    def __init__(self, encoder_tensor: Tensor):
+        self._encoder_tensor = encoder_tensor
+
+    def write(self, frames: Tensor) -> None:
+        if frames.ndim == 3:
+            frames = frames.unsqueeze(0)
+        if frames.ndim != 4:
+            raise ValueError(f"Expected 3D or 4D frames, got {frames.shape = }.")
+        if frames.dtype != torch.uint8:
+            raise ValueError(f"Expected uint8 frames, got {frames.dtype = }.")
+        _core.streaming_encoder_add_frames(self._encoder_tensor, frames)
+
+
+class _AudioStream:
+    def __init__(self, encoder_tensor: Tensor):
+        self._encoder_tensor = encoder_tensor
+
+    def write(self, samples: Tensor) -> None:
+        if samples.ndim == 1:
+            samples = samples.unsqueeze(0)
+        if samples.ndim != 2:
+            raise ValueError(f"Expected 1D or 2D samples, got {samples.shape = }.")
+        if samples.dtype != torch.float32:
+            raise ValueError(f"Expected float32 samples, got {samples.dtype = }.")
+        _core.streaming_encoder_add_samples(self._encoder_tensor, samples)
+
+
+class StreamingEncoder:
+    def __init__(self, dest: str | Path):
+        self._encoder_tensor = _core.create_streaming_encoder_to_file(str(dest))
+        self._opened = False
+        self._closed = False
+
+    def add_video(
+        self,
+        *,
+        height: int,
+        width: int,
+        frame_rate: float,
+        device: str = "cpu",
+        codec: str | None = None,
+        pixel_format: str | None = None,
+        crf: int | float | None = None,
+        preset: str | int | None = None,
+        extra_options: dict[str, Any] | None = None,
+    ) -> _VideoStream:
+        if self._opened:
+            raise RuntimeError("Cannot add streams after open() has been called.")
+        preset = str(preset) if isinstance(preset, int) else preset
+        _core.streaming_encoder_add_video_stream(
+            self._encoder_tensor,
+            height=height,
+            width=width,
+            frame_rate=frame_rate,
+            device=device,
+            codec=codec,
+            pixel_format=pixel_format,
+            crf=crf,
+            preset=preset,
+            extra_options=[
+                str(x) for k, v in (extra_options or {}).items() for x in (k, v)
+            ],
+        )
+        return _VideoStream(self._encoder_tensor)
+
+    def add_audio(
+        self,
+        *,
+        sample_rate: int,
+        num_channels: int,
+        bit_rate: int | None = None,
+    ) -> _AudioStream:
+        if self._opened:
+            raise RuntimeError("Cannot add streams after open() has been called.")
+        _core.streaming_encoder_add_audio_stream(
+            self._encoder_tensor,
+            sample_rate=sample_rate,
+            num_channels=num_channels,
+            bit_rate=bit_rate,
+        )
+        return _AudioStream(self._encoder_tensor)
+
+    def open(self) -> None:
+        if self._opened:
+            raise RuntimeError("Encoder is already open.")
+        self._opened = True
+        _core.streaming_encoder_open(self._encoder_tensor)
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        _core.streaming_encoder_close(self._encoder_tensor)

--- a/test/test_encoders.py
+++ b/test/test_encoders.py
@@ -14,6 +14,7 @@ from torchcodec import ffmpeg_major_version
 from torchcodec.decoders import AudioDecoder, VideoDecoder
 
 from torchcodec.encoders import AudioEncoder, VideoEncoder
+from torchcodec.encoders._multi_stream_encoder import StreamingEncoder
 
 from .utils import (
     assert_tensor_close_on_at_least,
@@ -22,6 +23,8 @@ from .utils import (
     IN_GITHUB_CI,
     IS_WINDOWS,
     NASA_AUDIO_MP3,
+    NASA_AUDIO_MP3_44100,
+    NASA_VIDEO,
     needs_ffmpeg_cli,
     psnr,
     SINE_MONO_S32,
@@ -1560,3 +1563,342 @@ class TestVideoEncoder:
             torch.testing.assert_close(
                 truncated_frame.data, reference_frames[i].data, atol=0, rtol=0
             )
+
+
+class TestStreamingEncoder:
+    def test_double_close(self, tmp_path):
+        enc = StreamingEncoder(tmp_path / "test.mp4")
+        enc.close()
+        enc.close()  # double close is a no-op
+
+    @pytest.mark.parametrize("format", ["mp4", "mov", "mkv"])
+    @pytest.mark.parametrize(
+        "device",
+        (
+            "cpu",
+            pytest.param(
+                "cuda",
+                marks=[
+                    pytest.mark.needs_cuda,
+                    pytest.mark.skipif(
+                        in_fbcode(), reason="NVENC not available in fbcode"
+                    ),
+                ],
+            ),
+        ),
+    )
+    def test_add_video_and_encode_frames(self, tmp_path, format, device):
+        source_decoder = VideoDecoder(str(TEST_SRC_2_720P.path))
+        source_frames = source_decoder.get_frames_in_range(start=0, stop=10).data.to(
+            device
+        )
+        frame_rate = source_decoder.metadata.average_fps
+        percentage, atol = (96, 2) if device == "cuda" else (99, 2)
+
+        output_path = tmp_path / f"test.{format}"
+        enc = StreamingEncoder(output_path)
+        add_video_kwargs = {
+            "height": source_frames.shape[2],
+            "width": source_frames.shape[3],
+            "frame_rate": frame_rate,
+            "device": device,
+        }
+        if device == "cpu":
+            add_video_kwargs["pixel_format"] = "yuv444p"
+            add_video_kwargs["crf"] = 0
+        else:
+            add_video_kwargs["extra_options"] = {"qp": "1"}
+        video = enc.add_video(**add_video_kwargs)
+        enc.open()
+        video.write(source_frames[:5])
+        video.write(source_frames[5:])
+        enc.close()
+
+        decoded_frames = (
+            VideoDecoder(str(output_path)).get_frames_in_range(start=0, stop=10).data
+        )
+        assert_tensor_close_on_at_least(
+            decoded_frames, source_frames.cpu(), percentage=percentage, atol=atol
+        )
+
+    def test_create_invalid_path(self):
+        with pytest.raises(RuntimeError, match="make sure it's a valid path"):
+            StreamingEncoder("/nonexistent/dir/test.mp4")
+
+    def test_create_invalid_format(self, tmp_path):
+        with pytest.raises(RuntimeError, match="check the desired extension"):
+            StreamingEncoder(tmp_path / "test.bad_extension")
+
+    @pytest.mark.parametrize("format", ["mp4", "mov"])
+    @pytest.mark.parametrize(
+        "device",
+        (
+            "cpu",
+            pytest.param(
+                "cuda",
+                marks=[
+                    pytest.mark.needs_cuda,
+                    pytest.mark.skipif(
+                        in_fbcode(), reason="NVENC not available in fbcode"
+                    ),
+                ],
+            ),
+        ),
+    )
+    def test_fragmented_mp4(self, format, tmp_path, device):
+        source_decoder = VideoDecoder(str(TEST_SRC_2_720P.path))
+        source_frames = source_decoder.get_frames_in_range(start=0, stop=10).data.to(
+            device
+        )
+        frame_rate = source_decoder.metadata.average_fps
+        percentage, atol = (96, 2) if device == "cuda" else (99, 2)
+
+        output_path = tmp_path / f"test.{format}"
+        enc = StreamingEncoder(output_path)
+        extra_options = {
+            "movflags": "+frag_every_frame+empty_moov",
+            "flush_packets": "1",
+            "threads": "1",
+        }
+        if device == "cuda":
+            extra_options.update({"qp": "1", "delay": "0"})
+            pixel_format, crf = None, None
+        else:
+            extra_options["tune"] = "zerolatency"
+            pixel_format, crf = "yuv444p", 0
+        video = enc.add_video(
+            height=source_frames.shape[2],
+            width=source_frames.shape[3],
+            frame_rate=frame_rate,
+            device=device,
+            pixel_format=pixel_format,
+            crf=crf,
+            extra_options=extra_options,
+        )
+        enc.open()
+        for batch in [source_frames[:5], source_frames[5:]]:
+            video.write(batch)
+            mid_decoder = VideoDecoder(str(output_path))
+            num_available = len(mid_decoder)
+            assert num_available > 0
+            assert_tensor_close_on_at_least(
+                mid_decoder.get_frames_in_range(start=0, stop=num_available).data,
+                source_frames[:num_available].cpu(),
+                percentage=percentage,
+                atol=atol,
+            )
+
+        enc.close()
+        assert_tensor_close_on_at_least(
+            VideoDecoder(str(output_path)).get_frames_in_range(start=0, stop=10).data,
+            source_frames.cpu(),
+            percentage=percentage,
+            atol=atol,
+        )
+
+    def test_add_video_twice_errors(self, tmp_path):
+        enc = StreamingEncoder(tmp_path / "test.mp4")
+        enc.add_video(height=64, width=64, frame_rate=30.0)
+        with pytest.raises(RuntimeError, match="already been added"):
+            enc.add_video(height=64, width=64, frame_rate=24.0)
+
+    def test_add_audio_twice_errors(self, tmp_path):
+        enc = StreamingEncoder(tmp_path / "test.mp4")
+        enc.add_audio(sample_rate=44100, num_channels=2)
+        with pytest.raises(RuntimeError, match="already been added"):
+            enc.add_audio(sample_rate=16000, num_channels=1)
+
+    @pytest.mark.parametrize(
+        "device",
+        (
+            "cpu",
+            pytest.param(
+                "cuda",
+                marks=[
+                    pytest.mark.needs_cuda,
+                    pytest.mark.skipif(
+                        in_fbcode(), reason="NVENC not available in fbcode"
+                    ),
+                ],
+            ),
+        ),
+    )
+    def test_write_frames_mismatched_dimensions_errors(self, tmp_path, device):
+        enc = StreamingEncoder(tmp_path / "test.mp4")
+        video = enc.add_video(height=256, width=256, frame_rate=30.0, device=device)
+        enc.open()
+        frames_128 = torch.randint(
+            0, 256, (2, 3, 128, 128), dtype=torch.uint8, device=device
+        )
+        with pytest.raises(RuntimeError, match="same dimensions"):
+            video.write(frames_128)
+        frames_256 = torch.randint(
+            0, 256, (2, 3, 256, 256), dtype=torch.uint8, device=device
+        )
+        frames_512 = torch.randint(
+            0, 256, (2, 3, 512, 512), dtype=torch.uint8, device=device
+        )
+        video.write(frames_256)
+        with pytest.raises(RuntimeError, match="same dimensions"):
+            video.write(frames_512)
+
+    @pytest.mark.needs_cuda
+    def test_write_frames_different_devices_errors(self, tmp_path):
+        enc = StreamingEncoder(tmp_path / "test.mp4")
+        video = enc.add_video(height=64, width=64, frame_rate=30.0)
+        enc.open()
+        cpu_frames = torch.randint(0, 256, (2, 3, 64, 64), dtype=torch.uint8)
+        cuda_frames = cpu_frames.to("cuda")
+        video.write(cpu_frames)
+        with pytest.raises(RuntimeError, match="same device"):
+            video.write(cuda_frames)
+
+    @pytest.mark.needs_cuda
+    def test_write_samples_on_cuda_errors(self, tmp_path):
+        enc = StreamingEncoder(tmp_path / "test.wav")
+        audio = enc.add_audio(sample_rate=44100, num_channels=1)
+        enc.open()
+        cuda_samples = torch.randn(1, 1000, device="cuda")
+        with pytest.raises(RuntimeError, match="samples must be on CPU, got cuda"):
+            audio.write(cuda_samples)
+
+    @pytest.mark.parametrize(
+        "device", ("cpu", pytest.param("cuda", marks=pytest.mark.needs_cuda))
+    )
+    def test_write_frames_without_open_errors(self, tmp_path, device):
+        enc = StreamingEncoder(tmp_path / "test.mp4")
+        video = enc.add_video(height=64, width=64, frame_rate=30.0, device=device)
+        frames = torch.randint(0, 256, (5, 3, 64, 64), dtype=torch.uint8, device=device)
+        with pytest.raises(
+            RuntimeError, match="Call open\\(\\) before addFrames\\(\\)"
+        ):
+            video.write(frames)
+
+    def test_write_samples_without_open_errors(self, tmp_path):
+        enc = StreamingEncoder(tmp_path / "test.mp4")
+        audio = enc.add_audio(sample_rate=44100, num_channels=1)
+        samples = torch.randn(1, 1000)
+        with pytest.raises(
+            RuntimeError, match="Call open\\(\\) before addSamples\\(\\)"
+        ):
+            audio.write(samples)
+
+    def test_write_samples_mismatched_channels_errors(self, tmp_path):
+        enc = StreamingEncoder(tmp_path / "test.wav")
+        audio = enc.add_audio(sample_rate=44100, num_channels=1)
+        enc.open()
+        samples = torch.randn(2, 1000)  # 2 channels but stream expects 1
+        with pytest.raises(RuntimeError, match="Expected 1 channels, got 2"):
+            audio.write(samples)
+
+    def test_open_without_stream_errors(self, tmp_path):
+        enc = StreamingEncoder(tmp_path / "test.mp4")
+        with pytest.raises(
+            RuntimeError,
+            match="Call addVideoStream\\(\\) or addAudioStream\\(\\) before open\\(\\)",
+        ):
+            enc.open()
+
+    def test_open_twice_errors(self, tmp_path):
+        enc = StreamingEncoder(tmp_path / "test.mp4")
+        enc.add_video(height=64, width=64, frame_rate=30.0)
+        enc.open()
+        with pytest.raises(RuntimeError, match="Encoder is already open"):
+            enc.open()
+
+    def test_add_audio_invalid_bit_rate_errors(self, tmp_path):
+        enc = StreamingEncoder(tmp_path / "test.mp4")
+        enc.add_audio(sample_rate=44100, num_channels=2, bit_rate=-1)
+        with pytest.raises(RuntimeError, match="bit_rate=-1 must be >= 0"):
+            enc.open()
+
+    def test_add_audio_and_encode_samples(self, tmp_path):
+        source_audio = AudioDecoder(str(SINE_MONO_S32.path)).get_all_samples()
+        samples = source_audio.data
+        sample_rate = source_audio.sample_rate
+        num_channels = samples.shape[0]
+
+        output_path = tmp_path / "test.wav"
+        enc = StreamingEncoder(output_path)
+        audio = enc.add_audio(sample_rate=sample_rate, num_channels=num_channels)
+        enc.open()
+        chunk_lengths = [1, 50, 1000, 0, 25]
+        offset = 0
+        for length in chunk_lengths:
+            audio.write(samples[:, offset : offset + length])
+            offset += length
+        audio.write(samples[:, offset:])
+        enc.close()
+
+        decoded = AudioDecoder(str(output_path)).get_all_samples()
+        assert decoded.data.shape[0] == num_channels
+        assert decoded.sample_rate == sample_rate
+        torch.testing.assert_close(decoded.data, samples, atol=1e-4, rtol=0)
+
+    @pytest.mark.parametrize(
+        "format",
+        (
+            "mp4",
+            pytest.param(
+                "mkv",
+                marks=pytest.mark.skipif(
+                    ffmpeg_major_version < 6,
+                    reason="Default audio codec for MKV has low accuracy on older FFmpeg versions.",
+                ),
+            ),
+            "mov",
+        ),
+    )
+    def test_add_audio_and_video_and_encode(self, tmp_path, format):
+        source_video_decoder = VideoDecoder(str(NASA_VIDEO.path))
+        source_frames = source_video_decoder.get_frames_in_range(
+            start=0, stop=len(source_video_decoder)
+        ).data
+
+        source_audio = AudioDecoder(str(NASA_AUDIO_MP3_44100.path)).get_all_samples()
+        source_samples = source_audio.data
+        sample_rate = source_audio.sample_rate
+
+        output_path = tmp_path / f"test.{format}"
+        enc = StreamingEncoder(output_path)
+        video = enc.add_video(
+            height=source_frames.shape[2],
+            width=source_frames.shape[3],
+            frame_rate=source_video_decoder.metadata.average_fps,
+            pixel_format="yuv444p",
+            crf=0,
+        )
+        audio = enc.add_audio(
+            sample_rate=sample_rate,
+            num_channels=source_samples.shape[0],
+        )
+        enc.open()
+        half_frames = source_frames.shape[0] // 2
+        half_samples = source_samples.shape[1] // 2
+        video.write(source_frames[:half_frames])
+        audio.write(source_samples[:, :half_samples])
+        video.write(source_frames[half_frames:])
+        audio.write(source_samples[:, half_samples:])
+        enc.close()
+
+        decoded_video_decoder = VideoDecoder(str(output_path))
+        decoded_frames = decoded_video_decoder.get_frames_in_range(
+            start=0, stop=len(decoded_video_decoder)
+        ).data
+        assert_tensor_close_on_at_least(
+            decoded_frames, source_frames, percentage=99, atol=2
+        )
+
+        audio_decoder = AudioDecoder(str(output_path))
+        decoded_audio = audio_decoder.get_all_samples()
+        assert decoded_audio.sample_rate == sample_rate
+        assert decoded_audio.data.shape[0] == source_samples.shape[0]
+        num_samples_to_compare = min(
+            decoded_audio.data.shape[1], source_samples.shape[1]
+        )
+        assert_tensor_close_on_at_least(
+            decoded_audio.data[:, :num_samples_to_compare],
+            source_samples[:, :num_samples_to_compare],
+            percentage=96 if format == "mkv" else 99,
+            atol=0.1 if format == "mkv" else 0.01,
+        )

--- a/test/test_encoders.py
+++ b/test/test_encoders.py
@@ -1566,12 +1566,31 @@ class TestVideoEncoder:
 
 
 class TestStreamingEncoder:
-    def test_double_close(self, tmp_path):
-        enc = StreamingEncoder(tmp_path / "test.mp4")
+    @staticmethod
+    def _create_encoder(method, tmp_path, format):
+        if method == "to_file":
+            encoder_output = tmp_path / f"test.{format}"
+            return StreamingEncoder(encoder_output), encoder_output
+        elif method == "to_file_like":
+            encoder_output = io.BytesIO()
+            return StreamingEncoder(encoder_output, format=format), encoder_output
+        else:
+            raise ValueError(f"Unknown method: {method}")
+
+    @staticmethod
+    def _get_decoder_source(encoder_output):
+        if isinstance(encoder_output, io.BytesIO):
+            return encoder_output.getvalue()
+        return str(encoder_output)
+
+    @pytest.mark.parametrize("method", ("to_file", "to_file_like"))
+    def test_double_close(self, tmp_path, method):
+        enc, _ = self._create_encoder(method, tmp_path, "mp4")
         enc.close()
         enc.close()  # double close is a no-op
 
     @pytest.mark.parametrize("format", ["mp4", "mov", "mkv"])
+    @pytest.mark.parametrize("method", ("to_file", "to_file_like"))
     @pytest.mark.parametrize(
         "device",
         (
@@ -1587,7 +1606,7 @@ class TestStreamingEncoder:
             ),
         ),
     )
-    def test_add_video_and_encode_frames(self, tmp_path, format, device):
+    def test_add_video_and_encode_frames(self, tmp_path, format, method, device):
         source_decoder = VideoDecoder(str(TEST_SRC_2_720P.path))
         source_frames = source_decoder.get_frames_in_range(start=0, stop=10).data.to(
             device
@@ -1595,8 +1614,7 @@ class TestStreamingEncoder:
         frame_rate = source_decoder.metadata.average_fps
         percentage, atol = (96, 2) if device == "cuda" else (99, 2)
 
-        output_path = tmp_path / f"test.{format}"
-        enc = StreamingEncoder(output_path)
+        enc, encoder_output = self._create_encoder(method, tmp_path, format)
         add_video_kwargs = {
             "height": source_frames.shape[2],
             "width": source_frames.shape[3],
@@ -1615,7 +1633,9 @@ class TestStreamingEncoder:
         enc.close()
 
         decoded_frames = (
-            VideoDecoder(str(output_path)).get_frames_in_range(start=0, stop=10).data
+            VideoDecoder(self._get_decoder_source(encoder_output))
+            .get_frames_in_range(start=0, stop=10)
+            .data
         )
         assert_tensor_close_on_at_least(
             decoded_frames, source_frames.cpu(), percentage=percentage, atol=atol
@@ -1625,11 +1645,20 @@ class TestStreamingEncoder:
         with pytest.raises(RuntimeError, match="make sure it's a valid path"):
             StreamingEncoder("/nonexistent/dir/test.mp4")
 
-    def test_create_invalid_format(self, tmp_path):
-        with pytest.raises(RuntimeError, match="check the desired extension"):
-            StreamingEncoder(tmp_path / "test.bad_extension")
+    @pytest.mark.parametrize("method", ("to_file", "to_file_like"))
+    def test_create_invalid_format(self, tmp_path, method):
+        if method == "to_file":
+            with pytest.raises(RuntimeError, match="check the desired extension"):
+                StreamingEncoder(tmp_path / "test.bad_extension")
+        elif method == "to_file_like":
+            with pytest.raises(
+                RuntimeError,
+                match=r"Check the desired format\? Got format=bad_extension",
+            ):
+                StreamingEncoder(io.BytesIO(), format="bad_extension")
 
     @pytest.mark.parametrize("format", ["mp4", "mov"])
+    @pytest.mark.parametrize("method", ("to_file", "to_file_like"))
     @pytest.mark.parametrize(
         "device",
         (
@@ -1645,7 +1674,7 @@ class TestStreamingEncoder:
             ),
         ),
     )
-    def test_fragmented_mp4(self, format, tmp_path, device):
+    def test_fragmented_mp4(self, format, tmp_path, method, device):
         source_decoder = VideoDecoder(str(TEST_SRC_2_720P.path))
         source_frames = source_decoder.get_frames_in_range(start=0, stop=10).data.to(
             device
@@ -1653,8 +1682,12 @@ class TestStreamingEncoder:
         frame_rate = source_decoder.metadata.average_fps
         percentage, atol = (96, 2) if device == "cuda" else (99, 2)
 
-        output_path = tmp_path / f"test.{format}"
-        enc = StreamingEncoder(output_path)
+        enc, encoder_output = self._create_encoder(method, tmp_path, format)
+        # In addition to the fragmentation flag, "flush_packets" and "threads"
+        # are necessary to decode frames before close().
+        # See frag flags: https://ffmpeg.org/ffmpeg-formats.html#Fragmentation
+        # TODO MultiStreamEncoder: Get a better understanding of which options
+        # are necessary for reading fragmented mp4s
         extra_options = {
             "movflags": "+frag_every_frame+empty_moov",
             "flush_packets": "1",
@@ -1676,9 +1709,10 @@ class TestStreamingEncoder:
             extra_options=extra_options,
         )
         enc.open()
+        # Here, we decode the available fragmented mp4 frames before calling close()
         for batch in [source_frames[:5], source_frames[5:]]:
             video.write(batch)
-            mid_decoder = VideoDecoder(str(output_path))
+            mid_decoder = VideoDecoder(self._get_decoder_source(encoder_output))
             num_available = len(mid_decoder)
             assert num_available > 0
             assert_tensor_close_on_at_least(
@@ -1689,25 +1723,31 @@ class TestStreamingEncoder:
             )
 
         enc.close()
+        # After close, all frames must be decodable
         assert_tensor_close_on_at_least(
-            VideoDecoder(str(output_path)).get_frames_in_range(start=0, stop=10).data,
+            VideoDecoder(self._get_decoder_source(encoder_output))
+            .get_frames_in_range(start=0, stop=10)
+            .data,
             source_frames.cpu(),
             percentage=percentage,
             atol=atol,
         )
 
-    def test_add_video_twice_errors(self, tmp_path):
-        enc = StreamingEncoder(tmp_path / "test.mp4")
+    @pytest.mark.parametrize("method", ("to_file", "to_file_like"))
+    def test_add_video_twice_errors(self, tmp_path, method):
+        enc, _ = self._create_encoder(method, tmp_path, "mp4")
         enc.add_video(height=64, width=64, frame_rate=30.0)
         with pytest.raises(RuntimeError, match="already been added"):
             enc.add_video(height=64, width=64, frame_rate=24.0)
 
-    def test_add_audio_twice_errors(self, tmp_path):
-        enc = StreamingEncoder(tmp_path / "test.mp4")
+    @pytest.mark.parametrize("method", ("to_file", "to_file_like"))
+    def test_add_audio_twice_errors(self, tmp_path, method):
+        enc, _ = self._create_encoder(method, tmp_path, "mp4")
         enc.add_audio(sample_rate=44100, num_channels=2)
         with pytest.raises(RuntimeError, match="already been added"):
             enc.add_audio(sample_rate=16000, num_channels=1)
 
+    @pytest.mark.parametrize("method", ("to_file", "to_file_like"))
     @pytest.mark.parametrize(
         "device",
         (
@@ -1723,15 +1763,17 @@ class TestStreamingEncoder:
             ),
         ),
     )
-    def test_write_frames_mismatched_dimensions_errors(self, tmp_path, device):
-        enc = StreamingEncoder(tmp_path / "test.mp4")
+    def test_write_frames_mismatched_dimensions_errors(self, tmp_path, method, device):
+        enc, _ = self._create_encoder(method, tmp_path, "mp4")
         video = enc.add_video(height=256, width=256, frame_rate=30.0, device=device)
         enc.open()
+        # write with wrong size errors
         frames_128 = torch.randint(
             0, 256, (2, 3, 128, 128), dtype=torch.uint8, device=device
         )
         with pytest.raises(RuntimeError, match="same dimensions"):
             video.write(frames_128)
+        # write with different size than first also errors
         frames_256 = torch.randint(
             0, 256, (2, 3, 256, 256), dtype=torch.uint8, device=device
         )
@@ -1743,8 +1785,9 @@ class TestStreamingEncoder:
             video.write(frames_512)
 
     @pytest.mark.needs_cuda
-    def test_write_frames_different_devices_errors(self, tmp_path):
-        enc = StreamingEncoder(tmp_path / "test.mp4")
+    @pytest.mark.parametrize("method", ("to_file", "to_file_like"))
+    def test_write_frames_different_devices_errors(self, tmp_path, method):
+        enc, _ = self._create_encoder(method, tmp_path, "mp4")
         video = enc.add_video(height=64, width=64, frame_rate=30.0)
         enc.open()
         cpu_frames = torch.randint(0, 256, (2, 3, 64, 64), dtype=torch.uint8)
@@ -1754,19 +1797,21 @@ class TestStreamingEncoder:
             video.write(cuda_frames)
 
     @pytest.mark.needs_cuda
-    def test_write_samples_on_cuda_errors(self, tmp_path):
-        enc = StreamingEncoder(tmp_path / "test.wav")
+    @pytest.mark.parametrize("method", ("to_file", "to_file_like"))
+    def test_write_samples_on_cuda_errors(self, tmp_path, method):
+        enc, _ = self._create_encoder(method, tmp_path, "wav")
         audio = enc.add_audio(sample_rate=44100, num_channels=1)
         enc.open()
         cuda_samples = torch.randn(1, 1000, device="cuda")
         with pytest.raises(RuntimeError, match="samples must be on CPU, got cuda"):
             audio.write(cuda_samples)
 
+    @pytest.mark.parametrize("method", ("to_file", "to_file_like"))
     @pytest.mark.parametrize(
         "device", ("cpu", pytest.param("cuda", marks=pytest.mark.needs_cuda))
     )
-    def test_write_frames_without_open_errors(self, tmp_path, device):
-        enc = StreamingEncoder(tmp_path / "test.mp4")
+    def test_write_frames_without_open_errors(self, tmp_path, method, device):
+        enc, _ = self._create_encoder(method, tmp_path, "mp4")
         video = enc.add_video(height=64, width=64, frame_rate=30.0, device=device)
         frames = torch.randint(0, 256, (5, 3, 64, 64), dtype=torch.uint8, device=device)
         with pytest.raises(
@@ -1774,8 +1819,9 @@ class TestStreamingEncoder:
         ):
             video.write(frames)
 
-    def test_write_samples_without_open_errors(self, tmp_path):
-        enc = StreamingEncoder(tmp_path / "test.mp4")
+    @pytest.mark.parametrize("method", ("to_file", "to_file_like"))
+    def test_write_samples_without_open_errors(self, tmp_path, method):
+        enc, _ = self._create_encoder(method, tmp_path, "mp4")
         audio = enc.add_audio(sample_rate=44100, num_channels=1)
         samples = torch.randn(1, 1000)
         with pytest.raises(
@@ -1783,43 +1829,47 @@ class TestStreamingEncoder:
         ):
             audio.write(samples)
 
-    def test_write_samples_mismatched_channels_errors(self, tmp_path):
-        enc = StreamingEncoder(tmp_path / "test.wav")
+    @pytest.mark.parametrize("method", ("to_file", "to_file_like"))
+    def test_write_samples_mismatched_channels_errors(self, tmp_path, method):
+        enc, _ = self._create_encoder(method, tmp_path, "wav")
         audio = enc.add_audio(sample_rate=44100, num_channels=1)
         enc.open()
         samples = torch.randn(2, 1000)  # 2 channels but stream expects 1
         with pytest.raises(RuntimeError, match="Expected 1 channels, got 2"):
             audio.write(samples)
 
-    def test_open_without_stream_errors(self, tmp_path):
-        enc = StreamingEncoder(tmp_path / "test.mp4")
+    @pytest.mark.parametrize("method", ("to_file", "to_file_like"))
+    def test_open_without_stream_errors(self, tmp_path, method):
+        enc, _ = self._create_encoder(method, tmp_path, "mp4")
         with pytest.raises(
             RuntimeError,
             match="Call addVideoStream\\(\\) or addAudioStream\\(\\) before open\\(\\)",
         ):
             enc.open()
 
-    def test_open_twice_errors(self, tmp_path):
-        enc = StreamingEncoder(tmp_path / "test.mp4")
+    @pytest.mark.parametrize("method", ("to_file", "to_file_like"))
+    def test_open_twice_errors(self, tmp_path, method):
+        enc, _ = self._create_encoder(method, tmp_path, "mp4")
         enc.add_video(height=64, width=64, frame_rate=30.0)
         enc.open()
         with pytest.raises(RuntimeError, match="open\\(\\) was already called"):
             enc.open()
 
-    def test_add_audio_invalid_bit_rate_errors(self, tmp_path):
-        enc = StreamingEncoder(tmp_path / "test.mp4")
+    @pytest.mark.parametrize("method", ("to_file", "to_file_like"))
+    def test_add_audio_invalid_bit_rate_errors(self, tmp_path, method):
+        enc, _ = self._create_encoder(method, tmp_path, "mp4")
         enc.add_audio(sample_rate=44100, num_channels=2, bit_rate=-1)
         with pytest.raises(RuntimeError, match="bit_rate=-1 must be >= 0"):
             enc.open()
 
-    def test_add_audio_and_encode_samples(self, tmp_path):
+    @pytest.mark.parametrize("method", ("to_file", "to_file_like"))
+    def test_add_audio_and_encode_samples(self, tmp_path, method):
         source_audio = AudioDecoder(str(SINE_MONO_S32.path)).get_all_samples()
         samples = source_audio.data
         sample_rate = source_audio.sample_rate
         num_channels = samples.shape[0]
 
-        output_path = tmp_path / "test.wav"
-        enc = StreamingEncoder(output_path)
+        enc, encoder_output = self._create_encoder(method, tmp_path, "wav")
         audio = enc.add_audio(sample_rate=sample_rate, num_channels=num_channels)
         enc.open()
         chunk_lengths = [1, 50, 1000, 0, 25]
@@ -1830,7 +1880,9 @@ class TestStreamingEncoder:
         audio.write(samples[:, offset:])
         enc.close()
 
-        decoded = AudioDecoder(str(output_path)).get_all_samples()
+        decoded = AudioDecoder(
+            self._get_decoder_source(encoder_output)
+        ).get_all_samples()
         assert decoded.data.shape[0] == num_channels
         assert decoded.sample_rate == sample_rate
         torch.testing.assert_close(decoded.data, samples, atol=1e-4, rtol=0)
@@ -1849,7 +1901,8 @@ class TestStreamingEncoder:
             "mov",
         ),
     )
-    def test_add_audio_and_video_and_encode(self, tmp_path, format):
+    @pytest.mark.parametrize("method", ("to_file", "to_file_like"))
+    def test_add_audio_and_video_and_encode(self, tmp_path, format, method):
         source_video_decoder = VideoDecoder(str(NASA_VIDEO.path))
         source_frames = source_video_decoder.get_frames_in_range(
             start=0, stop=len(source_video_decoder)
@@ -1859,8 +1912,7 @@ class TestStreamingEncoder:
         source_samples = source_audio.data
         sample_rate = source_audio.sample_rate
 
-        output_path = tmp_path / f"test.{format}"
-        enc = StreamingEncoder(output_path)
+        enc, encoder_output = self._create_encoder(method, tmp_path, format)
         video = enc.add_video(
             height=source_frames.shape[2],
             width=source_frames.shape[3],
@@ -1881,7 +1933,9 @@ class TestStreamingEncoder:
         audio.write(source_samples[:, half_samples:])
         enc.close()
 
-        decoded_video_decoder = VideoDecoder(str(output_path))
+        source = self._get_decoder_source(encoder_output)
+
+        decoded_video_decoder = VideoDecoder(source)
         decoded_frames = decoded_video_decoder.get_frames_in_range(
             start=0, stop=len(decoded_video_decoder)
         ).data
@@ -1889,10 +1943,14 @@ class TestStreamingEncoder:
             decoded_frames, source_frames, percentage=99, atol=2
         )
 
-        audio_decoder = AudioDecoder(str(output_path))
+        audio_decoder = AudioDecoder(source)
         decoded_audio = audio_decoder.get_all_samples()
         assert decoded_audio.sample_rate == sample_rate
         assert decoded_audio.data.shape[0] == source_samples.shape[0]
+        # Codecs for lossy audio formats (not WAV or FLAC) can add padding which causes
+        # sample count to differ, so we only compare the smaller sample count.
+        # TODO MultiStreamEncoder: The previous AudioEncoder didn't need
+        # padding after introducing a FIFO. Investigate why this is needed.
         num_samples_to_compare = min(
             decoded_audio.data.shape[1], source_samples.shape[1]
         )

--- a/test/test_encoders.py
+++ b/test/test_encoders.py
@@ -1803,7 +1803,7 @@ class TestStreamingEncoder:
         enc = StreamingEncoder(tmp_path / "test.mp4")
         enc.add_video(height=64, width=64, frame_rate=30.0)
         enc.open()
-        with pytest.raises(RuntimeError, match="Encoder is already open"):
+        with pytest.raises(RuntimeError, match="open\\(\\) was already called"):
             enc.open()
 
     def test_add_audio_invalid_bit_rate_errors(self, tmp_path):

--- a/test/test_encoders.py
+++ b/test/test_encoders.py
@@ -1566,6 +1566,17 @@ class TestVideoEncoder:
 
 
 class TestStreamingEncoder:
+    cpu_and_oss_cuda = (
+        "cpu",
+        pytest.param(
+            "cuda",
+            marks=[
+                pytest.mark.needs_cuda,
+                pytest.mark.skipif(in_fbcode(), reason="NVENC not available in fbcode"),
+            ],
+        ),
+    )
+
     @staticmethod
     def _create_encoder(method, tmp_path, format):
         if method == "to_file":
@@ -1591,21 +1602,7 @@ class TestStreamingEncoder:
 
     @pytest.mark.parametrize("format", ["mp4", "mov", "mkv"])
     @pytest.mark.parametrize("method", ("to_file", "to_file_like"))
-    @pytest.mark.parametrize(
-        "device",
-        (
-            "cpu",
-            pytest.param(
-                "cuda",
-                marks=[
-                    pytest.mark.needs_cuda,
-                    pytest.mark.skipif(
-                        in_fbcode(), reason="NVENC not available in fbcode"
-                    ),
-                ],
-            ),
-        ),
-    )
+    @pytest.mark.parametrize("device", cpu_and_oss_cuda)
     def test_add_video_and_encode_frames(self, tmp_path, format, method, device):
         source_decoder = VideoDecoder(str(TEST_SRC_2_720P.path))
         source_frames = source_decoder.get_frames_in_range(start=0, stop=10).data.to(
@@ -1659,21 +1656,7 @@ class TestStreamingEncoder:
 
     @pytest.mark.parametrize("format", ["mp4", "mov"])
     @pytest.mark.parametrize("method", ("to_file", "to_file_like"))
-    @pytest.mark.parametrize(
-        "device",
-        (
-            "cpu",
-            pytest.param(
-                "cuda",
-                marks=[
-                    pytest.mark.needs_cuda,
-                    pytest.mark.skipif(
-                        in_fbcode(), reason="NVENC not available in fbcode"
-                    ),
-                ],
-            ),
-        ),
-    )
+    @pytest.mark.parametrize("device", cpu_and_oss_cuda)
     def test_fragmented_mp4(self, format, tmp_path, method, device):
         source_decoder = VideoDecoder(str(TEST_SRC_2_720P.path))
         source_frames = source_decoder.get_frames_in_range(start=0, stop=10).data.to(
@@ -1748,21 +1731,7 @@ class TestStreamingEncoder:
             enc.add_audio(sample_rate=16000, num_channels=1)
 
     @pytest.mark.parametrize("method", ("to_file", "to_file_like"))
-    @pytest.mark.parametrize(
-        "device",
-        (
-            "cpu",
-            pytest.param(
-                "cuda",
-                marks=[
-                    pytest.mark.needs_cuda,
-                    pytest.mark.skipif(
-                        in_fbcode(), reason="NVENC not available in fbcode"
-                    ),
-                ],
-            ),
-        ),
-    )
+    @pytest.mark.parametrize("device", cpu_and_oss_cuda)
     def test_write_frames_mismatched_dimensions_errors(self, tmp_path, method, device):
         enc, _ = self._create_encoder(method, tmp_path, "mp4")
         video = enc.add_video(height=256, width=256, frame_rate=30.0, device=device)


### PR DESCRIPTION
Shallow Python API following proposal 2 from https://github.com/meta-pytorch/torchcodec/issues/1206#issuecomment-4434542608.

Everything is still private.

This isn't the final public API, everything is subject to change. Particularly, I suspect we'll want to pass the destination in `open()` rather than in the encoder's constructor.

The main point of this PR is to re-write the tests with the Python API so they're easier to read and write, to accelerate future development. All tests from `test_ops.py` were ported. I'll remove them in a follow-up PR.