### PR TITLE
Avoid calling cudaMemcpyToSymbol unnecessarily

### DIFF
--- a/src/torchcodec/_core/BetaCudaDeviceInterface.cpp
+++ b/src/torchcodec/_core/BetaCudaDeviceInterface.cpp
@@ -355,7 +355,8 @@ static torch::stable::Tensor convertP016FrameToRGB16(
     std::optional<torch::stable::Tensor> preAllocatedOutputTensor,
     const FrameDims& outputDims,
     int bitDepth,
-    const float colorMatrix[3][4]) {
+    const float colorMatrix[3][4],
+    bool colorMatrixChanged) {
   int height = avFrame->height;
   int width = avFrame->width;
   STD_TORCH_CHECK(
@@ -399,6 +400,7 @@ static torch::stable::Tensor convertP016FrameToRGB16(
       validateInt64ToInt(dst.stride(0) * 2, "dst.stride(0)*2"),
       bitDepth,
       colorMatrix,
+      colorMatrixChanged,
       stream);
 
   return dst;
@@ -1114,6 +1116,7 @@ void BetaCudaDeviceInterface::convertAVFrameToFrameOutput(
       int bitDepth = static_cast<int>(videoFormat_.bit_depth_luma_minus8) + 8;
       AVColorSpace colorspace = gpuFrame->colorspace;
       AVColorRange colorRange = gpuFrame->color_range;
+      bool colorMatrixChanged = false;
       if (!cachedColorMatrix_.valid ||
           cachedColorMatrix_.colorspace != colorspace ||
           cachedColorMatrix_.colorRange != colorRange ||
@@ -1124,6 +1127,7 @@ void BetaCudaDeviceInterface::convertAVFrameToFrameOutput(
         cachedColorMatrix_.colorRange = colorRange;
         cachedColorMatrix_.bitDepth = bitDepth;
         cachedColorMatrix_.valid = true;
+        colorMatrixChanged = true;
       }
       return convertP016FrameToRGB16(
           gpuFrame,
@@ -1132,7 +1136,8 @@ void BetaCudaDeviceInterface::convertAVFrameToFrameOutput(
           preAlloc,
           originalDims,
           bitDepth,
-          cachedColorMatrix_.matrix);
+          cachedColorMatrix_.matrix,
+          colorMatrixChanged);
     }
     return convertNV12FrameToRGB(
         gpuFrame, device_, nppCtx_, nvdecStream, preAlloc, originalDims);

--- a/src/torchcodec/_core/P016ToRGB16.cu
+++ b/src/torchcodec/_core/P016ToRGB16.cu
@@ -92,13 +92,18 @@ void launchP016ToRGB16Kernel(
     int rgbPitch,
     int bitDepth,
     const float colorMatrix[3][4],
+    bool colorMatrixChanged,
     cudaStream_t stream) {
 
-  // TODO_HDR this is a sync point. We should try to make it non-blocking.
-  // E.g. put it on the `stream`? Make it async? Avoid re-sending the matrix if
-  // it hasn't changed from before (it likely didn't for the same video!!)?
-  cudaMemcpyToSymbol(
-      d_colorMatrix, colorMatrix, sizeof(float) * 12, 0, cudaMemcpyHostToDevice);
+  if (colorMatrixChanged) {
+    // We only send the color-matrix from CPU to GPU if it changed.
+    // In practice it probably doesn't impact perf that much since decoding is
+    // bottlenecked by NVDEC's frame mapping, not color-conversion. But it's a
+    // simple optimization, so we do it anyway.
+    cudaMemcpyToSymbol(
+        d_colorMatrix, colorMatrix, sizeof(float) * 12, 0,
+        cudaMemcpyHostToDevice);
+  }
 
   int yPitchElements = yPitch / static_cast<int>(sizeof(uint16_t));
   int uvPitchElements = uvPitch / static_cast<int>(sizeof(uint16_t));

--- a/src/torchcodec/_core/P016ToRGB16.h
+++ b/src/torchcodec/_core/P016ToRGB16.h
@@ -28,6 +28,7 @@ void launchP016ToRGB16Kernel(
     int rgbPitch,
     int bitDepth,
     const float colorMatrix[3][4],
+    bool colorMatrixChanged,
     cudaStream_t stream);
 
 } // namespace facebook::torchcodec


### PR DESCRIPTION
Could verify with nsys that we now only call it once per video.