### PR TITLE
Only run Cpp tests on ffmpeg7

### DIFF
--- a/.github/workflows/cpp_tests.yaml
+++ b/.github/workflows/cpp_tests.yaml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ffmpeg-version-for-tests: ['4.4.2', '5.1.2', '6.1.1', '7.0.1']
+        ffmpeg-version-for-tests: ['7.0.1']
     steps:
       - name: Check out repo
         uses: actions/checkout@v6


### PR DESCRIPTION
No point testing all FFmpeg versions for the Cpp tests which have very little coverage anyway.