### PR TITLE
Fix build failure on Python 3.14t without --enable-shared

### DIFF
--- a/src/torchcodec/_core/CMakeLists.txt
+++ b/src/torchcodec/_core/CMakeLists.txt
@@ -185,8 +185,10 @@ function(make_torchcodec_libraries
     )
     set(custom_ops_dependencies
         ${core_library_name}
-        ${Python3_LIBRARIES}
     )
+    if(WIN32)
+        list(APPEND custom_ops_dependencies ${Python3_LIBRARIES})
+    endif()
     make_torchcodec_sublibrary(
         "${custom_ops_library_name}"
         SHARED


### PR DESCRIPTION
Free-threaded Python (3.13t+) uses mimalloc, whose initial-exec TLS is incompatible with shared libraries loaded via dlopen(). When Python is built without --enable-shared (the default), linking ${Python3_LIBRARIES} pulls in the static libpython3.14t.a and triggers a link error.

On Linux/macOS, extension modules don't need to link libpython — symbols resolve from the interpreter at runtime. Only Windows requires it (DLL import library).

This is consistent with how PyTorch handles it in torch/CMakeLists.txt (only links Python libraries on MSVC), and also consistent with pybind_ops in this repo which already avoids linking ${Python3_LIBRARIES}.