### PR TITLE
Add benchmark for WavDecoder

### DIFF
--- a/benchmarks/decoders/benchmark_wav_decoder.py
+++ b/benchmarks/decoders/benchmark_wav_decoder.py
@@ -1,4 +1,3 @@
-import gc
 import io
 import os
 import subprocess
@@ -90,7 +89,6 @@ def decode_audio_decoder(raw_bytes):
     return decoder.get_all_samples().data
 
 
-import random
 def decode_soundfile(raw_bytes):
     data, sr = sf.read(io.BytesIO(raw_bytes), dtype="float32")
     return data

--- a/benchmarks/decoders/benchmark_wav_decoder.py
+++ b/benchmarks/decoders/benchmark_wav_decoder.py
@@ -1,0 +1,228 @@
+import gc
+import io
+import os
+import subprocess
+from time import perf_counter_ns
+
+import soundfile as sf
+import torch
+
+from torchcodec.decoders import AudioDecoder, WavDecoder
+
+
+def bench(f, *args, num_exp=100, warmup=0, **kwargs):
+
+    for _ in range(warmup):
+        f(*args, **kwargs)
+
+    times = []
+    for _ in range(num_exp):
+        start = perf_counter_ns()
+        f(*args, **kwargs)
+        end = perf_counter_ns()
+        times.append(end - start)
+    return torch.tensor(times).float()
+
+
+def report_stats(times, unit="ms"):
+    mul = {
+        "ns": 1,
+        "µs": 1e-3,
+        "ms": 1e-6,
+        "s": 1e-9,
+    }[unit]
+    times = times * mul
+    std = times.std().item()
+    med = times.median().item()
+    print(f"{med = :.2f}{unit} +- {std:.2f}")
+    return med
+
+
+WAV_DIR = "/tmp/wav_files"
+
+FORMATS = {
+    "u8": ("pcm_u8", "int16"),
+    "s16": ("pcm_s16le", "int16"),
+    "s24": ("pcm_s24le", "int32"),
+    "s32": ("pcm_s32le", "int32"),
+    "float32": ("pcm_f32le", "float32"),
+    "float64": ("pcm_f64le", "float64"),
+}
+
+DURATIONS = {
+    "10s": 10,
+    "5min": 300,
+}
+
+
+def generate_wav_files():
+    os.makedirs(WAV_DIR, exist_ok=True)
+    for fmt_name, (codec, _) in FORMATS.items():
+        for dur_name, dur_seconds in DURATIONS.items():
+            path = os.path.join(WAV_DIR, f"{fmt_name}_{dur_name}.wav")
+            if os.path.exists(path):
+                continue
+            print(f"Generating {path} ...")
+            subprocess.run(
+                [
+                    "ffmpeg",
+                    "-y",
+                    "-f",
+                    "lavfi",
+                    "-i",
+                    f"sine=frequency=440:duration={dur_seconds}",
+                    "-c:a",
+                    codec,
+                    path,
+                ],
+                check=True,
+                capture_output=True,
+            )
+
+
+def decode_torchcodec(raw_bytes):
+    decoder = WavDecoder(raw_bytes)
+    return decoder.get_all_samples()
+
+
+def decode_audio_decoder(raw_bytes):
+    decoder = AudioDecoder(raw_bytes)
+    return decoder.get_all_samples().data
+
+
+import random
+def decode_soundfile(raw_bytes):
+    data, sr = sf.read(io.BytesIO(raw_bytes), dtype="float32")
+    return data
+
+
+def decode_soundfile_native(raw_bytes, native_dtype):
+    data, sr = sf.read(io.BytesIO(raw_bytes), dtype=native_dtype)
+    return data
+
+
+def validate_results():
+    print("Validating WavDecoder vs AudioDecoder outputs...")
+    for fmt_name in FORMATS:
+        for dur_name in DURATIONS:
+            path = os.path.join(WAV_DIR, f"{fmt_name}_{dur_name}.wav")
+            with open(path, "rb") as f:
+                raw_bytes = f.read()
+            wav_out = decode_torchcodec(raw_bytes)
+            audio_out = decode_audio_decoder(raw_bytes)
+            torch.testing.assert_close(wav_out.data, audio_out.data, atol=0, rtol=0)
+            print(f"  {fmt_name}/{dur_name}: OK")
+    print("All validations passed!\n")
+
+
+def main():
+    generate_wav_files()
+    validate_results()
+
+    results = []
+
+    for fmt_name, (_, native_dtype) in FORMATS.items():
+        for dur_name in DURATIONS:
+            path = os.path.join(WAV_DIR, f"{fmt_name}_{dur_name}.wav")
+            with open(path, "rb") as f:
+                raw_bytes = f.read()
+            num_exp = 10 if dur_name == "5min" else 100
+
+            print(f"\n=== {fmt_name} / {dur_name} ({path}) ===")
+
+            print("  WavDecoder: ", end="")
+            tc_times = bench(decode_torchcodec, raw_bytes, num_exp=num_exp, warmup=2)
+            tc_med = report_stats(tc_times)
+
+            print("  AudioDecoder: ", end="")
+            ad_times = bench(decode_audio_decoder, raw_bytes, num_exp=num_exp, warmup=2)
+            ad_med = report_stats(ad_times)
+
+            print("  soundfile (dtype=float32): ", end="")
+            sf_times = bench(decode_soundfile, raw_bytes, num_exp=num_exp, warmup=2)
+            sf_med = report_stats(sf_times)
+
+            print(f"  soundfile (dtype={native_dtype}): ", end="")
+            sfn_times = bench(
+                decode_soundfile_native,
+                raw_bytes,
+                native_dtype,
+                num_exp=num_exp,
+                warmup=2,
+            )
+            sfn_med = report_stats(sfn_times)
+
+            results.append((fmt_name, dur_name, tc_med, ad_med, sf_med, sfn_med))
+
+    print("\n" + "=" * 155)
+    print("SUMMARY")
+    print("=" * 155)
+    print(
+        f"{'format':<10} {'duration':<10} "
+        f"{'WavDec (ms)':>12} {'AudioDec (ms)':>14} {'sndfile f32 (ms)':>17} {'sndfile native (ms)':>20} "
+        f"{'AudioDec/WavDec':>16} {'sndfile f32/WavDec':>19} {'sndfile nat/WavDec':>19}"
+    )
+    print("-" * 155)
+    for fmt_name, dur_name, tc_med, ad_med, sf_med, sfn_med in results:
+        audio_over_wav = ad_med / tc_med if tc_med > 0 else float("inf")
+        sf_over_wav = sf_med / tc_med if tc_med > 0 else float("inf")
+        sfn_over_wav = sfn_med / tc_med if tc_med > 0 else float("inf")
+        print(
+            f"{fmt_name:<10} {dur_name:<10} "
+            f"{tc_med:>12.2f} {ad_med:>14.2f} {sf_med:>17.2f} {sfn_med:>20.2f} "
+            f"{audio_over_wav:>15.2f}x {sf_over_wav:>18.2f}x {sfn_over_wav:>18.2f}x"
+        )
+
+
+def bench_input_types():
+    print("\n" + "=" * 100)
+    print("FILE vs FILE-LIKE vs BYTES")
+    print("=" * 100)
+    print(
+        f"{'format':<10} {'duration':<10} "
+        f"{'file (ms)':>12} {'file-like (ms)':>16} {'bytes (ms)':>12} "
+        f"{'flike/file':>12} {'bytes/file':>12}"
+    )
+    print("-" * 100)
+
+    for fmt_name in FORMATS:
+        for dur_name in DURATIONS:
+            path = os.path.join(WAV_DIR, f"{fmt_name}_{dur_name}.wav")
+            num_exp = 10 if dur_name == "5min" else 100
+
+            with open(path, "rb") as f:
+                raw_bytes = f.read()
+
+            def decode_file():
+                return WavDecoder(path).get_all_samples()
+
+            def decode_filelike():
+                with open(path, "rb") as f:
+                    return WavDecoder(f).get_all_samples()
+
+            def decode_bytes():
+                return WavDecoder(raw_bytes).get_all_samples()
+
+            file_med = (
+                bench(decode_file, num_exp=num_exp, warmup=2).median().item() * 1e-6
+            )
+            flike_med = (
+                bench(decode_filelike, num_exp=num_exp, warmup=2).median().item() * 1e-6
+            )
+            bytes_med = (
+                bench(decode_bytes, num_exp=num_exp, warmup=2).median().item() * 1e-6
+            )
+
+            flike_ratio = flike_med / file_med if file_med > 0 else float("inf")
+            bytes_ratio = bytes_med / file_med if file_med > 0 else float("inf")
+
+            print(
+                f"{fmt_name:<10} {dur_name:<10} "
+                f"{file_med:>12.2f} {flike_med:>16.2f} {bytes_med:>12.2f} "
+                f"{flike_ratio:>11.2f}x {bytes_ratio:>11.2f}x"
+            )
+
+
+if __name__ == "__main__":
+    main()
+    bench_input_types()


