### PR TITLE
Reduce size of built docs

### DIFF
--- a/examples/decoding/audio_decoding.py
+++ b/examples/decoding/audio_decoding.py
@@ -22,8 +22,10 @@ import requests
 from IPython.display import Audio
 
 
-def play_audio(samples):
-    return Audio(samples.data, rate=samples.sample_rate)
+def play_5s(samples):
+    # Play 5 seconds of the audio. Playing the entire file would take too much
+    # space in our docs (~40Mb!).
+    return Audio(samples.data[:, :5 * samples.sample_rate], rate=samples.sample_rate)
 
 
 # sphinx_gallery_thumbnail_path = '_static/thumbnails/grumps_audio.jpg'
@@ -67,7 +69,7 @@ print(decoder.metadata)
 samples = decoder.get_all_samples()
 
 print(samples)
-play_audio(samples)
+play_5s(samples)
 
 # %%
 # The ``.data`` field is a tensor of shape ``(num_channels, num_samples)`` and
@@ -88,7 +90,7 @@ play_audio(samples)
 samples = decoder.get_samples_played_in_range(start_seconds=10, stop_seconds=70)
 
 print(samples)
-play_audio(samples)
+play_5s(samples)
 
 # %%
 # Custom sample rate
@@ -103,4 +105,4 @@ decoder = AudioDecoder(raw_audio_bytes, sample_rate=16_000)
 samples = decoder.get_all_samples()
 
 print(samples)
-play_audio(samples)
+play_5s(samples)

--- a/examples/encoding/video_encoding.py
+++ b/examples/encoding/video_encoding.py
@@ -268,7 +268,9 @@ vs = encoder.add_video(
 with encoder.open_file_like(buf, format="mp4"):
     vs.add_frames(frames)
 
-play_video(buf.getvalue())
+# play_video is disabled because crf=0 creates a 50+ Mb video that we don't want
+# to check into our docs
+# play_video(buf.getvalue())
 
 # %%
 


### PR DESCRIPTION
We started getting a few warnings upon upload of our docs because they started getting really, really big - about 200Mb which is unreasonable for just a bunch of html files.

The issue was that when we use `play_audio` or `play_video`, the input is checked-in into the built docs artifacts. Meaning that we were storing large raw wav files, as well as large video files. This PR skips / reduces the amount of stuff we have to keep around. The audio example went from 60Mb to ~3, and the video example went from 45 to ~3.

This should account for 100Mb * 2 (since I think they were also duplicated). Let's see.