### PR TITLE
Add small benchmark against librosa

### DIFF
--- a/benchmarks/decoders/benchmark_librosa.py
+++ b/benchmarks/decoders/benchmark_librosa.py
@@ -1,0 +1,216 @@
+import io
+import os
+import subprocess
+from time import perf_counter_ns
+
+import librosa
+import torch
+
+import torchcodec
+from torchcodec.decoders import AudioDecoder, WavDecoder
+
+
+def bench(f, *args, num_exp=100, warmup=0, **kwargs):
+
+    for _ in range(warmup):
+        f(*args, **kwargs)
+
+    times = []
+    for _ in range(num_exp):
+        start = perf_counter_ns()
+        f(*args, **kwargs)
+        end = perf_counter_ns()
+        times.append(end - start)
+    return torch.tensor(times).float()
+
+
+def report_stats(times, unit="ms"):
+    mul = {
+        "ns": 1,
+        "µs": 1e-3,
+        "ms": 1e-6,
+        "s": 1e-9,
+    }[unit]
+    times = times * mul
+    std = times.std().item()
+    med = times.median().item()
+    print(f"{med = :.2f}{unit} +- {std:.2f}")
+    return med
+
+
+AUDIO_DIR = "/tmp/librosa_bench_files"
+
+# For .wav we decode with torchcodec's WavDecoder, for .mp3 with AudioDecoder.
+FORMATS = {
+    "wav": ("pcm_s16le", "wav"),
+    "mp3": ("libmp3lame", "mp3"),
+}
+
+DURATIONS = {
+    "10s": 10,
+    "30s": 30,
+    "1min": 60,
+}
+
+# The ffmpeg-generated sine inputs are at 44100 Hz, so 16kHz is a downsample
+# and 48kHz is an upsample.
+RESAMPLE_RATES = {
+    "downsample 16kHz": 16000,
+    "upsample 48kHz": 48000,
+}
+
+
+def generate_files():
+    os.makedirs(AUDIO_DIR, exist_ok=True)
+    for fmt_name, (codec, ext) in FORMATS.items():
+        for dur_name, dur_seconds in DURATIONS.items():
+            path = os.path.join(AUDIO_DIR, f"{fmt_name}_{dur_name}.{ext}")
+            if os.path.exists(path):
+                continue
+            print(f"Generating {path} ...")
+            subprocess.run(
+                [
+                    "ffmpeg",
+                    "-y",
+                    "-f",
+                    "lavfi",
+                    "-i",
+                    f"sine=frequency=440:duration={dur_seconds}",
+                    "-c:a",
+                    codec,
+                    path,
+                ],
+                check=True,
+                capture_output=True,
+            )
+
+
+def decode_wav_torchcodec(raw_bytes):
+    return WavDecoder(raw_bytes).get_all_samples().data
+
+
+def decode_audio_torchcodec(raw_bytes):
+    return AudioDecoder(raw_bytes).get_all_samples().data
+
+
+def decode_librosa(raw_bytes, sample_rate=None):
+    # sample_rate=None -> decode at the file's native sample rate (no resampling).
+    # When resampling, we explicitly use soxr (librosa's default res_type since 0.10).
+    data, sr = librosa.load(
+        io.BytesIO(raw_bytes), sr=sample_rate, mono=False, res_type="soxr_hq"
+    )
+    return data
+
+
+def decode_resample_torchcodec(raw_bytes, sample_rate):
+    # WavDecoder does not support resampling, so AudioDecoder is used for both
+    # wav and mp3 in the resampling benchmark.
+    return AudioDecoder(raw_bytes, sample_rate=sample_rate).get_all_samples().data
+
+
+def main():
+    print(f"torchcodec: {torchcodec.__version__}")
+    print(f"librosa:    {librosa.__version__}")
+    generate_files()
+
+    results = []
+
+    for fmt_name, (_, ext) in FORMATS.items():
+        for dur_name in DURATIONS:
+            path = os.path.join(AUDIO_DIR, f"{fmt_name}_{dur_name}.{ext}")
+            with open(path, "rb") as f:
+                raw_bytes = f.read()
+            num_exp = 30 if dur_name == "1min" else 100
+
+            tc_decode = (
+                decode_wav_torchcodec
+                if fmt_name == "wav"
+                else decode_audio_torchcodec
+            )
+            tc_name = "WavDecoder" if fmt_name == "wav" else "AudioDecoder"
+
+            print(f"\n=== {fmt_name} / {dur_name} ({path}) ===")
+
+            print(f"  torchcodec ({tc_name}): ", end="")
+            tc_times = bench(tc_decode, raw_bytes, num_exp=num_exp, warmup=2)
+            tc_med = report_stats(tc_times)
+
+            print("  librosa (soxr): ", end="")
+            lr_times = bench(decode_librosa, raw_bytes, num_exp=num_exp, warmup=2)
+            lr_med = report_stats(lr_times)
+
+            results.append((fmt_name, dur_name, tc_name, tc_med, lr_med))
+
+    print("\n" + "=" * 80)
+    print("SUMMARY")
+    print("=" * 80)
+    print(
+        f"{'format':<8} {'duration':<10} {'decoder':<14} "
+        f"{'torchcodec (ms)':>16} {'librosa (ms)':>14} {'librosa/tc':>12}"
+    )
+    print("-" * 80)
+    for fmt_name, dur_name, tc_name, tc_med, lr_med in results:
+        ratio = lr_med / tc_med if tc_med > 0 else float("inf")
+        print(
+            f"{fmt_name:<8} {dur_name:<10} {tc_name:<14} "
+            f"{tc_med:>16.2f} {lr_med:>14.2f} {ratio:>11.2f}x"
+        )
+
+
+def bench_resampling():
+    print("\n" + "=" * 80)
+    print("RESAMPLING (torchcodec AudioDecoder vs librosa soxr_hq)")
+    print("=" * 80)
+
+    results = []
+    for fmt_name, (_, ext) in FORMATS.items():
+        for dur_name in DURATIONS:
+            path = os.path.join(AUDIO_DIR, f"{fmt_name}_{dur_name}.{ext}")
+            with open(path, "rb") as f:
+                raw_bytes = f.read()
+            num_exp = 30 if dur_name == "1min" else 100
+
+            for rate_name, target_sr in RESAMPLE_RATES.items():
+                print(f"\n=== {fmt_name} / {dur_name} / {rate_name} ({target_sr}) ===")
+
+                print("  torchcodec (AudioDecoder): ", end="")
+                tc_times = bench(
+                    decode_resample_torchcodec,
+                    raw_bytes,
+                    target_sr,
+                    num_exp=num_exp,
+                    warmup=2,
+                )
+                tc_med = report_stats(tc_times)
+
+                print("  librosa (soxr_hq): ", end="")
+                lr_times = bench(
+                    decode_librosa,
+                    raw_bytes,
+                    target_sr,
+                    num_exp=num_exp,
+                    warmup=2,
+                )
+                lr_med = report_stats(lr_times)
+
+                results.append((fmt_name, dur_name, rate_name, tc_med, lr_med))
+
+    print("\n" + "=" * 80)
+    print("RESAMPLING SUMMARY")
+    print("=" * 80)
+    print(
+        f"{'format':<8} {'duration':<10} {'resample':<18} "
+        f"{'torchcodec (ms)':>16} {'librosa (ms)':>14} {'librosa/tc':>12}"
+    )
+    print("-" * 80)
+    for fmt_name, dur_name, rate_name, tc_med, lr_med in results:
+        ratio = lr_med / tc_med if tc_med > 0 else float("inf")
+        print(
+            f"{fmt_name:<8} {dur_name:<10} {rate_name:<18} "
+            f"{tc_med:>16.2f} {lr_med:>14.2f} {ratio:>11.2f}x"
+        )
+
+
+if __name__ == "__main__":
+    main()
+    bench_resampling()


