### PR TITLE
Write ffprobe outpouts to a temp file

### DIFF
--- a/test/test_encoders.py
+++ b/test/test_encoders.py
@@ -1,5 +1,4 @@
 import io
-import json
 import os
 import platform
 import re
@@ -18,6 +17,7 @@ from torchcodec.encoders._multi_stream_encoder import StreamingEncoder
 
 from .utils import (
     assert_tensor_close_on_at_least,
+    call_ffprobe,
     get_ffmpeg_minor_version,
     in_fbcode,
     IN_GITHUB_CI,
@@ -65,27 +65,15 @@ def validate_frames_properties(*, actual: Path, expected: Path):
     show_entries = "frame=" + ",".join(required_props)
 
     frames_actual, frames_expected = (
-        json.loads(
-            subprocess.run(
-                [
-                    "ffprobe",
-                    "-v",
-                    "error",
-                    "-hide_banner",
-                    "-select_streams",
-                    "a:0",
-                    "-show_frames",
-                    "-show_entries",
-                    show_entries,
-                    "-of",
-                    "json",
-                    f"{f}",
-                ],
-                check=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.DEVNULL,
-                text=True,
-            ).stdout
+        call_ffprobe(
+            [
+                "-select_streams",
+                "a:0",
+                "-show_frames",
+                "-show_entries",
+                show_entries,
+                f"{f}",
+            ]
         )["frames"]
         for f in (actual, expected)
     )
@@ -657,25 +645,16 @@ class TestVideoEncoder:
 
     def _get_frames_info(self, file_path, fields):
         """Helper function to get frame info (pts, dts, etc.) using ffprobe."""
-        result = subprocess.run(
+        parsed = call_ffprobe(
             [
-                "ffprobe",
-                "-v",
-                "error",
                 "-select_streams",
                 "v:0",
                 "-show_entries",
                 f"frame={','.join(fields)}",
-                "-of",
-                "json",
                 str(file_path),
-            ],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
-            check=True,
-            text=True,
+            ]
         )
-        frames = json.loads(result.stdout)["frames"]
+        frames = parsed["frames"]
         assert all(field in frame for field in fields for frame in frames)
         return frames
 

--- a/test/utils.py
+++ b/test/utils.py
@@ -5,6 +5,7 @@ import pathlib
 import platform
 import subprocess
 import sys
+import tempfile
 from dataclasses import dataclass, field
 
 import numpy as np
@@ -18,6 +19,25 @@ from torchcodec.decoders._video_decoder import _read_custom_frame_mappings
 
 IS_WINDOWS = sys.platform in ("win32", "cygwin")
 IN_GITHUB_CI = bool(os.getenv("GITHUB_ACTIONS"))
+
+
+def call_ffprobe(args):
+    # We write ffprobe's output to a temp file instead of capturing via
+    # subprocess pipe, to avoid sporadic JSON truncation on Windows.
+    with tempfile.NamedTemporaryFile(mode="r", suffix=".json", delete=False) as f:
+        tmp_path = f.name
+    try:
+        with open(tmp_path, "w") as stdout_file:
+            subprocess.run(
+                ["ffprobe", "-v", "error", "-hide_banner"] + args + ["-of", "json"],
+                check=True,
+                stdout=stdout_file,
+                stderr=subprocess.DEVNULL,
+            )
+        with open(tmp_path) as f:
+            return json.loads(f.read())
+    finally:
+        os.unlink(tmp_path)
 
 
 # Decorator for skipping CUDA tests when CUDA isn't available. The tests are
@@ -349,23 +369,16 @@ class TestContainerFile:
         return self._custom_frame_mappings_data[stream_index]
 
     def generate_custom_frame_mappings(self, stream_index: int) -> str:
-        result = subprocess.run(
+        parsed = call_ffprobe(
             [
-                "ffprobe",
                 "-i",
                 f"{self.path}",
                 "-select_streams",
                 f"{stream_index}",
                 "-show_frames",
-                "-of",
-                "json",
             ],
-            check=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
-            text=True,
-        ).stdout
-        return result
+        )
+        return json.dumps(parsed)
 
     @property
     def empty_pts_seconds(self) -> torch.Tensor:


### PR DESCRIPTION
Follow-up to https://github.com/meta-pytorch/torchcodec/pull/1387 which wasn't enough. Still trying to address https://github.com/meta-pytorch/torchcodec/issues/1330