### PR DESCRIPTION
Adds benchmark of WavDecoder against AudioDecoder against soundfile (float) against soundfile (native == dtype that is closest to wav source, usually without conversion, but not always, e.g. u8 wav still has to be converted to int16). Both WavDecoder and AudioDecoder always convert to float32.

Results on my machine are the following. Unsurprisingly the WavDecoder is much faster than AudioDecoder. We're overall faster than soundfile(float) but I would take the results against soundfile with a grain of salt. I observed vastly different perf depending on the libsoundfile.so that gets resolved, and most long file benhmarks show a modest improvement anyway. Unsurprisingly soundfile tends to be faster in the 'native' scenario since it does less: it doesn't convert to float32, like we do. The one bit that I still cannot explain despite some investigation is the  wav float32 decoding time:


```
float32    5min              18.95          37.02              5.71                 5.71            1.95x               0.30x               0.30x
```

How can we take 18ms and soundfile take 5? That makes no sense to me, we literally just copy the entire data into the output tensor in one shot. The cost of a `memcpy` for that size is in the range of 18ms, so there's no logical explanation for libsoundfile perf other than some sort of caching. In cache? via memmap?? via some smart numpy mechanism??? I have no idea, I couldn't figure it out.


```

===========================================================================================================================================================
SUMMARY
===========================================================================================================================================================
format     duration    WavDec (ms)  AudioDec (ms)  sndfile f32 (ms)  sndfile native (ms)  AudioDec/WavDec  sndfile f32/WavDec  sndfile nat/WavDec
-----------------------------------------------------------------------------------------------------------------------------------------------------------
u8         10s                0.09           0.86              0.60                 0.49            9.11x               6.36x               5.23x
u8         5min              16.67          35.90             21.06                13.53            2.15x               1.26x               0.81x
s16        10s                0.10           8.12              0.77                 0.09           81.97x               7.79x               0.89x
s16        5min              16.51          40.65             26.26                 1.33            2.46x               1.59x               0.08x
s24        10s                0.39           1.01              1.57                 1.36            2.57x               4.01x               3.46x
s24        5min              26.54          41.75             49.99                43.44            1.57x               1.88x               1.64x
s32        10s                0.11           0.80              0.76                 0.13            7.11x               6.74x               1.15x
s32        5min              17.91          35.64             26.21                 5.75            1.99x               1.46x               0.32x
float32    10s                0.10           0.83              0.13                 0.12            8.14x               1.23x               1.22x
float32    5min              18.95          37.02              5.71                 5.71            1.95x               0.30x               0.30x
float64    10s                0.21           1.07              0.80                 0.21            5.11x               3.85x               1.00x
float64    5min              21.86          45.27             29.77                12.03            2.07x               1.36x               0.55x

```




Also benchmarked different input types just for WavDecoder:

```

====================================================================================================
FILE vs FILE-LIKE vs BYTES
====================================================================================================
format     duration      file (ms)   file-like (ms)   bytes (ms)   flike/file   bytes/file
----------------------------------------------------------------------------------------------------
u8         10s                0.13             0.18         0.09        1.40x        0.70x
u8         5min              18.27            19.69        16.59        1.08x        0.91x
s16        10s                0.15             0.25         0.09        1.63x        0.60x
s16        5min              19.50            22.68        16.74        1.16x        0.86x
s24        10s                0.49             0.62         0.39        1.27x        0.80x
s24        5min              30.48            34.64        26.30        1.14x        0.86x
s32        10s                0.22             0.41         0.11        1.84x        0.50x
s32        5min              23.16            29.40        17.74        1.27x        0.77x
float32    10s                0.15             0.21         0.10        1.46x        0.66x
float32    5min              18.42            37.25        18.93        2.02x        1.03x
float64    10s                0.41             0.82         0.20        2.01x        0.48x
float64    5min              32.69            45.01        22.57        1.38x        0.69x
```

There is unsurprisingly some overhead with the file-like object, and reading from bytes is faster as it bypasses the `io` part. This is consistent with expectations.