### PR DESCRIPTION
A quick and dirty benchmark against librosa+soxr on my laptop, with and without resampling. This PR isn't meant to be merged.
I haven't verified whether the results generalize to other archs / software versions etc. This is just to show that "it's close".


Without resampling:

```
================================================================================
SUMMARY
================================================================================
format   duration   decoder         torchcodec (ms)   librosa (ms)   librosa/tc
--------------------------------------------------------------------------------
wav      10s        WavDecoder                 0.10           0.78        8.10x
wav      30s        WavDecoder                 0.25           2.31        9.39x
wav      1min       WavDecoder                 0.48           4.47        9.32x
mp3      10s        AudioDecoder               3.99           3.64        0.91x
mp3      30s        AudioDecoder              11.85          10.98        0.93x
mp3      1min       AudioDecoder              23.20          21.81        0.94x


~/dev/torchcodec (bench_librosa*) » python benchmarks/decoders/benchmark_librosa.py
torchcodec: 0.15.0a0+eeb61c7
librosa:    0.11.0

=== wav / 10s (/tmp/librosa_bench_files/wav_10s.wav) ===
  torchcodec (WavDecoder): med = 0.10ms +- 0.00
  librosa (soxr): med = 0.78ms +- 0.06

=== wav / 30s (/tmp/librosa_bench_files/wav_30s.wav) ===
  torchcodec (WavDecoder): med = 0.25ms +- 0.11
  librosa (soxr): med = 2.31ms +- 0.17

=== wav / 1min (/tmp/librosa_bench_files/wav_1min.wav) ===
  torchcodec (WavDecoder): med = 0.48ms +- 0.19
  librosa (soxr): med = 4.47ms +- 0.14

=== mp3 / 10s (/tmp/librosa_bench_files/mp3_10s.mp3) ===
  torchcodec (AudioDecoder): med = 3.99ms +- 0.20
  librosa (soxr): med = 3.64ms +- 0.09

=== mp3 / 30s (/tmp/librosa_bench_files/mp3_30s.mp3) ===
  torchcodec (AudioDecoder): med = 11.85ms +- 0.28
  librosa (soxr): med = 10.98ms +- 0.15

=== mp3 / 1min (/tmp/librosa_bench_files/mp3_1min.mp3) ===
  torchcodec (AudioDecoder): med = 23.20ms +- 0.29
  librosa (soxr): med = 21.81ms +- 0.15

```

