### PR TITLE
Use smoke tests for most jobs

### DIFF
--- a/.github/workflows/linux_aarch64_wheel.yaml
+++ b/.github/workflows/linux_aarch64_wheel.yaml
@@ -107,4 +107,8 @@ jobs:
 
       - name: Run Python tests
         run: |
-          pytest --override-ini="addopts=-v" test
+          if [[ "${{ matrix.ffmpeg-version-for-tests }}" == "7" ]]; then
+            pytest --override-ini="addopts=-v" test
+          else
+            pytest --override-ini="addopts=-v" test/smoke_test.py --tb=short
+          fi

--- a/.github/workflows/linux_aarch64_wheel.yaml
+++ b/.github/workflows/linux_aarch64_wheel.yaml
@@ -105,10 +105,11 @@ jobs:
       - name: Install test dependencies
         run: bash packaging/install_test_dependencies.sh
 
-      - name: Run Python tests
+      - name: Run Python smoke tests
         run: |
-          if [[ "${{ matrix.ffmpeg-version-for-tests }}" == "7" ]]; then
-            pytest --override-ini="addopts=-v" test
-          else
-            pytest --override-ini="addopts=-v" test/smoke_test.py --tb=short
-          fi
+          pytest --override-ini="addopts=-v" test/smoke_test.py --tb=short
+
+      - name: Run Python tests
+        if: ${{ matrix.ffmpeg-version-for-tests == '7' && !startsWith(github.ref, 'refs/heads/release/') }}
+        run: |
+          pytest --override-ini="addopts=-v" test

--- a/.github/workflows/linux_cuda_aarch64_wheel.yaml
+++ b/.github/workflows/linux_cuda_aarch64_wheel.yaml
@@ -111,10 +111,11 @@ jobs:
 
       - name: Install test dependencies
         run: bash packaging/install_test_dependencies.sh
-      - name: Run Python tests
+      - name: Run Python smoke tests
         run: |
-          if [[ "${{ matrix.ffmpeg-version-for-tests }}" == "8" ]]; then
-            pytest --override-ini="addopts=-v" test
-          else
-            pytest --override-ini="addopts=-v" test/smoke_test.py --tb=short
-          fi
+          pytest --override-ini="addopts=-v" test/smoke_test.py --tb=short
+
+      - name: Run Python tests
+        if: ${{ matrix.ffmpeg-version-for-tests == '8' && !startsWith(github.ref, 'refs/heads/release/') }}
+        run: |
+          pytest --override-ini="addopts=-v" test

--- a/.github/workflows/linux_cuda_aarch64_wheel.yaml
+++ b/.github/workflows/linux_cuda_aarch64_wheel.yaml
@@ -113,4 +113,8 @@ jobs:
         run: bash packaging/install_test_dependencies.sh
       - name: Run Python tests
         run: |
-          pytest --override-ini="addopts=-v" test
+          if [[ "${{ matrix.ffmpeg-version-for-tests }}" == "8" ]]; then
+            pytest --override-ini="addopts=-v" test
+          else
+            pytest --override-ini="addopts=-v" test/smoke_test.py --tb=short
+          fi

--- a/.github/workflows/macos_wheel.yaml
+++ b/.github/workflows/macos_wheel.yaml
@@ -108,4 +108,8 @@ jobs:
 
       - name: Run Python tests
         run: |
-          pytest --override-ini="addopts=-v" test
+          if [[ "${{ matrix.ffmpeg-version-for-tests }}" == "8" ]]; then
+            pytest --override-ini="addopts=-v" test
+          else
+            pytest --override-ini="addopts=-v" test/smoke_test.py --tb=short
+          fi

--- a/.github/workflows/macos_wheel.yaml
+++ b/.github/workflows/macos_wheel.yaml
@@ -106,10 +106,11 @@ jobs:
       - name: Install test dependencies
         run: bash packaging/install_test_dependencies.sh
 
-      - name: Run Python tests
+      - name: Run Python smoke tests
         run: |
-          if [[ "${{ matrix.ffmpeg-version-for-tests }}" == "8" ]]; then
-            pytest --override-ini="addopts=-v" test
-          else
-            pytest --override-ini="addopts=-v" test/smoke_test.py --tb=short
-          fi
+          pytest --override-ini="addopts=-v" test/smoke_test.py --tb=short
+
+      - name: Run Python tests
+        if: ${{ matrix.ffmpeg-version-for-tests == '8' && !startsWith(github.ref, 'refs/heads/release/') }}
+        run: |
+          pytest --override-ini="addopts=-v" test

--- a/.github/workflows/windows_wheel.yaml
+++ b/.github/workflows/windows_wheel.yaml
@@ -112,10 +112,11 @@ jobs:
       - name: Install test dependencies
         run: bash packaging/install_test_dependencies.sh
 
-      - name: Run Python tests
+      - name: Run Python smoke tests
         run: |
-          if [[ "${{ matrix.ffmpeg-version-for-tests }}" == "8" ]]; then
-            pytest --override-ini="addopts=-v" test
-          else
-            pytest --override-ini="addopts=-v" test/smoke_test.py --tb=short
-          fi
+          pytest --override-ini="addopts=-v" test/smoke_test.py --tb=short
+
+      - name: Run Python tests
+        if: ${{ matrix.ffmpeg-version-for-tests == '8' && !startsWith(github.ref, 'refs/heads/release/') }}
+        run: |
+          pytest --override-ini="addopts=-v" test

--- a/.github/workflows/windows_wheel.yaml
+++ b/.github/workflows/windows_wheel.yaml
@@ -113,4 +113,9 @@ jobs:
         run: bash packaging/install_test_dependencies.sh
 
       - name: Run Python tests
-        run: pytest --override-ini="addopts=-v" test
+        run: |
+          if [[ "${{ matrix.ffmpeg-version-for-tests }}" == "8" ]]; then
+            pytest --override-ini="addopts=-v" test
+          else
+            pytest --override-ini="addopts=-v" test/smoke_test.py --tb=short
+          fi


### PR DESCRIPTION
Use smoke tests instead of the whole test suite, for most jobs. We still typically keep one config running the whole test suite (e.g. FFMpeg 8 x CUDA 12.4) on PRs and on the `main` branch, but release branches will only run the smoke tests.

**The Linux x86 jobs are untouched and will keep running the whole test suite for *all* configurations on all branches**
The Windows CUDA jobs are also untouched and will always only run the smoke tests.