### PR TITLE
Optimize forward seeks

### DIFF
--- a/src/torchcodec/_core/SingleStreamDecoder.cpp
+++ b/src/torchcodec/_core/SingleStreamDecoder.cpp
@@ -1331,34 +1331,76 @@ bool SingleStreamDecoder::canWeAvoidSeeking() const {
     // caching we have to rewind back and decode the frame again.
     return false;
   }
-  // We are seeking forwards. We can skip a seek if both the last decoded frame
-  // and cursor_ share the same keyframe:
-  // Videos have I frames and non-I frames (P and B frames). Non-I frames need
-  // data from the previous I frame to be decoded.
+  // We are seeking forward, from the current frame x (lastDecodedAvFramePts_)
+  // to a target frame y (cursor_). Seeking means jumping to the last keyframe
+  // before y, which we call j:
   //
-  // Imagine the cursor is at a random frame with PTS=lastDecodedAvFramePts (x
-  // for brevity) and we wish to seek to a user-specified PTS=y.
+  //   .........x...............j...............y.......
+  //            ^               ^               ^
+  //       current frame   keyframe we'd     frame we
+  //       (last decoded)  seek to           want
   //
-  // If y < x, we don't have a choice but to seek backwards to the highest I
-  // frame before y.
+  // Whether seeking is worth it depends on how far j is from x. Seeking flushes
+  // the decoder, which throws away the `has_b_frames` frames already sitting in
+  // the reorder buffer plus the `thread_count - 1` frames in flight in the
+  // threading pipeline -- exactly the frames we'd decode next anyway. So we
+  // only seek if j is beyond them, i.e. if decoding straight through would cost
+  // more than the flush:
   //
-  // If y > x, we have two choices:
+  //   seek iff (j - x) > has_b_frames + thread_count - 1
   //
-  // 1. We could keep decoding forward until we hit y. Illustrated below:
-  //
-  // I    P     P    P    I    P    P    P    I    P    P    I    P
-  //                           x         y
-  //
-  // 2. We could try to jump to an I frame between x and y (indicated by j
-  // below). And then start decoding until we encounter y. Illustrated below:
-  //
-  // I    P     P    P    I    P    P    P    I    P    P    I    P
-  //                           x              j         y
-  // (2) is only more efficient than (1) if there is an I frame between x and y.
-  int lastKeyFrame = getKeyFrameIdentifier(lastDecodedAvFramePts_);
-  int targetKeyFrame = getKeyFrameIdentifier(cursor_);
-  return lastKeyFrame >= 0 && targetKeyFrame >= 0 &&
-      lastKeyFrame == targetKeyFrame;
+  // (the thread_count term only applies to CPU decoding, see below.)
+  // See https://github.com/meta-pytorch/torchcodec/issues/1488 for details.
+
+  // These "identifiers" only let us tell whether x and y share the same
+  // keyframe. They are not necessarily frame indices (see
+  // getKeyFrameIdentifier()), so we use them for equality only, not for the
+  // (j - x) distance below.
+  int lastKeyFrameId = getKeyFrameIdentifier(lastDecodedAvFramePts_);
+  int targetKeyFrameId = getKeyFrameIdentifier(cursor_);
+  if (lastKeyFrameId < 0 || targetKeyFrameId < 0) {
+    return false;
+  }
+  if (lastKeyFrameId == targetKeyFrameId) {
+    // x and y share the same keyframe (as in `...j...x...y`): seeking would go
+    // backwards to j and re-decode up to x, landing us back where we are.
+    return true;
+  }
+
+  // x
+  int64_t lastDecodedFrameIndex = secondsToIndexLowerBound(
+      ptsToSeconds(lastDecodedAvFramePts_, streamInfo.timeBase));
+
+  // j
+  int64_t targetKeyFrameIndex;
+  if (!streamInfo.keyFrames.empty()) {
+    // exact and custom_frame_mappings modes: getKeyFrameIdentifier() returned
+    // getKeyFrameIndexForPtsUsingScannedIndex() for these modes, so
+    // targetKeyFrameId is already the position of j in the scanned keyFrames
+    // vector.
+    targetKeyFrameIndex = streamInfo.keyFrames[targetKeyFrameId].frameIndex;
+  } else {
+    // approximate mode: keyFrames is empty, so we can't locate j. We use y
+    // instead. This makes the heuristic more conservative, i.e. err towards
+    // seeking even more, which is safe.
+    targetKeyFrameIndex =
+        secondsToIndexLowerBound(ptsToSeconds(cursor_, streamInfo.timeBase));
+  }
+
+  int64_t frameReorderBufferSize =
+      std::max(streamInfo.codecContext->has_b_frames, 0);
+
+  // The `thread_count - 1` in-flight frames only exist with FFmpeg
+  // frame-threading, i.e. the CPU decoding path. On other devices (e.g. CUDA)
+  // decoding is offloaded and there's no such pipeline, so we don't count them.
+  // The reorder buffer (has_b_frames) is a codec property and applies
+  // regardless.
+  int64_t inFlightFrames = 0;
+  if (streamInfo.videoStreamOptions.device == kStableCPU) {
+    inFlightFrames = std::max(streamInfo.codecContext->thread_count, 1) - 1;
+  }
+  return (targetKeyFrameIndex - lastDecodedFrameIndex) <=
+      frameReorderBufferSize + inFlightFrames;
 }
 
 // This method looks at currentPts and desiredPts and seeks in the