With resampling (our fast WavDecoder doesn't support resampling (yet?)):

```
================================================================================
RESAMPLING SUMMARY
================================================================================
format   duration   resample            torchcodec (ms)   librosa (ms)   librosa/tc
--------------------------------------------------------------------------------
wav      10s        downsample 16kHz               9.09           2.49        0.27x
wav      10s        upsample 48kHz                 9.49           4.20        0.44x
wav      30s        downsample 16kHz              12.37           7.16        0.58x
wav      30s        upsample 48kHz                13.60          12.28        0.90x
wav      1min       downsample 16kHz              16.70          14.72        0.88x
wav      1min       upsample 48kHz                19.71          30.59        1.55x
mp3      10s        downsample 16kHz               5.32           5.35        1.01x
mp3      10s        upsample 48kHz                 5.60           7.07        1.26x
mp3      30s        downsample 16kHz              14.97          15.90        1.06x
mp3      30s        upsample 48kHz                16.27          21.29        1.31x
mp3      1min       downsample 16kHz              29.61          32.06        1.08x
mp3      1min       upsample 48kHz                32.65          47.81        1.46x

=== wav / 10s / downsample 16kHz (16000) ===
  torchcodec (AudioDecoder): med = 9.09ms +- 0.21
  librosa (soxr_hq): med = 2.49ms +- 0.13

=== wav / 10s / upsample 48kHz (48000) ===
  torchcodec (AudioDecoder): med = 9.49ms +- 0.23
  librosa (soxr_hq): med = 4.20ms +- 0.15

=== wav / 30s / downsample 16kHz (16000) ===
  torchcodec (AudioDecoder): med = 12.37ms +- 1.72
  librosa (soxr_hq): med = 7.16ms +- 0.64

=== wav / 30s / upsample 48kHz (48000) ===
  torchcodec (AudioDecoder): med = 13.60ms +- 0.23
  librosa (soxr_hq): med = 12.28ms +- 0.31

=== wav / 1min / downsample 16kHz (16000) ===
  torchcodec (AudioDecoder): med = 16.70ms +- 1.18
  librosa (soxr_hq): med = 14.72ms +- 1.43

=== wav / 1min / upsample 48kHz (48000) ===
  torchcodec (AudioDecoder): med = 19.71ms +- 0.39
  librosa (soxr_hq): med = 30.59ms +- 1.87

=== mp3 / 10s / downsample 16kHz (16000) ===
  torchcodec (AudioDecoder): med = 5.32ms +- 0.82
  librosa (soxr_hq): med = 5.35ms +- 0.44

=== mp3 / 10s / upsample 48kHz (48000) ===
  torchcodec (AudioDecoder): med = 5.60ms +- 0.10
  librosa (soxr_hq): med = 7.07ms +- 0.15

=== mp3 / 30s / downsample 16kHz (16000) ===
  torchcodec (AudioDecoder): med = 14.97ms +- 0.28
  librosa (soxr_hq): med = 15.90ms +- 0.55

=== mp3 / 30s / upsample 48kHz (48000) ===
  torchcodec (AudioDecoder): med = 16.27ms +- 0.31
  librosa (soxr_hq): med = 21.29ms +- 0.28

=== mp3 / 1min / downsample 16kHz (16000) ===
  torchcodec (AudioDecoder): med = 29.61ms +- 1.44
  librosa (soxr_hq): med = 32.06ms +- 0.33

=== mp3 / 1min / upsample 48kHz (48000) ===
  torchcodec (AudioDecoder): med = 32.65ms +- 0.27
  librosa (soxr_hq): med = 47.81ms +- 0.39


```