### PR TITLE
HDR: address some TODOs

### DIFF
--- a/src/torchcodec/_core/BetaCudaDeviceInterface.cpp
+++ b/src/torchcodec/_core/BetaCudaDeviceInterface.cpp
@@ -72,6 +72,11 @@ static DecoderCapsCache& getDecoderCapsCache() {
   return cache;
 }
 
+cudaVideoSurfaceFormat getSurfaceFormat(OutputDtype outputDtype) {
+  return outputDtype == OutputDtype::FLOAT32 ? cudaVideoSurfaceFormat_P016
+                                             : cudaVideoSurfaceFormat_NV12;
+}
+
 static bool g_cuda_nvdec = registerDeviceInterface(
     DeviceInterfaceKey(kStableCUDA, /*variant=*/"default"),
     [](const StableDevice& device) {
@@ -506,7 +511,7 @@ BetaCudaDeviceInterface::~BetaCudaDeviceInterface() {
     flush();
     unmapPreviousFrame();
     NVDECCache::getCache(device_).returnDecoder(
-        &videoFormat_, outputSurfaceFormat_, std::move(decoder_));
+        &videoFormat_, getSurfaceFormat(outputDtype_), std::move(decoder_));
   }
 
   if (videoParser_) {
@@ -626,9 +631,7 @@ int BetaCudaDeviceInterface::streamPropertyChange(CUVIDEOFORMAT* videoFormat) {
 
   videoFormat_ = *videoFormat;
 
-  outputSurfaceFormat_ = outputDtype_ == OutputDtype::FLOAT32
-      ? cudaVideoSurfaceFormat_P016
-      : cudaVideoSurfaceFormat_NV12;
+  auto surfaceFormat = getSurfaceFormat(outputDtype_);
 
   if (videoFormat_.min_num_decode_surfaces == 0) {
     // Same as DALI's fallback
@@ -636,14 +639,14 @@ int BetaCudaDeviceInterface::streamPropertyChange(CUVIDEOFORMAT* videoFormat) {
   }
 
   if (!decoder_) {
-    decoder_ = NVDECCache::getCache(device_).getDecoder(
-        videoFormat, outputSurfaceFormat_);
+    decoder_ =
+        NVDECCache::getCache(device_).getDecoder(videoFormat, surfaceFormat);
 
     if (!decoder_) {
       // TODONVDEC P2: consider re-configuring an existing decoder instead of
       // re-creating one. See docs, see DALI. Re-configuration doesn't seem to
       // be enabled in DALI by default.
-      decoder_ = createDecoder(videoFormat, outputSurfaceFormat_);
+      decoder_ = createDecoder(videoFormat, surfaceFormat);
     }
 
     STD_TORCH_CHECK(decoder_, "Failed to get or create decoder");
@@ -1112,7 +1115,7 @@ void BetaCudaDeviceInterface::convertAVFrameToFrameOutput(
 
   auto convertFrame = [&](std::optional<torch::stable::Tensor> preAlloc)
       -> torch::stable::Tensor {
-    if (outputSurfaceFormat_ == cudaVideoSurfaceFormat_P016) {
+    if (outputDtype_ == OutputDtype::FLOAT32) {
       return convertP016FrameToRGB16(
           gpuFrame,
           device_,

--- a/src/torchcodec/_core/BetaCudaDeviceInterface.cpp
+++ b/src/torchcodec/_core/BetaCudaDeviceInterface.cpp
@@ -355,8 +355,7 @@ static torch::stable::Tensor convertP016FrameToRGB16(
     std::optional<torch::stable::Tensor> preAllocatedOutputTensor,
     const FrameDims& outputDims,
     int bitDepth,
-    AVColorSpace colorspace,
-    AVColorRange colorRange) {
+    const float colorMatrix[3][4]) {
   int height = avFrame->height;
   int width = avFrame->width;
   STD_TORCH_CHECK(
@@ -388,10 +387,6 @@ static torch::stable::Tensor convertP016FrameToRGB16(
 
   cudaStream_t stream = getCurrentCudaStream(device.index());
   syncStreams(/*runningStream=*/nvdecStream, /*waitingStream=*/stream);
-
-  float colorMatrix[3][4];
-  // TODO_HDR this needs to be cached.
-  computeP016ColorMatrix(colorspace, colorRange, bitDepth, colorMatrix);
 
   launchP016ToRGB16Kernel(
       reinterpret_cast<const uint16_t*>(avFrame->data[0]),
@@ -1116,15 +1111,28 @@ void BetaCudaDeviceInterface::convertAVFrameToFrameOutput(
   auto convertFrame = [&](std::optional<torch::stable::Tensor> preAlloc)
       -> torch::stable::Tensor {
     if (outputDtype_ == OutputDtype::FLOAT32) {
+      int bitDepth = static_cast<int>(videoFormat_.bit_depth_luma_minus8) + 8;
+      AVColorSpace colorspace = gpuFrame->colorspace;
+      AVColorRange colorRange = gpuFrame->color_range;
+      if (!cachedColorMatrix_.valid ||
+          cachedColorMatrix_.colorspace != colorspace ||
+          cachedColorMatrix_.colorRange != colorRange ||
+          cachedColorMatrix_.bitDepth != bitDepth) {
+        computeP016ColorMatrix(
+            colorspace, colorRange, bitDepth, cachedColorMatrix_.matrix);
+        cachedColorMatrix_.colorspace = colorspace;
+        cachedColorMatrix_.colorRange = colorRange;
+        cachedColorMatrix_.bitDepth = bitDepth;
+        cachedColorMatrix_.valid = true;
+      }
       return convertP016FrameToRGB16(
           gpuFrame,
           device_,
           nvdecStream,
           preAlloc,
           originalDims,
-          static_cast<int>(videoFormat_.bit_depth_luma_minus8) + 8,
-          gpuFrame->colorspace,
-          gpuFrame->color_range);
+          bitDepth,
+          cachedColorMatrix_.matrix);
     }
     return convertNV12FrameToRGB(
         gpuFrame, device_, nppCtx_, nvdecStream, preAlloc, originalDims);

--- a/src/torchcodec/_core/BetaCudaDeviceInterface.h
+++ b/src/torchcodec/_core/BetaCudaDeviceInterface.h
@@ -116,6 +116,16 @@ class BetaCudaDeviceInterface : public DeviceInterface {
   Rotation rotation_ = Rotation::NONE;
   OutputDtype outputDtype_ = OutputDtype::UINT8;
 
+  struct CachedP016ColorMatrix {
+    AVColorSpace colorspace = AVCOL_SPC_UNSPECIFIED;
+    AVColorRange colorRange = AVCOL_RANGE_UNSPECIFIED;
+    int bitDepth = 0;
+    float matrix[3][4] = {};
+    bool valid = false;
+  };
+
+  CachedP016ColorMatrix cachedColorMatrix_;
+
   // Stored from initialize() for deferred use in initializeVideo(), where
   // we know the outputDtype and can make the NVDEC-vs-CPU-fallback decision.
   // These are non-owning: SingleStreamDecoder owns them and outlives us.

--- a/src/torchcodec/_core/BetaCudaDeviceInterface.h
+++ b/src/torchcodec/_core/BetaCudaDeviceInterface.h
@@ -114,11 +114,7 @@ class BetaCudaDeviceInterface : public DeviceInterface {
 
   SwsConfig prevSwsConfig_;
   Rotation rotation_ = Rotation::NONE;
-  // TODO_HDR: figure out whether we actually need both. This should / could be
-  // a 1:1 mapping? If we need both because of the CPU falback logic, we might
-  // want to make things more explicit.
   OutputDtype outputDtype_ = OutputDtype::UINT8;
-  cudaVideoSurfaceFormat outputSurfaceFormat_ = cudaVideoSurfaceFormat_NV12;
 
   // Stored from initialize() for deferred use in initializeVideo(), where
   // we know the outputDtype and can make the NVDEC-vs-CPU-fallback decision.

--- a/src/torchcodec/_core/SingleStreamDecoder.cpp
+++ b/src/torchcodec/_core/SingleStreamDecoder.cpp
@@ -688,8 +688,7 @@ void SingleStreamDecoder::addAudioStream(
 FrameOutput SingleStreamDecoder::getNextFrame() {
   auto output = getNextFrameInternal();
   if (streamInfos_[activeStreamIndex_].avMediaType == AVMEDIA_TYPE_VIDEO) {
-    output.data = maybePermuteHWC2CHW(output.data);
-    output.data = maybeConvertToFloat32(output.data);
+    output.data = maybePermuteAndConvertToFloat32(output.data);
   }
   return output;
 }
@@ -705,8 +704,7 @@ FrameOutput SingleStreamDecoder::getNextFrameInternal(
 
 FrameOutput SingleStreamDecoder::getFrameAtIndex(int64_t frameIndex) {
   auto frameOutput = getFrameAtIndexInternal(frameIndex);
-  frameOutput.data = maybePermuteHWC2CHW(frameOutput.data);
-  frameOutput.data = maybeConvertToFloat32(frameOutput.data);
+  frameOutput.data = maybePermuteAndConvertToFloat32(frameOutput.data);
   return frameOutput;
 }
 
@@ -810,8 +808,8 @@ FrameBatchOutput SingleStreamDecoder::getFramesAtIndices(
     }
     previousIndexInVideo = indexInVideo;
   }
-  frameBatchOutput.data = maybePermuteHWC2CHW(frameBatchOutput.data);
-  frameBatchOutput.data = maybeConvertToFloat32(frameBatchOutput.data);
+  frameBatchOutput.data =
+      maybePermuteAndConvertToFloat32(frameBatchOutput.data);
   return frameBatchOutput;
 }
 
@@ -858,8 +856,8 @@ FrameBatchOutput SingleStreamDecoder::getFramesInRange(
     frameBatchOutputPtsSeconds[f] = frameOutput.ptsSeconds;
     frameBatchOutputDurationSeconds[f] = frameOutput.durationSeconds;
   }
-  frameBatchOutput.data = maybePermuteHWC2CHW(frameBatchOutput.data);
-  frameBatchOutput.data = maybeConvertToFloat32(frameBatchOutput.data);
+  frameBatchOutput.data =
+      maybePermuteAndConvertToFloat32(frameBatchOutput.data);
   return frameBatchOutput;
 }
 
@@ -900,8 +898,7 @@ FrameOutput SingleStreamDecoder::getFramePlayedAt(double seconds) {
 
   // Convert the frame to tensor.
   FrameOutput frameOutput = convertAVFrameToFrameOutput(avFrame);
-  frameOutput.data = maybePermuteHWC2CHW(frameOutput.data);
-  frameOutput.data = maybeConvertToFloat32(frameOutput.data);
+  frameOutput.data = maybePermuteAndConvertToFloat32(frameOutput.data);
   return frameOutput;
 }
 
@@ -989,8 +986,8 @@ FrameBatchOutput SingleStreamDecoder::getFramesPlayedInRange(
         getOutputDims(),
         videoStreamOptions.device,
         videoStreamOptions.outputDtype);
-    frameBatchOutput.data = maybePermuteHWC2CHW(frameBatchOutput.data);
-    frameBatchOutput.data = maybeConvertToFloat32(frameBatchOutput.data);
+    frameBatchOutput.data =
+        maybePermuteAndConvertToFloat32(frameBatchOutput.data);
     return frameBatchOutput;
   }
 
@@ -1060,8 +1057,8 @@ FrameBatchOutput SingleStreamDecoder::getFramesPlayedInRange(
       frameBatchOutputDurationSeconds[i] = frameDurationSeconds;
     }
 
-    frameBatchOutput.data = maybePermuteHWC2CHW(frameBatchOutput.data);
-    frameBatchOutput.data = maybeConvertToFloat32(frameBatchOutput.data);
+    frameBatchOutput.data =
+        maybePermuteAndConvertToFloat32(frameBatchOutput.data);
     return frameBatchOutput;
   } else {
     // Note that we look at nextPts for a frame, and not its pts or duration.
@@ -1096,8 +1093,8 @@ FrameBatchOutput SingleStreamDecoder::getFramesPlayedInRange(
       frameBatchOutputPtsSeconds[f] = frameOutput.ptsSeconds;
       frameBatchOutputDurationSeconds[f] = frameOutput.durationSeconds;
     }
-    frameBatchOutput.data = maybePermuteHWC2CHW(frameBatchOutput.data);
-    frameBatchOutput.data = maybeConvertToFloat32(frameBatchOutput.data);
+    frameBatchOutput.data =
+        maybePermuteAndConvertToFloat32(frameBatchOutput.data);
 
     return frameBatchOutput;
   }
@@ -1546,34 +1543,31 @@ FrameOutput SingleStreamDecoder::convertAVFrameToFrameOutput(
 // OUTPUT ALLOCATION AND SHAPE CONVERSION
 // --------------------------------------------------------------------------
 
-// Returns a [N]CHW *view* of a [N]HWC input tensor, if the options require
-// so. The [N] leading batch-dimension is optional i.e. the input tensor can
-// be 3D or 4D.
-torch::stable::Tensor SingleStreamDecoder::maybePermuteHWC2CHW(
+torch::stable::Tensor SingleStreamDecoder::maybePermuteAndConvertToFloat32(
     torch::stable::Tensor& hwcTensor) {
-  if (streamInfos_[activeStreamIndex_].videoStreamOptions.dimensionOrder ==
+  // Permute HWC to CHW if needed. Returns a view of the input tensor, the
+  // leading batch-dimension [N] is optional i.e. the input tensor can be 3D or
+  // 4D.
+  torch::stable::Tensor tensor = hwcTensor;
+  if (streamInfos_[activeStreamIndex_].videoStreamOptions.dimensionOrder !=
       "NHWC") {
-    return hwcTensor;
+    auto numDimensions = hwcTensor.dim();
+    auto shape = hwcTensor.sizes();
+    if (numDimensions == 3) {
+      STD_TORCH_CHECK(
+          shape[2] == 3, "Not a HWC tensor: ", intArrayRefToString(shape));
+      tensor = stablePermute(hwcTensor, {2, 0, 1});
+    } else if (numDimensions == 4) {
+      STD_TORCH_CHECK(
+          shape[3] == 3, "Not a NHWC tensor: ", intArrayRefToString(shape));
+      tensor = stablePermute(hwcTensor, {0, 3, 1, 2});
+    } else {
+      STD_TORCH_CHECK(
+          false, "Expected tensor with 3 or 4 dimensions, got ", numDimensions);
+    }
   }
-  auto numDimensions = hwcTensor.dim();
-  auto shape = hwcTensor.sizes();
-  if (numDimensions == 3) {
-    STD_TORCH_CHECK(
-        shape[2] == 3, "Not a HWC tensor: ", intArrayRefToString(shape));
-    return stablePermute(hwcTensor, {2, 0, 1});
-  } else if (numDimensions == 4) {
-    STD_TORCH_CHECK(
-        shape[3] == 3, "Not a NHWC tensor: ", intArrayRefToString(shape));
-    return stablePermute(hwcTensor, {0, 3, 1, 2});
-  } else {
-    STD_TORCH_CHECK(
-        false, "Expected tensor with 3 or 4 dimensions, got ", numDimensions);
-  }
-}
 
-// TODO_HDR: should this be a single call along with maybePermuteHWC2CHW?
-torch::stable::Tensor SingleStreamDecoder::maybeConvertToFloat32(
-    torch::stable::Tensor& tensor) {
+  // Convert to float32 and normalize to [0, 1] if needed.
   OutputDtype outputDtype =
       streamInfos_[activeStreamIndex_].videoStreamOptions.outputDtype;
   if (outputDtype != OutputDtype::FLOAT32) {

--- a/src/torchcodec/_core/SingleStreamDecoder.h
+++ b/src/torchcodec/_core/SingleStreamDecoder.h
@@ -274,11 +274,10 @@ class FORCE_PUBLIC_VISIBILITY SingleStreamDecoder {
       std::optional<torch::stable::Tensor> preAllocatedOutputTensor =
           std::nullopt);
 
-  torch::stable::Tensor maybePermuteHWC2CHW(torch::stable::Tensor& hwcTensor);
-
-  // Converts the tensor to float32 and normalizes to [0, 1] when the active
-  // stream's outputDtype is FLOAT32. Otherwise returns the input unchanged.
-  torch::stable::Tensor maybeConvertToFloat32(torch::stable::Tensor& tensor);
+  // Permutes HWC to CHW if needed, then converts to float32 and normalizes to
+  // [0, 1] if the active stream's outputDtype is FLOAT32.
+  torch::stable::Tensor maybePermuteAndConvertToFloat32(
+      torch::stable::Tensor& tensor);
 
   FrameOutput convertAVFrameToFrameOutput(
       UniqueAVFrame& avFrame,

--- a/src/torchcodec/_core/custom_ops.cpp
+++ b/src/torchcodec/_core/custom_ops.cpp
@@ -58,9 +58,9 @@ STABLE_TORCH_LIBRARY(torchcodec_ns, m) {
   m.def(
       "_create_from_file_like(int file_like_context, str? seek_mode=None) -> Tensor");
   m.def(
-      "_add_video_stream(Tensor(a!) decoder, *, int? num_threads=None, str? dimension_order=None, int? stream_index=None, str device=\"cpu\", str device_variant=\"default\", str transform_specs=\"\", Tensor? custom_frame_mappings_pts=None, Tensor? custom_frame_mappings_duration=None, Tensor? custom_frame_mappings_keyframe_indices=None, str? color_conversion_library=None, str? output_dtype=None) -> ()");
+      "_add_video_stream(Tensor(a!) decoder, *, int? num_threads=None, str? dimension_order=None, int? stream_index=None, str device=\"cpu\", str device_variant=\"default\", str transform_specs=\"\", Tensor? custom_frame_mappings_pts=None, Tensor? custom_frame_mappings_duration=None, Tensor? custom_frame_mappings_keyframe_indices=None, str? color_conversion_library=None, str output_dtype=\"uint8\") -> ()");
   m.def(
-      "add_video_stream(Tensor(a!) decoder, *, int? num_threads=None, str? dimension_order=None, int? stream_index=None, str device=\"cpu\", str device_variant=\"default\", str transform_specs=\"\", Tensor? custom_frame_mappings_pts=None, Tensor? custom_frame_mappings_duration=None, Tensor? custom_frame_mappings_keyframe_indices=None, str? output_dtype=None) -> ()");
+      "add_video_stream(Tensor(a!) decoder, *, int? num_threads=None, str? dimension_order=None, int? stream_index=None, str device=\"cpu\", str device_variant=\"default\", str transform_specs=\"\", Tensor? custom_frame_mappings_pts=None, Tensor? custom_frame_mappings_duration=None, Tensor? custom_frame_mappings_keyframe_indices=None, str output_dtype=\"uint8\") -> ()");
   m.def(
       "add_audio_stream(Tensor(a!) decoder, *, int? stream_index=None, int? sample_rate=None, int? num_channels=None) -> ()");
   m.def("seek_to_pts(Tensor(a!) decoder, float seconds) -> ()");
@@ -516,34 +516,22 @@ void _add_video_stream(
     std::optional<torch::stable::Tensor>
         custom_frame_mappings_keyframe_indices = std::nullopt,
     std::optional<std::string> color_conversion_library = std::nullopt,
-    // TODO_HDR: see other TODO, should default be uint8 instead? Maybe it
-    // shoudn't even be optional?
-    // videoStreamOptions.outputDtype defaults to UINT8 so if
-    // output_dtype is nullopt, the videoStreamOptions will default to UINT8.
-    // But that's pretty implicit and suggests maybe this shouldn't be optional
-    // at all.
-    // TODO_UINT8 Also this currently takes strings but surely the public API
-    // will want to support torch.dtype object, we should figure out when to do
-    // the conversion.
-    std::optional<std::string> output_dtype = std::nullopt) {
+    std::string output_dtype = "uint8") {
   VideoStreamOptions videoStreamOptions;
   videoStreamOptions.ffmpegThreadCount = num_threads;
 
-  if (output_dtype.has_value()) {
-    const std::string& val = *output_dtype;
-    if (val == "uint8") {
-      videoStreamOptions.outputDtypeConfig = OutputDtypeConfig::UINT8;
-    } else if (val == "float32") {
-      videoStreamOptions.outputDtypeConfig = OutputDtypeConfig::FLOAT32;
-    } else if (val == "auto") {
-      videoStreamOptions.outputDtypeConfig = OutputDtypeConfig::AUTO;
-    } else {
-      STD_TORCH_CHECK(
-          false,
-          "Invalid output_dtype=",
-          val,
-          ". Supported values are: uint8, float32, auto.");
-    }
+  if (output_dtype == "uint8") {
+    videoStreamOptions.outputDtypeConfig = OutputDtypeConfig::UINT8;
+  } else if (output_dtype == "float32") {
+    videoStreamOptions.outputDtypeConfig = OutputDtypeConfig::FLOAT32;
+  } else if (output_dtype == "auto") {
+    videoStreamOptions.outputDtypeConfig = OutputDtypeConfig::AUTO;
+  } else {
+    STD_TORCH_CHECK(
+        false,
+        "Invalid output_dtype=",
+        output_dtype,
+        ". Supported values are: uint8, float32, auto.");
   }
 
   if (dimension_order.has_value()) {
@@ -616,7 +604,7 @@ void add_video_stream(
         std::nullopt,
     std::optional<torch::stable::Tensor>
         custom_frame_mappings_keyframe_indices = std::nullopt,
-    std::optional<std::string> output_dtype = std::nullopt) {
+    std::string output_dtype = "uint8") {
   _add_video_stream(
       decoder,
       num_threads,

--- a/src/torchcodec/_core/ops.py
+++ b/src/torchcodec/_core/ops.py
@@ -84,7 +84,6 @@ def add_video_stream(
     custom_frame_mappings: (
         tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None
     ) = None,
-    # TODO_HDR
     output_dtype: str = "uint8",
 ) -> None:
     custom_frame_mappings_pts: torch.Tensor | None = None

--- a/src/torchcodec/_frame.py
+++ b/src/torchcodec/_frame.py
@@ -70,7 +70,7 @@ class FrameBatch(Iterable):
     """
 
     data: Tensor
-    """The frames data (``torch.Tensor`` of uint8)."""  # TODO_HDR: not always uint8 anymore
+    """The frames data (``torch.Tensor`` of uint8 in [0, 255] or float in [0, 1])."""
     pts_seconds: Tensor
     """The :term:`pts` of the frame, in seconds (``torch.Tensor`` of floats)."""
     duration_seconds: Tensor

--- a/src/torchcodec/decoders/_video_decoder.py
+++ b/src/torchcodec/decoders/_video_decoder.py
@@ -125,7 +125,18 @@ class VideoDecoder:
             :class:`~torchcodec.transforms.DecoderTransform` and
             :class:`~torchvision.transforms.v2.Transform`
             objects. Read more about this parameter in :ref:`sphx_glr_generated_examples_decoding_transforms.py`.
-        output_dtype: TODO_HDR: add docs for output_dtype
+        output_dtype (torch.dtype or ``"auto"``, optional): The dtype of the
+            output frames. Supported values are ``torch.uint8`` with values in
+            [0, 255] (default), ``torch.float32`` with values in [0, 1], and
+            ``"auto"``. When ``"auto"`` is specified, the output dtype is
+            determined automatically based on the video content: uint8 for SDR
+            content, float32 for HDR content.
+
+            .. note::
+                On ``"auto"``: since detecting whether a video is SDR or HDR is
+                difficult, the heuristic is subject to change and improve across
+                versions.
+
         custom_frame_mappings (str, bytes, or file-like object, optional):
             Mapping of frames to their metadata, typically generated via ffprobe.
             This enables accurate frame seeking without requiring a full video scan.
@@ -169,7 +180,6 @@ class VideoDecoder:
         device: str | torch_device | None = None,
         seek_mode: Literal["exact", "approximate"] = "exact",
         transforms: Sequence[DecoderTransform | nn.Module] | None = None,
-        # TODO_HDR
         output_dtype: torch.dtype | Literal["auto"] = torch.uint8,
         custom_frame_mappings: (
             str | bytes | io.RawIOBase | io.BufferedReader | None
@@ -209,7 +219,6 @@ class VideoDecoder:
             raise ValueError(f"{num_ffmpeg_threads = } should be an int.")
 
         _DTYPE_TO_STR = {torch.uint8: "uint8", torch.float32: "float32"}
-        # TODO_HDR: raise error on ffmpeg interface.
         if output_dtype != "auto":
             if output_dtype not in _DTYPE_TO_STR:
                 raise ValueError(
@@ -223,6 +232,18 @@ class VideoDecoder:
             device = str(torch.get_default_device())
         elif isinstance(device, torch_device):
             device = str(device)
+
+        if (
+            device.startswith("cuda")
+            and device_variant == "ffmpeg"
+            and output_dtype != "uint8"
+        ):
+            raise ValueError(
+                f"output_dtype={output_dtype} is not supported with the 'ffmpeg' "
+                f"CUDA backend. Only torch.uint8 is supported. Use the default "
+                f"'nvdec' CUDA backend for non-uint8 output dtypes."
+            )
+
         (
             self._decoder,
             self.stream_index,

--- a/test/test_decoders.py
+++ b/test/test_decoders.py
@@ -2523,6 +2523,13 @@ class TestVideoDecoder:
             VideoDecoder(NASA_VIDEO.path, output_dtype=bad_dtype)
 
     @needs_cuda
+    @pytest.mark.parametrize("output_dtype", (torch.float32, "auto"))
+    def test_output_dtype_not_uint8_ffmpeg_cuda_backend(self, output_dtype):
+        with set_cuda_backend("ffmpeg"):
+            with pytest.raises(ValueError, match="not supported with the 'ffmpeg'"):
+                VideoDecoder(NASA_VIDEO.path, output_dtype=output_dtype, device="cuda")
+
+    @needs_cuda
     def test_output_dtype_float32_cpu_fallback(self):
         # H264_10BITS triggers CPU fallback on NVDEC. float32 output should
         # still work via the CPU fallback path.


### PR DESCRIPTION
- cache color-conversion matrix to avoid recomputing it on each frame.
- add docs
- let uint8 be default instead of None or nullopt, and don't make the `output_dtype` param optional
- fuse maybePermuteHWC2CHW and maybeConvertToFloat32
- remove `outputSurfaceFormat_` field
- raise error on ffmpeg interface when output_dtype is set.