### PR TITLE
Avoid warning on Encoder's to_tensor()

### DIFF
--- a/src/torchcodec/encoders/_audio_encoder.py
+++ b/src/torchcodec/encoders/_audio_encoder.py
@@ -122,7 +122,7 @@ class AudioEncoder:
         )
         with encoder.open_file_like(buf, format=format):
             audio.add_samples(self._samples)
-        return torch.frombuffer(buf.getvalue(), dtype=torch.uint8).clone()
+        return torch.frombuffer(buf.getbuffer(), dtype=torch.uint8)
 
     def to_file_like(
         self,

--- a/src/torchcodec/encoders/_multi_stream_encoder.py
+++ b/src/torchcodec/encoders/_multi_stream_encoder.py
@@ -102,7 +102,7 @@ class Encoder:
             video_stream = encoder.add_video(height=256, width=256, frame_rate=30)
             with encoder.open_file_like(buf, format="mp4"):
                 video_stream.add_frames(frames_tensor)
-            encoded_bytes = buf.getvalue()
+            encoded_bytes = buf.getbuffer()  # or getvalue()
             # Optionally convert to a uint8 tensor of bytes with
             # bytes_tensor = torch.frombuffer(encoded_bytes, dtype=torch.uint8)
     """

--- a/src/torchcodec/encoders/_video_encoder.py
+++ b/src/torchcodec/encoders/_video_encoder.py
@@ -167,7 +167,7 @@ class VideoEncoder:
         )
         with encoder.open_file_like(buf, format=format):
             video.add_frames(self._frames)
-        return torch.frombuffer(buf.getvalue(), dtype=torch.uint8).clone()
+        return torch.frombuffer(buf.getbuffer(), dtype=torch.uint8)
 
     def to_file_like(
         self,

--- a/test/test_encoders.py
+++ b/test/test_encoders.py
@@ -4,6 +4,7 @@ import platform
 import re
 import subprocess
 import sys
+import warnings
 from functools import partial
 from pathlib import Path
 
@@ -139,9 +140,16 @@ class TestAudioEncoder:
         audio = enc.add_audio(sample_rate=sample_rate, num_channels=num_channels)
         with enc.open_file_like(buf, format="flac"):
             audio.add_samples(source_samples)
-        encoder_output = torch.frombuffer(buf.getvalue(), dtype=torch.uint8).clone()
+        encoder_output = torch.frombuffer(buf.getbuffer(), dtype=torch.uint8)
 
         torch.testing.assert_close(audio_encoder_output, encoder_output, rtol=0, atol=0)
+
+    def test_to_tensor_no_warning(self):
+        # Non-regression test for https://github.com/meta-pytorch/torchcodec/issues/1509
+        samples = torch.rand(2, 32_000, dtype=torch.float32)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            AudioEncoder(samples, sample_rate=32_000).to_tensor(format="flac")
 
 
 class TestVideoEncoder:
@@ -183,9 +191,16 @@ class TestVideoEncoder:
         )
         with enc.open_file_like(buf, format="mp4"):
             video.add_frames(source_frames)
-        encoder_output = torch.frombuffer(buf.getvalue(), dtype=torch.uint8).clone()
+        encoder_output = torch.frombuffer(buf.getbuffer(), dtype=torch.uint8)
 
         torch.testing.assert_close(video_encoder_output, encoder_output, rtol=0, atol=0)
+
+    def test_to_tensor_no_warning(self):
+        # Non-regression test for https://github.com/meta-pytorch/torchcodec/issues/1509
+        frames = torch.randint(0, 256, (10, 3, 64, 64), dtype=torch.uint8)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            VideoEncoder(frames, frame_rate=30).to_tensor(format="mp4")
 
 
 class TestEncoder:


### PR DESCRIPTION
And avoid copy. Fixes https://github.com/meta-pytorch/torchcodec/issues/1509