### PR TITLE
Skip FFmpeg-version probe for absent runtimes (fixes glibc TLS abort)

### DIFF
--- a/src/torchcodec/_internally_replaced_utils.py
+++ b/src/torchcodec/_internally_replaced_utils.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import ctypes
 import importlib
 import importlib.util
 import sys
@@ -64,6 +65,24 @@ def _load_pybind11_module(module_name: str, library_path: str) -> ModuleType:
     return mod
 
 
+def _ffmpeg_runtime_present(ffmpeg_major_version: int) -> bool:
+    """Return True if the FFmpeg runtime for this major version is loadable.
+
+    dlopen'ing a core lib whose FFmpeg runtime is absent still maps the core
+    lib's CUDA deps (which carry TLS) before failing on the missing libavutil
+    and unwinding (dlclose) -- freeing TLS module ids and leaving glibc's TLS
+    slotinfo bookkeeping inconsistent, which aborts an unrelated later dlopen
+    ("_dl_add_to_slotinfo: idx == 0"; glibc before the bug-31717 rework).
+
+    Checking libavutil first: libavutil soname major == FFmpeg major + 52.
+    """
+    try:
+        ctypes.CDLL(f"libavutil.so.{ffmpeg_major_version + 52}")
+        return True
+    except OSError:
+        return False
+
+
 def load_torchcodec_shared_libraries() -> tuple[int, str, ModuleType]:
     """
     Successively try to load the shared libraries for each version of FFmpeg
@@ -85,6 +104,8 @@ def load_torchcodec_shared_libraries() -> tuple[int, str, ModuleType]:
     """
     exceptions = []
     for ffmpeg_major_version in (8, 7, 6, 5, 4):
+        if not _ffmpeg_runtime_present(ffmpeg_major_version):
+            continue
         core_library_name = f"libtorchcodec_core{ffmpeg_major_version}"
         custom_ops_library_name = f"libtorchcodec_custom_ops{ffmpeg_major_version}"
         pybind_ops_library_name = f"libtorchcodec_pybind_ops{ffmpeg_major_version}"


### PR DESCRIPTION
We ran into this recently where we'd run into libc assertion failures on server startup -- and with LD_DEBUG=files noticed that it happens right after loading torchcodec. Claude took it further to repro & root cause, attaching the description with all details here; but mainly trying to avoid triggering the libc bug with this patch.

---

[by claude]

## Summary
`load_torchcodec_shared_libraries()` tries each FFmpeg major (8→4) by
`torch.ops.load_library("libtorchcodec_core{N}")`. For a major whose FFmpeg
runtime isn't installed, the loader still maps the core lib's *other*
`DT_NEEDED` deps — including CUDA libs like `libnvrtc`/`libnppicc`, which carry
TLS — then fails on the missing `libavutil.so.{N+52}` and unwinds (`dlclose`).

probe failures (e.g. 8 and 7 absent, 6 present) free TLS module ids and leave
glibc's TLS DTV slotinfo bookkeeping inconsistent; a later TLS `dlopen` then
aborts the whole process:

