### PR TITLE
Avoid red doc job on RC push

### DIFF
--- a/.github/workflows/linux_cuda_wheel.yaml
+++ b/.github/workflows/linux_cuda_wheel.yaml
@@ -295,7 +295,8 @@ jobs:
 
     needs: build-docs
     if: github.repository == 'meta-pytorch/torchcodec' && github.event_name == 'push' &&
-        ((github.ref_type == 'branch' && github.ref_name == 'main') || github.ref_type == 'tag')
+        ((github.ref_type == 'branch' && github.ref_name == 'main') ||
+         (github.ref_type == 'tag' && !contains(github.ref_name, '-rc')))
     runs-on: ubuntu-latest
     steps:
       - name: Check out gh-pages branch
@@ -318,17 +319,9 @@ jobs:
           if [[ "${REF_TYPE}" == branch ]]; then
             TARGET_FOLDER="${REF_NAME}"
           elif [[ "${REF_TYPE}" == tag ]]; then
-            case "${REF_NAME}" in
-              *-rc*)
-                echo "Aborting upload since this is an RC tag: ${REF_NAME}"
-                exit 0
-                ;;
-              *)
-                # Strip the leading "v" as well as the trailing patch version. For example:
-                # 'v0.10.2' -> '0.10'
-                TARGET_FOLDER=$(echo "${REF_NAME}" | sed 's/v\([0-9]\+\)\.\([0-9]\+\)\.[0-9]\+/\1.\2/')
-                ;;
-            esac
+            # Strip the leading "v" as well as the trailing patch version. For example:
+            # 'v0.10.2' -> '0.10'
+            TARGET_FOLDER=$(echo "${REF_NAME}" | sed 's/v\([0-9]\+\)\.\([0-9]\+\)\.[0-9]\+/\1.\2/')
           fi
           echo "Target Folder: ${TARGET_FOLDER}"
 


### PR DESCRIPTION
The early exit on our doc job is causing the job to be red even though everything is fine. This PR removes the early exit into a run condition to bypass it.

example of early exit being interpreted as error: https://github.com/meta-pytorch/torchcodec/actions/runs/26819748093/job/79081708899