### PR TITLE
Fix eviction test interactions

### DIFF
--- a/test/test_decoders.py
+++ b/test/test_decoders.py
@@ -2143,6 +2143,10 @@ class TestVideoDecoder:
             del dec
             gc.collect()
 
+        # Evict any leftover cached decoders from previous tests
+        with self.restore_nvdec_cache_capacity():
+            set_nvdec_cache_capacity(0)
+
         with self.restore_nvdec_cache_capacity():
             assert _core._get_nvdec_cache_size(device_index=0) == 0
 


### PR DESCRIPTION
`test_nvdec_cache_capacity_eviction` starts by asserting that no decoder is currently cached:

```py
assert _core._get_nvdec_cache_size(device_index=0) == 0
```

but depending on test execution order, some decoders can definitely exist in the cache, sometimes causing this test to fail. This PR flushes the cache before this test to let it run 'from fresh' without influence from other tests.