```
Inconsistency detected by ld.so: dl-tls.c: 1044: _dl_add_to_slotinfo: Assertion `idx == 0' failed!
```

This is reproducible on plain glibc with no torchcodec at all (a `dlopen` whose
`DT_NEEDED` lists a present TLS lib then a missing lib, in a loop). It bites
CUDA-enabled torchcodec wheels on systems whose FFmpeg major != the highest
torchcodec supports — and is nasty because the abort surfaces in an *unrelated*
later `dlopen`, not in torchcodec.

## Fix
Check whether the FFmpeg runtime for a major is loadable (`libavutil.so.{52+N}`,
via `ctypes.CDLL`) *before* `dlopen`ing its core lib, and `continue` if absent.
This avoids ever partial-loading + `dlclose`ing a mismatched core lib, so no TLS
module ids are freed and no DTV gap forms. All supported FFmpeg versions remain
supported; only the doomed probes are skipped.

## Why checking libavutil is correct
1. **libavutil is the right gate.** Every FFmpeg shared library (libavcodec,
   libavformat, libavfilter, …) depends on libavutil, and each
   `libtorchcodec_core{N}` links the libavutil for FFmpeg major N. In the
   failing trace it is exactly the dep whose absence aborts the `core{N}`
   `dlopen` (`file=libavutil.so.60 … needed by …/libtorchcodec_core8.so`). An
   FFmpeg install ships its `av*` libs together, so libavutil-N present ⇒ the
   rest of the FFmpeg-N runtime is present — libavutil alone is a sufficient
   proxy for "FFmpeg major N is installed."
2. **The `+52` mapping is stable FFmpeg ABI, and torchcodec already relies on
   it.** libavutil's SONAME major is bumped by exactly 1 each FFmpeg major
   release: FFmpeg 4→`libavutil.so.56`, 5→57, 6→58, 7→59, 8→60 — i.e.
   `libavutil_soname_major == ffmpeg_major + 52` across the whole `(8,7,6,5,4)`
   range this loop iterates. This is the *same* correspondence torchcodec
   already bakes in by shipping one `core{N}` per FFmpeg major, so the check
   introduces **no new assumption** beyond what the existing code requires. (If
   FFmpeg ever broke the 1-per-major cadence, torchcodec's per-major cores and
   this check would need updating *together* — the check can't drift alone.)
   Upstream `LIBAVUTIL_VERSION_MAJOR` in `libavutil/version.h` confirms it —
   [n6.0 → 58](https://github.com/FFmpeg/FFmpeg/blob/n6.0/libavutil/version.h),
   [n7.0 → 59](https://github.com/FFmpeg/FFmpeg/blob/n7.0/libavutil/version.h),
   [n8.0 → 60](https://github.com/FFmpeg/FFmpeg/blob/n8.0/libavutil/version.h).
3. **The check must not itself load the core lib — and it doesn't.**
   `ctypes.CDLL("libavutil.so.{N+52}")` loads only libavutil (+ its small,
   non-CUDA, non-TLS-problematic deps); it never touches `core{N}` or its CUDA
   deps, so it can't create the gap it's guarding against. Absent → `OSError`
   with nothing mapped (no `dlclose`); present → libavutil is simply reused when
   `core{N}` is then loaded.
4. **`ctypes.CDLL` (not a file-existence check) matches the real resolution.**
   It goes through the dynamic loader's search (`LD_LIBRARY_PATH`, ldconfig
   cache, rpath), so it reflects exactly what `dlopen(core{N})` would find — no
   guessed paths, no false positives on an unloadable file.
5. **It can never make things worse.** Worst case (a pathological partial FFmpeg
   install: libavutil-N present but another `av*` lib missing) we proceed to
   `dlopen core{N}` and it fails on that other lib — identical to today's
   behavior for that one version. The common case (probing FFmpeg majors that
   aren't installed at all) is what gets the churn eliminated.

## Validation
- Standalone C reproducer (no torch): fires the identical assertion; the patch
  pattern (skip-if-runtime-absent) eliminates it.
- `import torchcodec` under `LD_DEBUG=files`: stock dlcloses
  `core8/core7 + libnvrtc + libnppicc`; patched does zero of those (loads the
  matching `core6` directly).
- End-to-end: a multi-node GPU inference workload that crashed ~100% at process
  init now starts cleanly (0 asserts) with a patched wheel.

## glibc references
- The aborting assertion is `_dl_add_to_slotinfo`'s `assert (idx == 0)`:
  [glibc-2.39 `elf/dl-tls.c` L1044](https://github.com/bminor/glibc/blob/glibc-2.39/elf/dl-tls.c#L1044).
- glibc later reworked this exact function — adding an `l->l_tls_in_slotinfo`
  guard so a module already in the slotinfo list is never re-added — in commit
  [`5097cd3`](https://github.com/bminor/glibc/commit/5097cd344fd243fb8deb6dec96e8073753f962f9)
  "elf: Avoid re-initializing already allocated TLS in dlopen"
  ([bug 31717](https://sourceware.org/bugzilla/show_bug.cgi?id=31717), 2024-08-01).
  That commit landed *after* the 2.40.0 release, so it first ships in
  **glibc 2.41**
  ([glibc-2.41 `elf/dl-tls.c` L1157](https://github.com/bminor/glibc/blob/glibc-2.41/elf/dl-tls.c#L1157))
  and was backported to the **glibc 2.40 stable branch** (2.40.x); **2.40.0 and
  2.39 do not have it**.
- So this bites **glibc ≤ 2.40.0** (e.g. Ubuntu 24.04 / glibc 2.39). Note: bug
  31717 targets the "re-initialize already-allocated TLS" path; it reworks the
  same function but isn't verbatim this failed-probe scenario, so whether the
  rework fully closes this specific case is worth a check on a 2.41 / 2.40.x
  system. Either way the fix here removes the trigger regardless of glibc
  version, and avoids the wasted probe loads.





