### PR TITLE
Fix transforms tests

### DIFF
--- a/src/torchcodec/transforms/_decoder_transforms.py
+++ b/src/torchcodec/transforms/_decoder_transforms.py
@@ -119,7 +119,7 @@ class Resize(DecoderTransform):
 
         assert isinstance(tv_resize, v2.Resize)
 
-        if tv_resize.interpolation is not v2.InterpolationMode.BILINEAR:
+        if tv_resize.interpolation not in (v2.InterpolationMode.BILINEAR, "bilinear"):
             raise ValueError(
                 "TorchVision Resize transform must use bilinear interpolation."
             )


### PR DESCRIPTION
Transforms tests are recently [failing](https://github.com/meta-pytorch/torchcodec/actions/runs/25862127984/job/75995944532) after pulling in the latest torchvision nightlies, which is due to a change of default (but not of semantics) that I made in TV with https://github.com/pytorch/vision/pull/9461
