### PR TITLE
Update device agnostic encoding to support multiple devices

### DIFF
--- a/src/torchcodec/_core/CpuDeviceInterface.cpp
+++ b/src/torchcodec/_core/CpuDeviceInterface.cpp
@@ -5,10 +5,40 @@
 // LICENSE file in the root directory of this source tree.
 
 #include "CpuDeviceInterface.h"
+#include <sstream>
 
 namespace facebook::torchcodec {
 
 namespace {
+
+AVPixelFormat validate_pixel_format(
+    const AVCodec& av_codec,
+    const std::string& target_pixel_format) {
+  AVPixelFormat pixel_format = av_get_pix_fmt(target_pixel_format.c_str());
+  const AVPixelFormat* supported_formats =
+      get_supported_pixel_formats(av_codec);
+  if (supported_formats != nullptr) {
+    for (int i = 0; supported_formats[i] != AV_PIX_FMT_NONE; ++i) {
+      if (supported_formats[i] == pixel_format) {
+        return pixel_format;
+      }
+    }
+  }
+  std::stringstream error_msg;
+  if (pixel_format == AV_PIX_FMT_NONE) {
+    error_msg << "Unknown pixel format: " << target_pixel_format;
+  } else {
+    error_msg << "Specified pixel format " << target_pixel_format
+              << " is not supported by the " << av_codec.name << " encoder.";
+  }
+  error_msg << "\nSupported pixel formats for " << av_codec.name << ":";
+  if (supported_formats != nullptr) {
+    for (int i = 0; supported_formats[i] != AV_PIX_FMT_NONE; ++i) {
+      error_msg << " " << av_get_pix_fmt_name(supported_formats[i]);
+    }
+  }
+  STD_TORCH_CHECK(false, error_msg.str());
+}
 
 AVPixelFormat get_output_pixel_format(OutputDtype output_dtype) {
   return output_dtype == OutputDtype::FLOAT32 ? AV_PIX_FMT_RGB48
@@ -26,6 +56,18 @@ static bool g_cpu = register_device_interface(
     [](const StableDevice& device) { return new CpuDeviceInterface(device); });
 
 } // namespace
+
+AVPixelFormat CpuDeviceInterface::get_encoding_pixel_format(
+    const AVCodec& av_codec,
+    const std::optional<std::string>& user_pixel_format) const {
+  if (user_pixel_format.has_value()) {
+    return validate_pixel_format(av_codec, user_pixel_format.value());
+  }
+  const AVPixelFormat* formats = get_supported_pixel_formats(av_codec);
+  // Pick the codec's first supported format (often yuv420p), else fall back.
+  return (formats && formats[0] != AV_PIX_FMT_NONE) ? formats[0]
+                                                    : AV_PIX_FMT_YUV420P;
+}
 
 CpuDeviceInterface::CpuDeviceInterface(const StableDevice& device)
     : DeviceInterface(device) {

--- a/src/torchcodec/_core/CpuDeviceInterface.h
+++ b/src/torchcodec/_core/CpuDeviceInterface.h
@@ -51,6 +51,10 @@ class CpuDeviceInterface : public DeviceInterface {
       int frame_index,
       AVCodecContext* codec_context) override;
 
+  AVPixelFormat get_encoding_pixel_format(
+      const AVCodec& av_codec,
+      const std::optional<std::string>& user_pixel_format) const override;
+
   std::string get_details() override;
 
  private:

--- a/src/torchcodec/_core/CudaDeviceInterface.cpp
+++ b/src/torchcodec/_core/CudaDeviceInterface.cpp
@@ -395,6 +395,16 @@ std::string CudaDeviceInterface::get_details() {
 // Below are methods exclusive to video encoding:
 // --------------------------------------------------------------------------
 
+AVPixelFormat CudaDeviceInterface::get_encoding_pixel_format(
+    [[maybe_unused]] const AVCodec& av_codec,
+    const std::optional<std::string>& user_pixel_format) const {
+  STD_TORCH_CHECK(
+      !user_pixel_format.has_value(),
+      "Video encoding on GPU currently only supports the nv12 pixel format. "
+      "Do not set pixel_format to use nv12 by default.");
+  return CudaDeviceInterface::CUDA_ENCODING_PIXEL_FORMAT;
+}
+
 UniqueAVFrame CudaDeviceInterface::convert_tensor_to_av_frame_for_encoding(
     const torch::stable::Tensor& tensor,
     int frame_index,
@@ -477,7 +487,7 @@ void CudaDeviceInterface::setup_hardware_frame_context_for_encoding(
       hw_frames_ctx_ref != nullptr,
       "Failed to allocate hardware frames context for codec");
 
-  codec_context->sw_pix_fmt = DeviceInterface::CUDA_ENCODING_PIXEL_FORMAT;
+  codec_context->sw_pix_fmt = CudaDeviceInterface::CUDA_ENCODING_PIXEL_FORMAT;
   // Always set pixel format to support CUDA encoding.
   codec_context->pix_fmt = AV_PIX_FMT_CUDA;
 

--- a/src/torchcodec/_core/CudaDeviceInterface.h
+++ b/src/torchcodec/_core/CudaDeviceInterface.h
@@ -15,6 +15,9 @@ namespace facebook::torchcodec {
 
 class CudaDeviceInterface : public DeviceInterface {
  public:
+  //  Pixel format used for encoding on CUDA devices.
+  static constexpr AVPixelFormat CUDA_ENCODING_PIXEL_FORMAT = AV_PIX_FMT_NV12;
+
   CudaDeviceInterface(const StableDevice& device);
 
   virtual ~CudaDeviceInterface();
@@ -49,6 +52,10 @@ class CudaDeviceInterface : public DeviceInterface {
       const torch::stable::Tensor& tensor,
       int frame_index,
       AVCodecContext* codec_context) override;
+
+  AVPixelFormat get_encoding_pixel_format(
+      const AVCodec& av_codec,
+      const std::optional<std::string>& user_pixel_format) const override;
 
   void setup_hardware_frame_context_for_encoding(
       AVCodecContext* codec_context) override;

--- a/src/torchcodec/_core/DeviceInterface.h
+++ b/src/torchcodec/_core/DeviceInterface.h
@@ -160,9 +160,6 @@ class DeviceInterface {
     return "";
   }
 
-  // Pixel format used for encoding on CUDA devices
-  static constexpr AVPixelFormat CUDA_ENCODING_PIXEL_FORMAT = AV_PIX_FMT_NV12;
-
   virtual UniqueAVFrame convert_tensor_to_av_frame_for_encoding(
       [[maybe_unused]] const torch::stable::Tensor& tensor,
       [[maybe_unused]] int frame_index,

--- a/src/torchcodec/_core/DeviceInterface.h
+++ b/src/torchcodec/_core/DeviceInterface.h
@@ -170,13 +170,18 @@ class DeviceInterface {
     STD_TORCH_CHECK(false, "convertTensorToAVFrameForEncoding not implemented");
   }
 
-  // Function used for video encoding, only implemented in CudaDeviceInterface.
-  // It is here to isolate CUDA dependencies from CPU builds
-  virtual void setup_hardware_frame_context_for_encoding(
-      [[maybe_unused]] AVCodecContext* codec_context) {
-    STD_TORCH_CHECK(
-        false, "setupHardwareFrameContextForEncoding not implemented");
+  // Returns the pixel format the encoder should use for this device.
+  virtual AVPixelFormat get_encoding_pixel_format(
+      [[maybe_unused]] const AVCodec& av_codec,
+      [[maybe_unused]] const std::optional<std::string>& user_pixel_format)
+      const {
+    STD_TORCH_CHECK(false, "get_encoding_pixel_format not implemented");
   }
+
+  // No-op on CPU so the encoder can call it unconditionally; HW devices
+  // override to attach an AVHWFramesContext.
+  virtual void setup_hardware_frame_context_for_encoding(
+      [[maybe_unused]] AVCodecContext* codec_context) {}
 
   virtual std::optional<const AVCodec*> find_hardware_encoder(
       [[maybe_unused]] const AVCodecID& codec_id) {

--- a/src/torchcodec/_core/Encoder.cpp
+++ b/src/torchcodec/_core/Encoder.cpp
@@ -176,38 +176,6 @@ torch::stable::Tensor validate_frames(
   return torch::stable::contiguous(frames);
 }
 
-AVPixelFormat validate_pixel_format(
-    const AVCodec& av_codec,
-    const std::string& target_pixel_format) {
-  AVPixelFormat pixel_format = av_get_pix_fmt(target_pixel_format.c_str());
-
-  // Validate that the encoder supports this pixel format
-  const AVPixelFormat* supported_formats =
-      get_supported_pixel_formats(av_codec);
-  if (supported_formats != nullptr) {
-    for (int i = 0; supported_formats[i] != AV_PIX_FMT_NONE; ++i) {
-      if (supported_formats[i] == pixel_format) {
-        return pixel_format;
-      }
-    }
-  }
-
-  std::stringstream error_msg;
-  // av_get_pix_fmt failed to find a pix_fmt
-  if (pixel_format == AV_PIX_FMT_NONE) {
-    error_msg << "Unknown pixel format: " << target_pixel_format;
-  } else {
-    error_msg << "Specified pixel format " << target_pixel_format
-              << " is not supported by the " << av_codec.name << " encoder.";
-  }
-  // Build error message, similar to FFmpeg's error log
-  error_msg << "\nSupported pixel formats for " << av_codec.name << ":";
-  for (int i = 0; supported_formats[i] != AV_PIX_FMT_NONE; ++i) {
-    error_msg << " " << av_get_pix_fmt_name(supported_formats[i]);
-  }
-  STD_TORCH_CHECK(false, error_msg.str());
-}
-
 void try_to_validate_codec_option(
     const AVCodec& av_codec,
     const char* option_name,
@@ -426,8 +394,6 @@ int MultiStreamEncoder::add_audio_stream(
 }
 
 void MultiStreamEncoder::initialize_video_stream(VideoStream& video_stream) {
-  auto device_type = video_stream.device_interface->device().type();
-
   const AVCodec* av_codec = nullptr;
   // If codec arg is provided, find codec using logic similar to FFmpeg:
   // https://github.com/FFmpeg/FFmpeg/blob/master/fftools/ffmpeg_opt.c#L804-L835
@@ -473,32 +439,10 @@ void MultiStreamEncoder::initialize_video_stream(VideoStream& video_stream) {
 
   int out_height = video_stream.in_height;
   int out_width = video_stream.in_width;
-  AVPixelFormat out_pixel_format = AV_PIX_FMT_NONE;
-
-  if (video_stream.options.pixel_format.has_value()) {
-    if (device_type == kStableCUDA) {
-      STD_TORCH_CHECK(
-          false,
-          "Video encoding on GPU currently only supports the nv12 pixel format. "
-          "Do not set pixel_format to use nv12 by default.");
-    }
-    out_pixel_format = validate_pixel_format(
-        *av_codec, video_stream.options.pixel_format.value());
-  } else {
-    if (device_type == kStableCUDA) {
-      // Default to nv12 pixel format when encoding on GPU.
-      out_pixel_format = DeviceInterface::CUDA_ENCODING_PIXEL_FORMAT;
-    } else {
-      const AVPixelFormat* formats = get_supported_pixel_formats(*av_codec);
-      // Use first listed pixel format as default (often yuv420p).
-      // This is similar to FFmpeg's logic:
-      // https://www.ffmpeg.org/doxygen/4.0/decode_8c_source.html#l01087
-      // If pixel formats are undefined for some reason, try yuv420p
-      out_pixel_format = (formats && formats[0] != AV_PIX_FMT_NONE)
-          ? formats[0]
-          : AV_PIX_FMT_YUV420P;
-    }
-  }
+  // Pixel-format selection is delegated to the device interface.
+  AVPixelFormat out_pixel_format =
+      video_stream.device_interface->get_encoding_pixel_format(
+          *av_codec, video_stream.options.pixel_format);
 
   // Configure codec parameters
   video_stream.av_codec_context->codec_id = av_codec->id;
@@ -542,13 +486,11 @@ void MultiStreamEncoder::initialize_video_stream(VideoStream& video_stream) {
         video_stream.options.preset.value().c_str(),
         0);
   }
-
-  if (device_type == kStableCUDA) {
-    video_stream.device_interface->register_hardware_device_with_codec(
-        video_stream.av_codec_context.get());
-    video_stream.device_interface->setup_hardware_frame_context_for_encoding(
-        video_stream.av_codec_context.get());
-  }
+  // Hardware setup is a no-op on CPU; HW devices override these hooks.
+  video_stream.device_interface->register_hardware_device_with_codec(
+      video_stream.av_codec_context.get());
+  video_stream.device_interface->setup_hardware_frame_context_for_encoding(
+      video_stream.av_codec_context.get());
 
   int status = avcodec_open2(
       video_stream.av_codec_context.get(),

--- a/test/third-party-interface/ThirdPartyInterfaceTest.cpp
+++ b/test/third-party-interface/ThirdPartyInterfaceTest.cpp
@@ -29,6 +29,17 @@ class DummyDeviceInterface : public DeviceInterface {
       std::optional<torch::stable::Tensor> pre_allocated_output_tensor =
           std::nullopt) override {}
 
+  // Encoder-side hooks added to exercise the third-party API surface at build
+  // time.
+  AVPixelFormat get_encoding_pixel_format(
+      const AVCodec& /*av_codec*/,
+      const std::optional<std::string>& /*user_pixel_format*/) const override {
+    return AV_PIX_FMT_NONE;
+  }
+
+  void setup_hardware_frame_context_for_encoding(
+      AVCodecContext* /*codec_context*/) override {}
+
  private:
   std::unique_ptr<FilterGraph> filter_graph_context_;
 };


### PR DESCRIPTION
## Enable hardware-agnostic encoding in `MultiStreamEncoder` (XPU plugin support)

Signed-off-by: Edgar Romo Montiel <edgar.romo.montiel@intel.com> 
Co-Authored-by: Dmitry Rogozhkin <dmitry.v.rogozhkin@intel.com>

### Summary
This PR makes `MultiStreamEncoder` hardware-agnostic by moving every device-specific step of the video-encoding pipeline behind the existing `DeviceInterface` abstraction. The immediate motivation is enabling Intel **XPU** hardware encoding through the external torchcodec plugin mechanism, without requiring any further changes to the core encoder.

Companion PR (XPU plugin implementation):
https://github.com/intel/torchlib-xpu/pull/58

### Motivation
Prior to this change, `Encoder.cpp` had CUDA-specific branches for codec discovery, pixel-format selection, hardware-frame context setup, and tensor→`AVFrame` conversion. That prevented any other backend (XPU, or any future device) from providing hardware encoding without patching the core encoder.

By promoting those steps to virtual hooks on `DeviceInterface`, each backend (CPU, CUDA, XPU plugin, …) implements only the pieces it needs, and `MultiStreamEncoder` remains device-neutral.

### What changed
- `DeviceInterface`  new / generalized virtual methods used by the encoder:
  - `find_codec(codec_id, is_decoder=false)`   allow a device to substitute the container’s default codec with its hardware equivalent.
  - `get_encoding_pixel_format(av_codec, user_pixel_format)`  pixel-format selection is delegated to the device.
  - `register_hardware_device_with_codec(codec_context)`  no-op on CPU, attaches the `AVHWDeviceContext` on HW backends.
  - `setup_hardware_frame_context_for_encoding(codec_context)`   no-op on CPU, attaches an `AVHWFramesContext` on HW backends.
  - `convert_tensor_to_av_frame_for_encoding(tensor, frame_index, codec_context)`   device owns tensor→`AVFrame` conversion (upload, tiling, colour conversion, etc.).
- `Encoder.cpp` (`MultiStreamEncoder::initialize_video_stream` and `add_frames`)   CUDA-specific branches removed and replaced with unconditional calls to the hooks above. The CPU path is preserved via default no-op implementations.
- `CpuDeviceInterface` / `CudaDeviceInterface`  existing behaviour preserved by implementing the new hooks (CUDA keeps NV12 default, hardware frames context, and `nvenc` codec substitution).
- Plugin surface (`test/plugin/`, `torchcodec/_core/DeviceInterface.h`) unchanged in shape, the XPU plugin implements the same virtual interface out-of-tree.

### Design notes
- Backwards compatible: CPU and CUDA paths take the exact same code path as before; only indirection level changed.
- No new public Python API. This is a C++ core refactor.
- The XPU plugin lives out-of-tree (see companion PR) and is loaded via the existing plugin registration mechanism (`register_device_interface`).

### Testing
- XPU encoding: manually verified end-to-end on Intel XPU hardware using the plugin from intel/torchlib-xpu

### Risk / compatibility
- Internal refactor only. No API break, no behavioural change for existing CPU/CUDA users.
- All new virtual methods have safe default implementations (no-op or `STD_TORCH_CHECK(false, ...)`) so unrelated backends fail loudly rather than silently misbehave.

### Follow-ups (out of scope)
- Upstream XPU-specific tests once the plugin is stabilised.
- Consider similarly generalising the audio-encoding path when a hardware audio backend becomes relevant.

---

Thanks in advance for the review, happy to split further or adjust the hook naming/signatures if that helps land this cleanly.


CC: @dvrogozh, @NicolasHug, @Dan-Flores