### PR TITLE
Attempt to fix flaky Windows json issue on tests

### DIFF
--- a/test/test_encoders.py
+++ b/test/test_encoders.py
@@ -79,7 +79,8 @@ def validate_frames_properties(*, actual: Path, expected: Path):
                     f"{f}",
                 ],
                 check=True,
-                capture_output=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
                 text=True,
             ).stdout
         )["frames"]
@@ -638,7 +639,8 @@ class TestVideoEncoder:
                 "default=noprint_wrappers=1",
                 str(file_path),
             ],
-            capture_output=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
             check=True,
             text=True,
         )
@@ -665,7 +667,8 @@ class TestVideoEncoder:
                 "json",
                 str(file_path),
             ],
-            capture_output=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
             check=True,
             text=True,
         )

--- a/test/utils.py
+++ b/test/utils.py
@@ -361,7 +361,8 @@ class TestContainerFile:
                 "json",
             ],
             check=True,
-            capture_output=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
             text=True,
         ).stdout
         return result


### PR DESCRIPTION
Attempt at fixing https://github.com/meta-pytorch/torchcodec/issues/1330

Claude says the errors are caused by interleaving stderr and stdout in the output of `ffprobe`, which causes the json to not be properly formatted. That sounds plausible. This PR disables stderr on our calls to ffprobe.  Let's get that in and monitor if we get more of those.