### PR TITLE
Leak NVDECCache to avoid calling into CUDA during static destruction

### DIFF
--- a/src/torchcodec/_core/NVDECCache.cpp
+++ b/src/torchcodec/_core/NVDECCache.cpp
@@ -21,7 +21,9 @@ extern "C" {
 namespace facebook::torchcodec {
 
 NVDECCache* NVDECCache::getCacheInstances() {
-  static NVDECCache cacheInstances[MAX_CUDA_GPUS];
+  // Intentionally leaked to avoid calling into CUDA/NVCUVID during static
+  // destruction, when the CUDA runtime may already be torn down.
+  static NVDECCache* cacheInstances = new NVDECCache[MAX_CUDA_GPUS];
   return cacheInstances;
 }
 


### PR DESCRIPTION
Trying to address https://github.com/meta-pytorch/torchcodec/issues/1438

I can't reproduce https://github.com/meta-pytorch/torchcodec/issues/1438 directly, but hopefully this is a fix. `claude`'s analysis is that the `static` cache entries end up calling their `cuvidDestroyDecoder()` destructor at a point during process teardown where the  CUDA libraries have potentially already been torn down.

> The core issue is that shared library unload order at process exit is undefined. When the process is shutting down,
  the dynamic linker (ld.so) unloads .so files, and C++ runs static destructors within each library as it's unloaded.
  But there's no dependency graph — the linker doesn't know that our destructor needs to call into libnvcuvid.so, so it
   might unload libnvcuvid.so first, then unload our library and run our destructors, which now call into unmapped
  memory.

I don't understand process teardown enough to verify the quote - but wild stuff happen all the time, that I can believe.

The workaround is to heap-allocate the cache so its destructor never runs at exit, leaking all existing decoders in the cache, which the OS should reclaim anyway. `pytorch` itself has a habit of leaking lots of stuff, so this is probably OK in terms of practice.