@@ -1627,8 +1669,8 @@ int SingleStreamDecoder::getKeyFrameIndexForPtsUsingScannedIndex(
   return upperBound - 1 - keyFrames.begin();
 }
 
-int64_t SingleStreamDecoder::secondsToIndexLowerBound(double seconds) {
-  auto& streamInfo = streamInfos_[activeStreamIndex_];
+int64_t SingleStreamDecoder::secondsToIndexLowerBound(double seconds) const {
+  const auto& streamInfo = streamInfos_.at(activeStreamIndex_);
   switch (seekMode_) {
     case SeekMode::custom_frame_mappings:
     case SeekMode::exact: {

--- a/src/torchcodec/_core/SingleStreamDecoder.cpp
+++ b/src/torchcodec/_core/SingleStreamDecoder.cpp
@@ -1349,7 +1349,8 @@ bool SingleStreamDecoder::canWeAvoidSeeking() const {
   //
   //   seek iff (j - x) > has_b_frames + thread_count - 1
   //
-  // (the thread_count term only applies to CPU decoding, see below.)
+  // (the thread_count term only applies to CPU decoding and to FRAME threading,
+  // see below.)
   // See https://github.com/meta-pytorch/torchcodec/issues/1488 for details.
 
   // These "identifiers" only let us tell whether x and y share the same
@@ -1390,13 +1391,16 @@ bool SingleStreamDecoder::canWeAvoidSeeking() const {
   int64_t frameReorderBufferSize =
       std::max(streamInfo.codecContext->has_b_frames, 0);
 
-  // The `thread_count - 1` in-flight frames only exist with FFmpeg
-  // frame-threading, i.e. the CPU decoding path. On other devices (e.g. CUDA)
-  // decoding is offloaded and there's no such pipeline, so we don't count them.
-  // The reorder buffer (has_b_frames) is a codec property and applies
-  // regardless.
+  // The reorder buffer (has_b_frames) is a codec property that applies
+  // in all scenarios, but the `thread_count - 1` in-flight frames only exist
+  // with FFmpeg FRAME threading, in the CPU decoding path. On other devices
+  // (e.g. CUDA) decoding doesn't depend on thread_count, and with SLICE
+  // threading the threads cooperate on a single frame rather than pipelining
+  // several frames. Note that FRAME threading is the default across the vast
+  // majority of codecs, so our check is just to be on the safe side.
   int64_t inFlightFrames = 0;
-  if (streamInfo.videoStreamOptions.device == kStableCPU) {
+  if (streamInfo.videoStreamOptions.device == kStableCPU &&
+      (streamInfo.codecContext->active_thread_type & FF_THREAD_FRAME)) {
     inFlightFrames = std::max(streamInfo.codecContext->thread_count, 1) - 1;
   }
   return (targetKeyFrameIndex - lastDecodedFrameIndex) <=

--- a/src/torchcodec/_core/SingleStreamDecoder.h
+++ b/src/torchcodec/_core/SingleStreamDecoder.h
@@ -297,7 +297,7 @@ class FORCE_PUBLIC_VISIBILITY SingleStreamDecoder {
       const std::vector<SingleStreamDecoder::FrameInfo>& keyFrames,
       int64_t pts) const;
 
-  int64_t secondsToIndexLowerBound(double seconds);
+  int64_t secondsToIndexLowerBound(double seconds) const;
 
   int64_t secondsToIndexUpperBound(double seconds);
 


### PR DESCRIPTION
This PR implements the heuristic described in https://github.com/meta-pytorch/torchcodec/issues/1488, which greatly speeds up various sparse sampling scenarios

On `main`:
```
== 10s clip ===
  scenario num_frames=32:
    threads=1     897.97 ±   1.46 ms
    threads=8     318.66 ±  11.46 ms
    threads=16    405.97 ±  43.35 ms
  scenario fps=2:
    threads=1     823.16 ±   4.05 ms
    threads=8     297.88 ±  15.41 ms
    threads=16    335.72 ±  38.15 ms

=== 30s clip ===
  scenario num_frames=32:
    threads=1    2093.25 ±  12.27 ms
    threads=8     747.90 ±  36.04 ms
    threads=16    888.11 ±  70.06 ms
  scenario fps=2:
    threads=1    3072.13 ±  27.38 ms
    threads=8     958.11 ±  53.55 ms
    threads=16   1017.69 ± 100.46 ms
```

This PR:

```
=== 10s clip ===
  scenario num_frames=32:
    threads=1     900.39 ±  19.13 ms
    threads=8     256.81 ±  14.87 ms
    threads=16    162.67 ±  12.00 ms
  scenario fps=2:
    threads=1     829.18 ±   8.31 ms
    threads=8     246.38 ±  17.08 ms
    threads=16    212.49 ±  22.90 ms

=== 30s clip ===
  scenario num_frames=32:
    threads=1    2071.08 ±  14.91 ms
    threads=8     705.73 ±  39.94 ms
    threads=16    564.64 ±  39.22 ms
  scenario fps=2:
    threads=1    3050.82 ±  19.00 ms
    threads=8     789.66 ±  43.08 ms
    threads=16    502.18 ±  26.40 ms
```

benchmark code:
<details>

```py
"""Tiny torchcodec-only benchmark to compare branches (e.g. main vs the
forward-seek heuristic from issue #1488).

Same clip + scenarios as bench_opencv.py, but self-contained. Run it on each
branch and eyeball:

    git checkout main         && <rebuild> && python bench_heuristic.py
    git checkout <my-branch>  && <rebuild> && python bench_heuristic.py

Thread count matters: the heuristic threshold is has_b_frames + thread_count - 1,
so the no-seek win grows with more threads on sparse sampling (fps=2).
"""

import hashlib
import math
import statistics
import subprocess
import tempfile
import time
from pathlib import Path

import numpy as np

from torchcodec.decoders import VideoDecoder

SRC_FPS = 30
SRC_GOP = 30
DURATIONS_S = [10, 30]
THREADS = [1, 8, 16]
ITERS = 20

# (label, kwargs) sampling scenarios to exercise.
SCENARIOS = [
    ("num_frames=32", {"num_frames": 32}),
    ("fps=2", {"fps": 2}),
]

CACHE_DIR = Path(tempfile.gettempdir()) / "vllm_video_bench"


def get_or_make_video(duration_s):
    """Return a cached animated 720p clip, generating it with ffmpeg if needed."""
    spec = [
        "-f", "lavfi",
        "-i", f"mandelbrot=s=1280x720:rate={SRC_FPS}",
        "-t", str(duration_s),
        "-g", str(SRC_GOP),
        "-pix_fmt", "yuv420p",
    ]
    digest = hashlib.sha256(" ".join(spec).encode()).hexdigest()[:16]
    CACHE_DIR.mkdir(parents=True, exist_ok=True)
    path = CACHE_DIR / f"clip_{duration_s}s_{digest}.mp4"
    if not path.exists():
        print(f"generating {path} ...")
        tmp = path.with_suffix(".tmp.mp4")
        subprocess.run(
            ["ffmpeg", "-y", "-loglevel", "error", *spec, str(tmp)], check=True
        )
        tmp.rename(path)
    return str(path)


def compute_frame_idx(total_frames, duration, num_frames=-1, fps=-1):
    """Uniformly sample frame indices (copied from vLLM: multimodal/video.py)."""
    n = total_frames
    if num_frames > 0:
        n = min(num_frames, total_frames)
    if fps > 0:
        n = min(n, math.floor(duration * fps))
    n = max(1, n)
    if n == total_frames:
        return list(range(n))
    return np.linspace(0, total_frames - 1, n, dtype=int).tolist()


def torchcodec_decode(path, threads, num_frames=-1, fps=-1):
    decoder = VideoDecoder(path, num_ffmpeg_threads=threads)
    frame_idx = compute_frame_idx(
        decoder._num_frames, decoder.metadata.duration_seconds, num_frames, fps
    )
    return decoder.get_frames_at(frame_idx).data


def bench(path, kwargs, threads):
    torchcodec_decode(path, threads, **kwargs)  # warm-up
    times = []
    for _ in range(ITERS):
        start = time.perf_counter()
        torchcodec_decode(path, threads, **kwargs)
        times.append((time.perf_counter() - start) * 1e3)
    return statistics.median(times), (statistics.stdev(times) if len(times) > 1 else 0.0)


def main():
    rev = subprocess.run(
        ["git", "rev-parse", "--short", "HEAD"], capture_output=True, text=True
    ).stdout.strip()
    print(f"git HEAD: {rev}  (iters={ITERS})")

    for duration in DURATIONS_S:
        path = get_or_make_video(duration)
        print(f"\n=== {duration}s clip ===")
        for label, kwargs in SCENARIOS:
            print(f"  scenario {label}:")
            for threads in THREADS:
                median_ms, std_ms = bench(path, kwargs, threads)
                print(f"    threads={threads:<2}  {median_ms:8.2f} ± {std_ms:6.2f} ms")


if __name__ == "__main__":
    main()
```

</details>