### PR TITLE
Unify Cmake and BUCK source files

### DIFF
--- a/src/torchcodec/_core/CMakeLists.txt
+++ b/src/torchcodec/_core/CMakeLists.txt
@@ -6,7 +6,36 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(PYBIND11_FINDPYTHON ON)
 find_package(pybind11 REQUIRED)
 find_package(Torch REQUIRED)
-find_package(Python3 ${PYTHON_VERSION} EXACT COMPONENTS Development)
+find_package(Python3 ${PYTHON_VERSION} EXACT COMPONENTS Development Interpreter)
+
+# Read a list variable from sources.bzl, the single source of truth for the
+# _core C++ source files shared with the internal Buck build. The .bzl file is
+# valid Python, so we exec it and print the requested list; configure_file
+# registers it as a dependency so re-running CMake picks up edits.
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/sources.bzl
+    ${CMAKE_CURRENT_BINARY_DIR}/sources.bzl
+    COPYONLY)
+
+function(read_sources_from_bzl output_var list_name)
+    execute_process(
+        COMMAND "${Python3_EXECUTABLE}" -c
+            "exec(open('${CMAKE_CURRENT_SOURCE_DIR}/sources.bzl').read()); print(';'.join(${list_name}))"
+        OUTPUT_VARIABLE _sources
+        RESULT_VARIABLE _retval
+        OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(NOT _retval EQUAL 0)
+        message(FATAL_ERROR "Failed to read '${list_name}' from sources.bzl")
+    endif()
+    set(${output_var} ${_sources} PARENT_SCOPE)
+endfunction()
+
+read_sources_from_bzl(TORCHCODEC_DECODER_CORE_SOURCES decoder_core_sources)
+read_sources_from_bzl(TORCHCODEC_FFMPEG_COMMON_SOURCES ffmpeg_common_sources)
+read_sources_from_bzl(TORCHCODEC_DECODER_CORE_CUDA_SOURCES decoder_core_cuda_sources)
+read_sources_from_bzl(TORCHCODEC_FILE_LIKE_CONTEXT_SOURCES file_like_context_sources)
+read_sources_from_bzl(TORCHCODEC_CUSTOM_OPS_SOURCES custom_ops_sources)
+read_sources_from_bzl(TORCHCODEC_PYBIND_OPS_SOURCES pybind_ops_sources)
 
 if(DEFINED TORCHCODEC_DISABLE_COMPILE_WARNING_AS_ERROR AND TORCHCODEC_DISABLE_COMPILE_WARNING_AS_ERROR)
     set(TORCHCODEC_WERROR_OPTION "")
@@ -126,28 +155,13 @@ function(make_torchcodec_libraries
     # 1. Create libtorchcodec_coreN.{ext}.
     set(core_library_name "libtorchcodec_core${ffmpeg_major_version}")
     set(core_sources
-        AVIOContextHolder.cpp
-        AVIOTensorContext.cpp
-        AVIOFileContext.cpp
-        FFMPEGCommon.cpp
-        FilterGraph.cpp
-        Frame.cpp
-        DeviceInterface.cpp
-        CpuDeviceInterface.cpp
-        SingleStreamDecoder.cpp
-        Encoder.cpp
-        ValidationUtils.cpp
-        Transform.cpp
-        Metadata.cpp
-        SwScale.cpp
-        WavDecoder.cpp
-        NVDECCacheConfig.cpp
-        Logging.cpp
+        ${TORCHCODEC_DECODER_CORE_SOURCES}
+        ${TORCHCODEC_FFMPEG_COMMON_SOURCES}
     )
 
     if(ENABLE_CUDA)
         enable_language(CUDA)
-	    list(APPEND core_sources CudaDeviceInterface.cpp BetaCudaDeviceInterface.cpp NVDECCache.cpp CUDACommon.cpp NVCUVIDRuntimeLoader.cpp color_conversion.cpp color_conversion.cu)
+        list(APPEND core_sources ${TORCHCODEC_DECODER_CORE_CUDA_SOURCES})
     endif()
 
     set(core_library_dependencies
@@ -181,7 +195,7 @@ function(make_torchcodec_libraries
     # 2. Create libtorchcodec_custom_opsN.{ext}.
     set(custom_ops_library_name "libtorchcodec_custom_ops${ffmpeg_major_version}")
     set(custom_ops_sources
-        custom_ops.cpp
+        ${TORCHCODEC_CUSTOM_OPS_SOURCES}
     )
     set(custom_ops_dependencies
         ${core_library_name}
@@ -197,8 +211,8 @@ function(make_torchcodec_libraries
     # 3. Create libtorchcodec_pybind_opsN.so.
     set(pybind_ops_library_name "libtorchcodec_pybind_ops${ffmpeg_major_version}")
     set(pybind_ops_sources
-        AVIOFileLikeContext.cpp
-        pybind_ops.cpp
+        ${TORCHCODEC_FILE_LIKE_CONTEXT_SOURCES}
+        ${TORCHCODEC_PYBIND_OPS_SOURCES}
     )
     set(pybind_ops_dependencies
        ${core_library_name}

--- a/src/torchcodec/_core/sources.bzl
+++ b/src/torchcodec/_core/sources.bzl
@@ -1,0 +1,76 @@
+# Single source of truth for torchcodec's _core C++ source file lists.
+#
+# These lists are consumed by BOTH build systems so that adding or removing a
+# source file only requires editing this one file:
+# - CMake (the GitHub/OSS build) reads it from CMakeLists.txt in this directory.
+# - Buck (the internal Meta build) loads it from src/BUCK.
+#
+# This file must stay syntactically valid as BOTH Starlark (so Buck can `load()`
+# it) and Python (CMake execs it with the Python interpreter to extract the
+# lists). Only plain list literals and list comprehensions are allowed here: no
+# functions, no `load()`, no `select()`, no f-strings, no Starlark-only or
+# Python-only constructs.
+#
+# Filenames are listed WITHOUT a directory prefix: they live next to this file
+# in src/torchcodec/_core/. CMake runs from this directory and uses them as-is;
+# Buck prepends the "torchcodec/_core/" path prefix at load time.
+#
+# The lists are intentionally fine-grained building blocks so each build system
+# can compose exactly the targets it needs without changing what gets compiled.
+# The two builds group these differently (e.g. CMake compiles FFMPEGCommon.cpp
+# into the core library while Buck builds it as a separate target), so do not
+# merge the lists.
+
+# CPU sources for the core decoder library. Does NOT include FFMPEGCommon.cpp
+# (see ffmpeg_common_sources): the Buck build compiles that into a separate
+# "core_common" target.
+decoder_core_sources = [
+    "AVIOContextHolder.cpp",
+    "AVIOTensorContext.cpp",
+    "AVIOFileContext.cpp",
+    "FilterGraph.cpp",
+    "Frame.cpp",
+    "DeviceInterface.cpp",
+    "CpuDeviceInterface.cpp",
+    "SingleStreamDecoder.cpp",
+    "Encoder.cpp",
+    "ValidationUtils.cpp",
+    "Transform.cpp",
+    "Metadata.cpp",
+    "SwScale.cpp",
+    "WavDecoder.cpp",
+    "NVDECCacheConfig.cpp",
+    "Logging.cpp",
+]
+
+# FFmpeg glue. Part of the core library under CMake; a standalone "core_common"
+# target under Buck.
+ffmpeg_common_sources = [
+    "FFMPEGCommon.cpp",
+]
+
+# CUDA sources, added to the core library only for CUDA-enabled builds.
+decoder_core_cuda_sources = [
+    "CudaDeviceInterface.cpp",
+    "BetaCudaDeviceInterface.cpp",
+    "NVDECCache.cpp",
+    "CUDACommon.cpp",
+    "NVCUVIDRuntimeLoader.cpp",
+    "color_conversion.cpp",
+    "color_conversion.cu",
+]
+
+# Shared by both the custom-ops and pybind-ops libraries.
+file_like_context_sources = [
+    "AVIOFileLikeContext.cpp",
+]
+
+# PyTorch custom ops registration.
+custom_ops_sources = [
+    "custom_ops.cpp",
+]
+
+# pybind11 bindings.
+pybind_ops_sources = [
+    "pybind_ops.cpp",
+]


### PR DESCRIPTION
We have two build sustems: Cmake on GitHub, and BUCK on fbcode. We list out the source files separately in each system, which means that every time we add or remove a source file on GitHub, we have to update the BUCK system accordingly. And because of the way diff-train is setup, we have to create a separate diff for that, and that blocks the diff-train for a while. This is painful.

This PR is the first step to unify the source file specification under both build systems. We're doing what pytorch already does.