### PR TITLE
Add SPDX license expression to package metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ name = "torchcodec"
 description = "A video decoder for PyTorch"
 readme = "README.md"
 requires-python = ">=3.10"
+license = "BSD-3-Clause"
 license-files = ["LICENSE"]
 authors = [
     { name = "PyTorch Team", email = "packages@pytorch.org" },


### PR DESCRIPTION
This adds an explicit SPDX license expression to the package metadata.

The project already includes the LICENSE file via license-files, but without project.license some license-reporting tools may show less useful license metadata. BSD-3-Clause matches the repository license.