### PR TITLE
Trigger doc build job on stable release tag push - not just on RCs

### DIFF
--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -9,6 +9,7 @@ on:
       - release/*
     tags:
         - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
+        - v[0-9]+.[0-9]+.[0-9]+
   workflow_dispatch:
 
 concurrency:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -143,8 +143,10 @@ templates_path = [
 source_suffix = [".rst"]
 
 version = ".".join(torchcodec.__version__.split(".")[:2])
+# Strip CUDA suffix (e.g. "0.14.0-cu126" -> "0.14.0") for display
+release = torchcodec.__version__.split("-")[0]
 
-html_title = f"TorchCodec {torchcodec.__version__} Documentation"
+html_title = f"TorchCodec {release} Documentation"
 
 # The master toctree document.
 master_doc = "index"


### PR DESCRIPTION
We were not triggering a doc build on releases, only on RCs. Now, we should properly automatically push the new built docs to the 0.14 folder of gh-pages, provided the tag is `v0.14.x`. Also, we cleanup the version name to display as the title of the html pages, because it'd typically render as `TorchCodec v014.0-cu126` (or some worse hash) otherwise.