### PR TITLE
Fix CUDA decoder dropping frames before the first IDR

### DIFF
--- a/src/torchcodec/_core/BetaCudaDeviceInterface.cpp
+++ b/src/torchcodec/_core/BetaCudaDeviceInterface.cpp
@@ -349,18 +349,47 @@ void BetaCudaDeviceInterface::initialize_video(
   // pass it via pExtVideoInfo. Same approach as DALI and FFmpeg cuviddec.
   // DALI does the same thing
   // https://github.com/NVIDIA/DALI/blob/ae79f316ae9b14c464d9cb98465f7f783da9ea89/dali/operators/video/frames_decoder_gpu.cc#L402-L408
-  if (codec_par->extradata_size > 0) {
+  //
+  const uint8_t* seqhdr = codec_par->extradata;
+  int seqhdr_data_size = codec_par->extradata_size;
+  if (bitstream_filter_ && bitstream_filter_->par_out->extradata_size > 0) {
+    // when a BSF is used (e.g. h264_mp4toannexb), we must pass the
+    // *filtered* extradata!
+    seqhdr = bitstream_filter_->par_out->extradata;
+    seqhdr_data_size = bitstream_filter_->par_out->extradata_size;
+  }
+  if (seqhdr_data_size > 0) {
     auto seqhdr_size = std::min(
-        static_cast<size_t>(codec_par->extradata_size),
+        static_cast<size_t>(seqhdr_data_size),
         sizeof(parser_ext_info_.raw_seqhdr_data));
     parser_ext_info_.format.seqhdr_data_length = seqhdr_size;
-    memcpy(parser_ext_info_.raw_seqhdr_data, codec_par->extradata, seqhdr_size);
+    memcpy(parser_ext_info_.raw_seqhdr_data, seqhdr, seqhdr_size);
     parser_params.pExtVideoInfo = &parser_ext_info_;
   }
 
   CUresult result = cuvidCreateVideoParser(&video_parser_, &parser_params);
   STD_TORCH_CHECK(
       result == CUDA_SUCCESS, "Failed to create video parser: ", result);
+
+  send_seqhdr_packet();
+}
+
+void BetaCudaDeviceInterface::send_seqhdr_packet() {
+  // This must be called at parser initialization, and after each flush.
+  // See TODO for details.
+  // FFmpeg's nvcuviddec.c does the same thing (not the nvdec.c one, because it
+  // doesn't rely on the nvcuvid parser):
+  // -
+  // https://github.com/FFmpeg/FFmpeg/blob/d244d438c372b76d825be4527fccfd162429010a/libavcodec/cuviddec.c#L1211
+  // -
+  // https://github.com/FFmpeg/FFmpeg/blob/d244d438c372b76d825be4527fccfd162429010a/libavcodec/cuviddec.c#L1157
+  if (parser_ext_info_.format.seqhdr_data_length == 0) {
+    return;
+  }
+  CUVIDSOURCEDATAPACKET seq_pkt = {};
+  seq_pkt.payload = parser_ext_info_.raw_seqhdr_data;
+  seq_pkt.payload_size = parser_ext_info_.format.seqhdr_data_length;
+  send_cuvid_packet(seq_pkt);
 }
 
 BetaCudaDeviceInterface::~BetaCudaDeviceInterface() {
@@ -790,6 +819,8 @@ void BetaCudaDeviceInterface::flush() {
 
   std::queue<CUVIDPARSERDISPINFO> empty_queue;
   std::swap(ready_frames_, empty_queue);
+
+  send_seqhdr_packet();
 }
 
 UniqueAVFrame BetaCudaDeviceInterface::transfer_cpu_frame_to_gpu(

--- a/src/torchcodec/_core/BetaCudaDeviceInterface.h
+++ b/src/torchcodec/_core/BetaCudaDeviceInterface.h
@@ -72,6 +72,8 @@ class BetaCudaDeviceInterface : public DeviceInterface {
  private:
   int send_cuvid_packet(CUVIDSOURCEDATAPACKET& cuvid_packet);
 
+  void send_seqhdr_packet();
+
   void initialize_bsf(
       const AVCodecParameters* codec_par,
       const UniqueDecodingAVFormatContext& av_format_ctx);

--- a/test/test_decoders.py
+++ b/test/test_decoders.py
@@ -2062,6 +2062,42 @@ class TestVideoDecoder:
         # pixel mismatches] (BT.601 vs BT.709 color matrix mismatch between the
         # ffmpeg and default cuda backend for this MPEG4 asset).
 
+    @pytest.mark.skip(reason="Assets not checked in; run manually with them present.")
+    @needs_cuda
+    @pytest.mark.parametrize(
+        "path", ("./youtube-1HYJQESw3hs.mp4", "./youtube-c_B4XII1L6A.mp4")
+    )
+    @pytest.mark.parametrize("seek_mode", ("exact", "approximate"))
+    def test_cuda_open_gop_late_idr(self, path, seek_mode):
+        # Non-regression test for open-GOP H.264 files whose only IDR is not at
+        # the start of the stream: the in-band SPS/PPS only shows up at that
+        # late IDR. NVDEC used to have no usable sequence header until then, so
+        # it dropped every frame before the IDR, returned shifted frames, and
+        # hit a premature EOF on a full/sequential decode. CPU is unaffected and
+        # serves as the reference here.
+        cpu_decoder = VideoDecoder(path, device="cpu", seek_mode=seek_mode)
+        cuda_decoder = VideoDecoder(path, device="cuda", seek_mode=seek_mode)
+
+        assert cpu_decoder.metadata == cuda_decoder.metadata
+        num_frames = cpu_decoder.metadata.num_frames
+
+        # Full sequential decode must not raise and must yield every frame (the
+        # `dec[:]` / `dec[:54]` failures we're guarding against).
+        assert cuda_decoder[:].shape[0] == num_frames
+
+        # Frames must not be shifted: pts must match the CPU reference exactly,
+        # and pixels must be close. Exact pixel equality is skipped because CPU
+        # and CUDA use different color-conversion matrices; a shifted/wrong frame
+        # would show a large diff, so a tolerant mean check cleanly catches it.
+        for i in [0, 1, 53, num_frames // 2, num_frames - 1]:
+            cpu_frame = cpu_decoder.get_frame_at(i)
+            cuda_frame = cuda_decoder.get_frame_at(i)
+            assert cuda_frame.pts_seconds == cpu_frame.pts_seconds
+            mean_abs_diff = (
+                (cuda_frame.data.cpu().float() - cpu_frame.data.float()).abs().mean()
+            )
+            assert mean_abs_diff < 5
+
     @needs_cuda
     def test_nvdec_cuda_interface_cpu_fallback(self):
         # Non-regression test for the CPU fallback behavior of the NVDEC CUDA


### PR DESCRIPTION
Addresses at least part of https://github.com/meta-pytorch/torchcodec/issues/1502

This fixes decoding on `youtube-c_B4XII1L6A.mp4` (shared from drive link [drive.google.com/file/d/1NQ_FsrVKaDHFA6weuVNYlKM0b-qOlB9Z/view?usp=drive_link](https://drive.google.com/file/d/1NQ_FsrVKaDHFA6weuVNYlKM0b-qOlB9Z/view?usp=drive_link) in https://github.com/meta-pytorch/torchcodec/issues/1502) and `youtube-1HYJQESw3hs.mp4` (from LSVQ video quality dataset [baidut/PatchVQ](https://github.com/baidut/PatchVQ?rgh-link-date=2026-07-09T05%3A24%3A16.000Z), in `ia-batch23.zip` with `LIVE2020` password)

----

## Context

Keyframes can be IDR or "recovery-point" I-frames. What that means doesn't matter - what matters is that there are two kinds of I-Frames.

Before the decoder can decode any frame it needs the sequence header (SPS/PPS for H.264). That header lives either in the container header (MP4's avcC box) or in-band in the stream, where our BSF will inject it before any IDR frames (not at recovery-point I-frames!). The NVCUVID parser only reliably starts decoding once it has parsed a sequence header out of the bitstream.

Most files - or at least those we have used the CUDA decoder on, start with an IDR at frame 0. The SPS is right there in-band, and on seeks you always land on another IDR that re-supplies it. torchcodec's `main` branch  therefore worked for them.

But the problematic files mentioned above are open-GOP with a single, late IDR (e.g. slice 251/69). Frame 0 is a recovery-point I-frame with no in-band SPS; the only in-band SPS appears at that late IDR. So the parser had nothing to initialize from and NVCUVID  dropped every frame until the IDR - treating frame ~251 as frame 0, shifting everything, and hitting a genuine-but-premature EOF.

## The fix (mirrors FFmpeg's cuviddec.c).
  1. Convert the avcC header to Annex-B (via the `h264_mp4toannexb` BSF output) so it's valid bytes the parser can read. Previously `parser_params.pExtVideoInfo` was fed avcC (non-Annex-B) data it couldn't parse. We still set `pExtVideoInfo` (with Annex-B now, matching FFmpeg), but it turns out `pExtVideoInfo` is redundant — the Annex-B bytes matter because they're what step 2's packet carries.
  2. Feed that header to the parser as an explicit data packet - this is the mechanism that actually makes the parser start decoding, independent of where the first in-band IDR is. We do this at init and after every flush (flush = seek; it ends the parser's sequence and resets its state, so each new sequence must be re-primed - that's important when we seek to a non-IDR I-frame.