### PR TITLE
Modernize jpeg decoder

### DIFF
--- a/packaging/repair_wheel.py
+++ b/packaging/repair_wheel.py
@@ -17,7 +17,7 @@ the torch wheel).
 """
 
 import io
-import os  # only for os.environ / os.pathsep (env vars have no pathlib equivalent)
+import os
 import platform
 import shutil
 import subprocess

--- a/src/torchcodec/_core/CMakeLists.txt
+++ b/src/torchcodec/_core/CMakeLists.txt
@@ -36,6 +36,8 @@ if(NOT DEFINED JPEG_ROOT AND DEFINED ENV{CONDA_PREFIX})
     endif()
 endif()
 find_package(JPEG)  # Not REQUIRED on purpose.
+# TODO_IMAGE: we should probably make it mandatory by default and allow to make
+# it optional via a flag?
 if(JPEG_FOUND)
     message(STATUS "libjpeg found: building torchcodec with JPEG image decoding support.")
 else()

--- a/src/torchcodec/_core/CMakeLists.txt
+++ b/src/torchcodec/_core/CMakeLists.txt
@@ -72,13 +72,6 @@ read_sources_from_bzl(TORCHCODEC_CUSTOM_OPS_SOURCES custom_ops_sources)
 read_sources_from_bzl(TORCHCODEC_PYBIND_OPS_SOURCES pybind_ops_sources)
 read_sources_from_bzl(TORCHCODEC_IMAGE_SOURCES image_sources)
 
-# TODO_IMAGE: Fix this
-if(NOT WIN32)
-    set_source_files_properties(
-        ${TORCHCODEC_IMAGE_SOURCES}
-        PROPERTIES COMPILE_OPTIONS "-Wno-error")
-endif()
-
 if(DEFINED TORCHCODEC_DISABLE_COMPILE_WARNING_AS_ERROR AND TORCHCODEC_DISABLE_COMPILE_WARNING_AS_ERROR)
     set(TORCHCODEC_WERROR_OPTION "")
 else()

--- a/src/torchcodec/_core/DecodeJpeg.cpp
+++ b/src/torchcodec/_core/DecodeJpeg.cpp
@@ -35,6 +35,7 @@ torch::stable::Tensor decode_jpeg(
 #include <setjmp.h>
 
 #include <algorithm>
+#include <cstdint>
 #include <cstring>
 #include <optional>
 
@@ -70,18 +71,15 @@ void validate_encoded_data(const torch::stable::Tensor& encoded_data) {
 
 constexpr JOCTET EOI_BUFFER[1] = {JPEG_EOI};
 
-struct torch_jpeg_error_mgr {
+struct error_mgr {
   jpeg_error_mgr pub; /* "public" fields */
   char jpegLastErrorMsg[JMSG_LENGTH_MAX]; /* error messages */
   jmp_buf setjmp_buffer; /* for return to caller */
 };
 
-using torch_jpeg_error_ptr = torch_jpeg_error_mgr*;
-
-void torch_jpeg_error_exit(j_common_ptr cinfo) {
-  // cinfo->err really points to a torch_jpeg_error_mgr struct, so coerce
-  // pointer.
-  auto myerr = reinterpret_cast<torch_jpeg_error_ptr>(cinfo->err);
+void error_exit(j_common_ptr cinfo) {
+  // cinfo->err really points to an error_mgr struct, so coerce pointer.
+  auto myerr = reinterpret_cast<error_mgr*>(cinfo->err);
 
   cinfo->err->format_message(cinfo, myerr->jpegLastErrorMsg);
 
@@ -89,23 +87,23 @@ void torch_jpeg_error_exit(j_common_ptr cinfo) {
   longjmp(myerr->setjmp_buffer, 1);
 }
 
-struct torch_jpeg_mgr {
+struct source_mgr {
   jpeg_source_mgr pub;
   const JOCTET* data;
   size_t len;
 };
 
-void torch_jpeg_init_source(j_decompress_ptr) {}
+void init_source(j_decompress_ptr) {}
 
-boolean torch_jpeg_fill_input_buffer(j_decompress_ptr cinfo) {
+boolean fill_input_buffer(j_decompress_ptr cinfo) {
   // No more data.  Probably an incomplete image;  Raise exception.
-  auto myerr = reinterpret_cast<torch_jpeg_error_ptr>(cinfo->err);
+  auto myerr = reinterpret_cast<error_mgr*>(cinfo->err);
   strcpy(myerr->jpegLastErrorMsg, "Image is incomplete or truncated");
   longjmp(myerr->setjmp_buffer, 1);
 }
 
-void torch_jpeg_skip_input_data(j_decompress_ptr cinfo, long num_bytes) {
-  auto* src = reinterpret_cast<torch_jpeg_mgr*>(cinfo->src);
+void skip_input_data(j_decompress_ptr cinfo, long num_bytes) {
+  auto* src = reinterpret_cast<source_mgr*>(cinfo->src);
   if (src->pub.bytes_in_buffer < static_cast<size_t>(num_bytes)) {
     // Skipping over all of remaining data;  output EOI.
     src->pub.next_input_byte = EOI_BUFFER;
@@ -117,25 +115,22 @@ void torch_jpeg_skip_input_data(j_decompress_ptr cinfo, long num_bytes) {
   }
 }
 
-void torch_jpeg_term_source(j_decompress_ptr) {}
+void term_source(j_decompress_ptr) {}
 
-void torch_jpeg_set_source_mgr(
-    j_decompress_ptr cinfo,
-    const unsigned char* data,
-    size_t len) {
-  torch_jpeg_mgr* src;
+void set_source_mgr(j_decompress_ptr cinfo, const uint8_t* data, size_t len) {
+  source_mgr* src;
   if (cinfo->src == nullptr) { // if this is first time;  allocate memory
     cinfo->src = static_cast<jpeg_source_mgr*>(cinfo->mem->alloc_small(
         reinterpret_cast<j_common_ptr>(cinfo),
         JPOOL_PERMANENT,
-        sizeof(torch_jpeg_mgr)));
+        sizeof(source_mgr)));
   }
-  src = reinterpret_cast<torch_jpeg_mgr*>(cinfo->src);
-  src->pub.init_source = torch_jpeg_init_source;
-  src->pub.fill_input_buffer = torch_jpeg_fill_input_buffer;
-  src->pub.skip_input_data = torch_jpeg_skip_input_data;
+  src = reinterpret_cast<source_mgr*>(cinfo->src);
+  src->pub.init_source = init_source;
+  src->pub.fill_input_buffer = fill_input_buffer;
+  src->pub.skip_input_data = skip_input_data;
   src->pub.resync_to_restart = jpeg_resync_to_restart; // default
-  src->pub.term_source = torch_jpeg_term_source;
+  src->pub.term_source = term_source;
   // fill the buffers
   src->data = reinterpret_cast<const JOCTET*>(data);
   src->len = len;
@@ -145,9 +140,7 @@ void torch_jpeg_set_source_mgr(
   jpeg_save_markers(cinfo, APP1, 0xffff);
 }
 
-inline unsigned char clamped_cmyk_rgb_convert(
-    unsigned char k,
-    unsigned char cmy) {
+inline uint8_t clamped_cmyk_rgb_convert(uint8_t k, uint8_t cmy) {
   // Inspired from Pillow:
   // https://github.com/python-pillow/Pillow/blob/07623d1a7cc65206a5355fba2ae256550bfcaba6/src/libImaging/Convert.c#L568-L569
   int v = k * cmy + 128;
@@ -156,10 +149,10 @@ inline unsigned char clamped_cmyk_rgb_convert(
 }
 
 void convert_line_cmyk_to_rgb(
-    j_decompress_ptr cinfo,
-    const unsigned char* cmyk_line,
-    unsigned char* rgb_line) {
-  int width = cinfo->output_width;
+    const jpeg_decompress_struct& cinfo,
+    const uint8_t* cmyk_line,
+    uint8_t* rgb_line) {
+  int width = cinfo.output_width;
   for (int i = 0; i < width; ++i) {
     int c = cmyk_line[i * 4 + 0];
     int m = cmyk_line[i * 4 + 1];
@@ -172,17 +165,17 @@ void convert_line_cmyk_to_rgb(
   }
 }
 
-inline unsigned char rgb_to_gray(int r, int g, int b) {
+inline uint8_t rgb_to_gray(int r, int g, int b) {
   // Inspired from Pillow:
   // https://github.com/python-pillow/Pillow/blob/07623d1a7cc65206a5355fba2ae256550bfcaba6/src/libImaging/Convert.c#L226
   return (r * 19595 + g * 38470 + b * 7471 + 0x8000) >> 16;
 }
 
 void convert_line_cmyk_to_gray(
-    j_decompress_ptr cinfo,
-    const unsigned char* cmyk_line,
-    unsigned char* gray_line) {
-  int width = cinfo->output_width;
+    const jpeg_decompress_struct& cinfo,
+    const uint8_t* cmyk_line,
+    uint8_t* gray_line) {
+  int width = cinfo.output_width;
   for (int i = 0; i < width; ++i) {
     int c = cmyk_line[i * 4 + 0];
     int m = cmyk_line[i * 4 + 1];
@@ -205,7 +198,7 @@ torch::stable::Tensor decode_jpeg(
   validate_encoded_data(data);
 
   jpeg_decompress_struct cinfo;
-  torch_jpeg_error_mgr jerr;
+  error_mgr jerr;
 
   // NOTE: libjpeg uses setjmp/longjmp for error handling. longjmp does not
   // unwind C++ stack frames, so destructors of objects created after setjmp
@@ -217,7 +210,7 @@ torch::stable::Tensor decode_jpeg(
   auto datap = data.const_data_ptr<uint8_t>();
   // Setup decompression structure
   cinfo.err = jpeg_std_error(&jerr.pub);
-  jerr.pub.error_exit = torch_jpeg_error_exit;
+  jerr.pub.error_exit = error_exit;
   /* Establish the setjmp return context for my_error_exit to use. */
   if (setjmp(jerr.setjmp_buffer)) {
     // Release any tensors that may have been allocated after setjmp.
@@ -232,7 +225,7 @@ torch::stable::Tensor decode_jpeg(
   }
 
   jpeg_create_decompress(&cinfo);
-  torch_jpeg_set_source_mgr(&cinfo, datap, data.numel());
+  set_source_mgr(&cinfo, datap, data.numel());
 
   // read info from header.
   jpeg_read_header(&cinfo, TRUE);
@@ -293,9 +286,9 @@ torch::stable::Tensor decode_jpeg(
       jpeg_read_scanlines(&cinfo, &cmyk_line_ptr, 1);
 
       if (channels == 3) {
-        convert_line_cmyk_to_rgb(&cinfo, cmyk_line_ptr, ptr);
+        convert_line_cmyk_to_rgb(cinfo, cmyk_line_ptr, ptr);
       } else if (channels == 1) {
-        convert_line_cmyk_to_gray(&cinfo, cmyk_line_ptr, ptr);
+        convert_line_cmyk_to_gray(cinfo, cmyk_line_ptr, ptr);
       }
     } else {
       jpeg_read_scanlines(&cinfo, &ptr, 1);

--- a/src/torchcodec/_core/DecodeJpeg.cpp
+++ b/src/torchcodec/_core/DecodeJpeg.cpp
@@ -68,30 +68,29 @@ void validate_encoded_data(const torch::stable::Tensor& encoded_data) {
       " numels.");
 }
 
-const JOCTET EOI_BUFFER[1] = {JPEG_EOI};
+constexpr JOCTET EOI_BUFFER[1] = {JPEG_EOI};
 
 struct torch_jpeg_error_mgr {
-  struct jpeg_error_mgr pub; /* "public" fields */
+  jpeg_error_mgr pub; /* "public" fields */
   char jpegLastErrorMsg[JMSG_LENGTH_MAX]; /* error messages */
   jmp_buf setjmp_buffer; /* for return to caller */
 };
 
-using torch_jpeg_error_ptr = struct torch_jpeg_error_mgr*;
+using torch_jpeg_error_ptr = torch_jpeg_error_mgr*;
 
 void torch_jpeg_error_exit(j_common_ptr cinfo) {
-  /* cinfo->err really points to a torch_jpeg_error_mgr struct, so coerce
-   * pointer */
-  torch_jpeg_error_ptr myerr = (torch_jpeg_error_ptr)cinfo->err;
+  // cinfo->err really points to a torch_jpeg_error_mgr struct, so coerce
+  // pointer.
+  auto myerr = reinterpret_cast<torch_jpeg_error_ptr>(cinfo->err);
 
-  /* Create the message */
-  (*(cinfo->err->format_message))(cinfo, myerr->jpegLastErrorMsg);
+  cinfo->err->format_message(cinfo, myerr->jpegLastErrorMsg);
 
-  /* Return control to the setjmp point */
+  // Return control to the setjmp point.
   longjmp(myerr->setjmp_buffer, 1);
 }
 
 struct torch_jpeg_mgr {
-  struct jpeg_source_mgr pub;
+  jpeg_source_mgr pub;
   const JOCTET* data;
   size_t len;
 };
@@ -100,14 +99,14 @@ void torch_jpeg_init_source(j_decompress_ptr) {}
 
 boolean torch_jpeg_fill_input_buffer(j_decompress_ptr cinfo) {
   // No more data.  Probably an incomplete image;  Raise exception.
-  torch_jpeg_error_ptr myerr = (torch_jpeg_error_ptr)cinfo->err;
+  auto myerr = reinterpret_cast<torch_jpeg_error_ptr>(cinfo->err);
   strcpy(myerr->jpegLastErrorMsg, "Image is incomplete or truncated");
   longjmp(myerr->setjmp_buffer, 1);
 }
 
 void torch_jpeg_skip_input_data(j_decompress_ptr cinfo, long num_bytes) {
-  torch_jpeg_mgr* src = (torch_jpeg_mgr*)cinfo->src;
-  if (src->pub.bytes_in_buffer < (size_t)num_bytes) {
+  auto* src = reinterpret_cast<torch_jpeg_mgr*>(cinfo->src);
+  if (src->pub.bytes_in_buffer < static_cast<size_t>(num_bytes)) {
     // Skipping over all of remaining data;  output EOI.
     src->pub.next_input_byte = EOI_BUFFER;
     src->pub.bytes_in_buffer = 1;
@@ -126,17 +125,19 @@ void torch_jpeg_set_source_mgr(
     size_t len) {
   torch_jpeg_mgr* src;
   if (cinfo->src == nullptr) { // if this is first time;  allocate memory
-    cinfo->src = (struct jpeg_source_mgr*)(*cinfo->mem->alloc_small)(
-        (j_common_ptr)cinfo, JPOOL_PERMANENT, sizeof(torch_jpeg_mgr));
+    cinfo->src = static_cast<jpeg_source_mgr*>(cinfo->mem->alloc_small(
+        reinterpret_cast<j_common_ptr>(cinfo),
+        JPOOL_PERMANENT,
+        sizeof(torch_jpeg_mgr)));
   }
-  src = (torch_jpeg_mgr*)cinfo->src;
+  src = reinterpret_cast<torch_jpeg_mgr*>(cinfo->src);
   src->pub.init_source = torch_jpeg_init_source;
   src->pub.fill_input_buffer = torch_jpeg_fill_input_buffer;
   src->pub.skip_input_data = torch_jpeg_skip_input_data;
   src->pub.resync_to_restart = jpeg_resync_to_restart; // default
   src->pub.term_source = torch_jpeg_term_source;
   // fill the buffers
-  src->data = (const JOCTET*)data;
+  src->data = reinterpret_cast<const JOCTET*>(data);
   src->len = len;
   src->pub.bytes_in_buffer = len;
   src->pub.next_input_byte = src->data;
@@ -203,8 +204,8 @@ torch::stable::Tensor decode_jpeg(
     int64_t mode) {
   validate_encoded_data(data);
 
-  struct jpeg_decompress_struct cinfo;
-  struct torch_jpeg_error_mgr jerr;
+  jpeg_decompress_struct cinfo;
+  torch_jpeg_error_mgr jerr;
 
   // NOTE: libjpeg uses setjmp/longjmp for error handling. longjmp does not
   // unwind C++ stack frames, so destructors of objects created after setjmp
@@ -239,6 +240,8 @@ torch::stable::Tensor decode_jpeg(
   int channels = cinfo.num_components;
   bool cmyk_to_rgb_or_gray = false;
 
+  // TODO_IMAGE wait, what does this return on a CMYK image when mode is
+  // UNCHANGED?
   if (mode != kImageReadModeUnchanged) {
     // libjpeg can't convert CMYK/YCCK straight to gray or RGB, so for those we
     // decode as CMYK and convert the lines ourselves (see the scanline loop),

--- a/src/torchcodec/_core/DecodeJpeg.cpp
+++ b/src/torchcodec/_core/DecodeJpeg.cpp
@@ -68,7 +68,7 @@ void validate_encoded_data(const torch::stable::Tensor& encoded_data) {
       " numels.");
 }
 
-static const JOCTET EOI_BUFFER[1] = {JPEG_EOI};
+const JOCTET EOI_BUFFER[1] = {JPEG_EOI};
 
 struct torch_jpeg_error_mgr {
   struct jpeg_error_mgr pub; /* "public" fields */
@@ -96,16 +96,16 @@ struct torch_jpeg_mgr {
   size_t len;
 };
 
-static void torch_jpeg_init_source(j_decompress_ptr) {}
+void torch_jpeg_init_source(j_decompress_ptr) {}
 
-static boolean torch_jpeg_fill_input_buffer(j_decompress_ptr cinfo) {
+boolean torch_jpeg_fill_input_buffer(j_decompress_ptr cinfo) {
   // No more data.  Probably an incomplete image;  Raise exception.
   torch_jpeg_error_ptr myerr = (torch_jpeg_error_ptr)cinfo->err;
   strcpy(myerr->jpegLastErrorMsg, "Image is incomplete or truncated");
   longjmp(myerr->setjmp_buffer, 1);
 }
 
-static void torch_jpeg_skip_input_data(j_decompress_ptr cinfo, long num_bytes) {
+void torch_jpeg_skip_input_data(j_decompress_ptr cinfo, long num_bytes) {
   torch_jpeg_mgr* src = (torch_jpeg_mgr*)cinfo->src;
   if (src->pub.bytes_in_buffer < (size_t)num_bytes) {
     // Skipping over all of remaining data;  output EOI.
@@ -118,14 +118,14 @@ static void torch_jpeg_skip_input_data(j_decompress_ptr cinfo, long num_bytes) {
   }
 }
 
-static void torch_jpeg_term_source(j_decompress_ptr) {}
+void torch_jpeg_term_source(j_decompress_ptr) {}
 
-static void torch_jpeg_set_source_mgr(
+void torch_jpeg_set_source_mgr(
     j_decompress_ptr cinfo,
     const unsigned char* data,
     size_t len) {
   torch_jpeg_mgr* src;
-  if (cinfo->src == 0) { // if this is first time;  allocate memory
+  if (cinfo->src == nullptr) { // if this is first time;  allocate memory
     cinfo->src = (struct jpeg_source_mgr*)(*cinfo->mem->alloc_small)(
         (j_common_ptr)cinfo, JPOOL_PERMANENT, sizeof(torch_jpeg_mgr));
   }
@@ -240,32 +240,21 @@ torch::stable::Tensor decode_jpeg(
   bool cmyk_to_rgb_or_gray = false;
 
   if (mode != kImageReadModeUnchanged) {
+    // libjpeg can't convert CMYK/YCCK straight to gray or RGB, so for those we
+    // decode as CMYK and convert the lines ourselves (see the scanline loop),
+    // like:
+    // https://github.com/tensorflow/tensorflow/blob/86871065265b04e0db8ca360c046421efb2bdeb4/tensorflow/core/lib/jpeg/jpeg_mem.cc#L284-L313
+    cmyk_to_rgb_or_gray = cinfo.jpeg_color_space == JCS_CMYK ||
+        cinfo.jpeg_color_space == JCS_YCCK;
     switch (mode) {
       case kImageReadModeGray:
-        if (cinfo.jpeg_color_space == JCS_CMYK ||
-            cinfo.jpeg_color_space == JCS_YCCK) {
-          cinfo.out_color_space = JCS_CMYK;
-          cmyk_to_rgb_or_gray = true;
-        } else {
-          cinfo.out_color_space = JCS_GRAYSCALE;
-        }
+        cinfo.out_color_space = cmyk_to_rgb_or_gray ? JCS_CMYK : JCS_GRAYSCALE;
         channels = 1;
         break;
       case kImageReadModeRgb:
-        if (cinfo.jpeg_color_space == JCS_CMYK ||
-            cinfo.jpeg_color_space == JCS_YCCK) {
-          cinfo.out_color_space = JCS_CMYK;
-          cmyk_to_rgb_or_gray = true;
-        } else {
-          cinfo.out_color_space = JCS_RGB;
-        }
+        cinfo.out_color_space = cmyk_to_rgb_or_gray ? JCS_CMYK : JCS_RGB;
         channels = 3;
         break;
-      /*
-       * Libjpeg does not support converting from CMYK to grayscale etc. There
-       * is a way to do this but it involves converting it manually to RGB:
-       * https://github.com/tensorflow/tensorflow/blob/86871065265b04e0db8ca360c046421efb2bdeb4/tensorflow/core/lib/jpeg/jpeg_mem.cc#L284-L313
-       */
       default:
         jpeg_destroy_decompress(&cinfo);
         STD_TORCH_CHECK(

--- a/src/torchcodec/_core/DecodeJpeg.cpp
+++ b/src/torchcodec/_core/DecodeJpeg.cpp
@@ -98,7 +98,7 @@ struct torch_jpeg_mgr {
   size_t len;
 };
 
-static void torch_jpeg_init_source(j_decompress_ptr cinfo) {}
+static void torch_jpeg_init_source(j_decompress_ptr) {}
 
 static boolean torch_jpeg_fill_input_buffer(j_decompress_ptr cinfo) {
   // No more data.  Probably an incomplete image;  Raise exception.
@@ -120,7 +120,7 @@ static void torch_jpeg_skip_input_data(j_decompress_ptr cinfo, long num_bytes) {
   }
 }
 
-static void torch_jpeg_term_source(j_decompress_ptr cinfo) {}
+static void torch_jpeg_term_source(j_decompress_ptr) {}
 
 static void torch_jpeg_set_source_mgr(
     j_decompress_ptr cinfo,

--- a/src/torchcodec/_core/DecodeJpeg.cpp
+++ b/src/torchcodec/_core/DecodeJpeg.cpp
@@ -12,7 +12,25 @@
 
 #include "StableABICompat.h"
 
-#if JPEG_FOUND
+#if !JPEG_FOUND
+
+namespace facebook::torchcodec {
+
+torch::stable::Tensor decode_jpeg(
+    const torch::stable::Tensor& data,
+    int64_t mode) {
+  STD_TORCH_CHECK(
+      false,
+      "decode_jpeg: torchcodec was not compiled with libjpeg support. "
+      "Rebuild torchcodec in an environment where libjpeg-turbo (and its "
+      "development headers) are available. If you see this error in a prebuilt "
+      "wheel, please report it to the TorchCodec repo.");
+}
+
+} // namespace facebook::torchcodec
+
+#else
+
 #include <jpeglib.h>
 #include <setjmp.h>
 
@@ -21,9 +39,10 @@
 #include <optional>
 
 #include "Exif.h"
-#endif // JPEG_FOUND
 
 namespace facebook::torchcodec {
+
+using namespace exif_private;
 
 namespace {
 
@@ -48,27 +67,6 @@ void validate_encoded_data(const torch::stable::Tensor& encoded_data) {
       encoded_data.numel(),
       " numels.");
 }
-
-} // namespace
-
-#if !JPEG_FOUND
-
-torch::stable::Tensor decode_jpeg(
-    const torch::stable::Tensor& data,
-    int64_t mode) {
-  STD_TORCH_CHECK(
-      false,
-      "decode_jpeg: torchcodec was not compiled with libjpeg support. "
-      "Rebuild torchcodec in an environment where libjpeg-turbo (and its "
-      "development headers) are available. If you see this error in a prebuilt "
-      "wheel, please report it to the TorchCodec repo.");
-}
-
-#else
-
-using namespace exif_private;
-
-namespace {
 
 static const JOCTET EOI_BUFFER[1] = {JPEG_EOI};
 
@@ -321,6 +319,6 @@ torch::stable::Tensor decode_jpeg(
   return exif_orientation_transform(output, exif_orientation);
 }
 
-#endif // #if !JPEG_FOUND
-
 } // namespace facebook::torchcodec
+
+#endif // !JPEG_FOUND

--- a/src/torchcodec/_core/DecodeJpeg.cpp
+++ b/src/torchcodec/_core/DecodeJpeg.cpp
@@ -263,35 +263,41 @@ torch::stable::Tensor decode_jpeg(
 
   jpeg_read_header(&jpeg_ctx, TRUE);
 
-  int num_output_channels = jpeg_ctx.num_components;
-  bool cmyk_to_rgb_or_gray = false;
-
   // TODO_IMAGE wait, what does this return on a CMYK image when mode is
   // UNCHANGED?
-  if (mode != kImageReadModeUnchanged) {
-    // libjpeg can't convert CMYK/YCCK straight to gray or RGB, so for those we
-    // decode as CMYK and convert the lines ourselves (see the scanline loop),
-    // like:
-    // https://github.com/tensorflow/tensorflow/blob/86871065265b04e0db8ca360c046421efb2bdeb4/tensorflow/core/lib/jpeg/jpeg_mem.cc#L284-L313
-    cmyk_to_rgb_or_gray = jpeg_ctx.jpeg_color_space == JCS_CMYK ||
-        jpeg_ctx.jpeg_color_space == JCS_YCCK;
-    switch (mode) {
-      case kImageReadModeGray:
-        jpeg_ctx.out_color_space =
-            cmyk_to_rgb_or_gray ? JCS_CMYK : JCS_GRAYSCALE;
-        num_output_channels = 1;
-        break;
-      case kImageReadModeRgb:
-        jpeg_ctx.out_color_space = cmyk_to_rgb_or_gray ? JCS_CMYK : JCS_RGB;
-        num_output_channels = 3;
-        break;
-      default:
-        jpeg_destroy_decompress(&jpeg_ctx);
-        STD_TORCH_CHECK(
-            false, "The provided mode is not supported for JPEG files");
-    }
+  int num_output_channels = -1;
+  switch (mode) {
+    case kImageReadModeUnchanged:
+      num_output_channels = jpeg_ctx.num_components;
+      break;
+    case kImageReadModeGray:
+      num_output_channels = 1;
+      break;
+    case kImageReadModeRgb:
+      num_output_channels = 3;
+      break;
+    default:
+      jpeg_destroy_decompress(&jpeg_ctx);
+      STD_TORCH_CHECK(
+          false, "The provided mode is not supported for JPEG files");
+  }
 
-    jpeg_calc_output_dimensions(&jpeg_ctx);
+  // libjpeg can't convert CMYK/YCCK straight to gray or RGB, so for those modes
+  // we keep libjpeg's JCS_CMYK default as the output color-space, and convert
+  // the lines ourselves (see the scanline loop). Similar to:
+  // https://github.com/tensorflow/tensorflow/blob/86871065265b04e0db8ca360c046421efb2bdeb4/tensorflow/core/lib/jpeg/jpeg_mem.cc#L284-L313
+  bool cmyk_to_rgb_or_gray = (jpeg_ctx.jpeg_color_space == JCS_CMYK ||
+                              jpeg_ctx.jpeg_color_space == JCS_YCCK) &&
+      (mode == kImageReadModeGray || mode == kImageReadModeRgb);
+
+  // For other sources, ask libjpeg to convert to the requested color space.
+  if (mode != kImageReadModeUnchanged && !cmyk_to_rgb_or_gray) {
+    if (mode == kImageReadModeGray) {
+      jpeg_ctx.out_color_space = JCS_GRAYSCALE;
+    } else {
+      STD_TORCH_CHECK(mode == kImageReadModeRgb, "Should never reach here.");
+      jpeg_ctx.out_color_space = JCS_RGB;
+    }
   }
 
   jpeg_start_decompress(&jpeg_ctx);

--- a/src/torchcodec/_core/DecodeJpeg.cpp
+++ b/src/torchcodec/_core/DecodeJpeg.cpp
@@ -53,6 +53,9 @@ constexpr int64_t kImageReadModeUnchanged = 0;
 constexpr int64_t kImageReadModeGray = 1;
 constexpr int64_t kImageReadModeRgb = 3;
 
+// EXIF APP1 marker: the orientation tag lives in this marker's payload.
+constexpr uint16_t APP1 = 0xe1;
+
 void validate_encoded_data(const torch::stable::Tensor& encoded_data) {
   STD_TORCH_CHECK(
       encoded_data.is_contiguous(), "Input tensor must be contiguous.");
@@ -71,73 +74,78 @@ void validate_encoded_data(const torch::stable::Tensor& encoded_data) {
 
 constexpr JOCTET EOI_BUFFER[1] = {JPEG_EOI};
 
-struct error_mgr {
-  jpeg_error_mgr pub; /* "public" fields */
-  char jpegLastErrorMsg[JMSG_LENGTH_MAX]; /* error messages */
-  jmp_buf setjmp_buffer; /* for return to caller */
+// The libjpeg base struct must come first: libjpeg only ever sees &base (via
+// jpeg_ctx->err), and our callbacks cast that back to error_ctx_t* to reach the
+// fields below.
+struct error_ctx_t {
+  jpeg_error_mgr base;
+  char last_error_message[JMSG_LENGTH_MAX];
+  jmp_buf setjmp_buffer; // for the longjmp back to decode_jpeg
 };
 
-void error_exit(j_common_ptr cinfo) {
-  // cinfo->err really points to an error_mgr struct, so coerce pointer.
-  auto myerr = reinterpret_cast<error_mgr*>(cinfo->err);
-
-  cinfo->err->format_message(cinfo, myerr->jpegLastErrorMsg);
-
+void error_exit_cb(j_common_ptr jpeg_ctx) {
+  // jpeg_ctx->err really points to an error_ctx_t struct, so coerce pointer.
+  auto err = reinterpret_cast<error_ctx_t*>(jpeg_ctx->err);
+  jpeg_ctx->err->format_message(jpeg_ctx, err->last_error_message);
   // Return control to the setjmp point.
-  longjmp(myerr->setjmp_buffer, 1);
+  longjmp(err->setjmp_buffer, 1);
 }
 
-struct source_mgr {
-  jpeg_source_mgr pub;
+// Same base-first requirement as error_ctx_t: libjpeg sees &base (via
+// jpeg_ctx->src), our callbacks cast it back to source_ctx_t*.
+struct source_ctx_t {
+  jpeg_source_mgr base;
   const JOCTET* data;
   size_t len;
 };
 
-void init_source(j_decompress_ptr) {}
-
-boolean fill_input_buffer(j_decompress_ptr cinfo) {
+boolean fill_input_buffer_cb(j_decompress_ptr jpeg_ctx) {
   // No more data.  Probably an incomplete image;  Raise exception.
-  auto myerr = reinterpret_cast<error_mgr*>(cinfo->err);
-  strcpy(myerr->jpegLastErrorMsg, "Image is incomplete or truncated");
+  auto myerr = reinterpret_cast<error_ctx_t*>(jpeg_ctx->err);
+  strcpy(myerr->last_error_message, "Image is incomplete or truncated");
   longjmp(myerr->setjmp_buffer, 1);
 }
 
-void skip_input_data(j_decompress_ptr cinfo, long num_bytes) {
-  auto* src = reinterpret_cast<source_mgr*>(cinfo->src);
-  if (src->pub.bytes_in_buffer < static_cast<size_t>(num_bytes)) {
+void skip_input_data_cb(j_decompress_ptr jpeg_ctx, long num_bytes) {
+  auto* source_ctx = reinterpret_cast<source_ctx_t*>(jpeg_ctx->src);
+  if (source_ctx->base.bytes_in_buffer < static_cast<size_t>(num_bytes)) {
     // Skipping over all of remaining data;  output EOI.
-    src->pub.next_input_byte = EOI_BUFFER;
-    src->pub.bytes_in_buffer = 1;
+    source_ctx->base.next_input_byte = EOI_BUFFER;
+    source_ctx->base.bytes_in_buffer = 1;
   } else {
     // Skipping over only some of the remaining data.
-    src->pub.next_input_byte += num_bytes;
-    src->pub.bytes_in_buffer -= num_bytes;
+    source_ctx->base.next_input_byte += num_bytes;
+    source_ctx->base.bytes_in_buffer -= num_bytes;
   }
 }
 
-void term_source(j_decompress_ptr) {}
+void init_source_cb(j_decompress_ptr) {}
 
-void set_source_mgr(j_decompress_ptr cinfo, const uint8_t* data, size_t len) {
-  source_mgr* src;
-  if (cinfo->src == nullptr) { // if this is first time;  allocate memory
-    cinfo->src = static_cast<jpeg_source_mgr*>(cinfo->mem->alloc_small(
-        reinterpret_cast<j_common_ptr>(cinfo),
-        JPOOL_PERMANENT,
-        sizeof(source_mgr)));
-  }
-  src = reinterpret_cast<source_mgr*>(cinfo->src);
-  src->pub.init_source = init_source;
-  src->pub.fill_input_buffer = fill_input_buffer;
-  src->pub.skip_input_data = skip_input_data;
-  src->pub.resync_to_restart = jpeg_resync_to_restart; // default
-  src->pub.term_source = term_source;
-  // fill the buffers
-  src->data = reinterpret_cast<const JOCTET*>(data);
-  src->len = len;
-  src->pub.bytes_in_buffer = len;
-  src->pub.next_input_byte = src->data;
+void term_source_cb(j_decompress_ptr) {}
 
-  jpeg_save_markers(cinfo, APP1, 0xffff);
+void set_source_ctx(
+    jpeg_decompress_struct& jpeg_ctx,
+    const uint8_t* data,
+    size_t len) {
+  // We decode one image per fresh jpeg_decompress_struct, so jpeg_ctx.src is
+  // always null here. Allocate our source manager from libjpeg's pool, which
+  // jpeg_destroy_decompress frees.
+  jpeg_ctx.src = static_cast<jpeg_source_mgr*>(jpeg_ctx.mem->alloc_small(
+      reinterpret_cast<j_common_ptr>(&jpeg_ctx),
+      JPOOL_PERMANENT,
+      sizeof(source_ctx_t)));
+  auto* source_ctx = reinterpret_cast<source_ctx_t*>(jpeg_ctx.src);
+  source_ctx->base.init_source = init_source_cb;
+  source_ctx->base.fill_input_buffer = fill_input_buffer_cb;
+  source_ctx->base.skip_input_data = skip_input_data_cb;
+  source_ctx->base.resync_to_restart = jpeg_resync_to_restart; // default
+  source_ctx->base.term_source = term_source_cb;
+  source_ctx->data = reinterpret_cast<const JOCTET*>(data);
+  source_ctx->len = len;
+  source_ctx->base.bytes_in_buffer = len;
+  source_ctx->base.next_input_byte = source_ctx->data;
+
+  jpeg_save_markers(&jpeg_ctx, APP1, 0xffff);
 }
 
 inline uint8_t clamped_cmyk_rgb_convert(uint8_t k, uint8_t cmy) {
@@ -149,10 +157,9 @@ inline uint8_t clamped_cmyk_rgb_convert(uint8_t k, uint8_t cmy) {
 }
 
 void convert_line_cmyk_to_rgb(
-    const jpeg_decompress_struct& cinfo,
+    int width,
     const uint8_t* cmyk_line,
     uint8_t* rgb_line) {
-  int width = cinfo.output_width;
   for (int i = 0; i < width; ++i) {
     int c = cmyk_line[i * 4 + 0];
     int m = cmyk_line[i * 4 + 1];
@@ -172,10 +179,9 @@ inline uint8_t rgb_to_gray(int r, int g, int b) {
 }
 
 void convert_line_cmyk_to_gray(
-    const jpeg_decompress_struct& cinfo,
+    int width,
     const uint8_t* cmyk_line,
     uint8_t* gray_line) {
-  int width = cinfo.output_width;
   for (int i = 0; i < width; ++i) {
     int c = cmyk_line[i * 4 + 0];
     int m = cmyk_line[i * 4 + 1];
@@ -190,6 +196,34 @@ void convert_line_cmyk_to_gray(
   }
 }
 
+int fetch_jpeg_exif_orientation(j_decompress_ptr jpeg_ctx) {
+  STD_TORCH_CHECK(jpeg_ctx != nullptr, "jpeg_ctx cannot be null");
+
+  // Check for Exif marker APP1
+  jpeg_saved_marker_ptr exif_marker = 0;
+  jpeg_saved_marker_ptr cmarker = jpeg_ctx->marker_list;
+  while (cmarker && exif_marker == 0) {
+    if (cmarker->marker == APP1) {
+      exif_marker = cmarker;
+    }
+    cmarker = cmarker->next;
+  }
+
+  if (!exif_marker) {
+    return -1;
+  }
+
+  constexpr size_t start_offset = 6;
+  if (exif_marker->data_length <= start_offset) {
+    return -1;
+  }
+
+  auto* exif_data_ptr = exif_marker->data + start_offset;
+  auto size = exif_marker->data_length - start_offset;
+
+  return fetch_exif_orientation(exif_data_ptr, size);
+}
+
 } // namespace
 
 torch::stable::Tensor decode_jpeg(
@@ -197,40 +231,39 @@ torch::stable::Tensor decode_jpeg(
     int64_t mode) {
   validate_encoded_data(data);
 
-  jpeg_decompress_struct cinfo;
-  error_mgr jerr;
-
-  // NOTE: libjpeg uses setjmp/longjmp for error handling. longjmp does not
-  // unwind C++ stack frames, so destructors of objects created after setjmp
-  // won't run. We use std::optional to declare tensors before setjmp while
-  // deferring construction, and explicitly reset them on the error path.
-  std::optional<torch::stable::Tensor> tensor;
+  // See error handling below why these are optional
+  std::optional<torch::stable::Tensor> output;
   std::optional<torch::stable::Tensor> cmyk_line_tensor;
 
   auto datap = data.const_data_ptr<uint8_t>();
-  // Setup decompression structure
-  cinfo.err = jpeg_std_error(&jerr.pub);
-  jerr.pub.error_exit = error_exit;
-  /* Establish the setjmp return context for my_error_exit to use. */
-  if (setjmp(jerr.setjmp_buffer)) {
+
+  jpeg_decompress_struct jpeg_ctx;
+
+  // Setup error handling. libjpeg uses setjmp/longjmp for that. longjmp does
+  // not unwind C++ stack frames, so destructors of objects created after setjmp
+  // won't run. We use std::optional to declare tensors before setjmp while
+  // deferring construction, and explicitly reset them on the error path.
+  error_ctx_t error_ctx;
+  jpeg_ctx.err = jpeg_std_error(&error_ctx.base);
+  error_ctx.base.error_exit = error_exit_cb;
+  // Establish the setjmp return context for error_exit_cb to use.
+  if (setjmp(error_ctx.setjmp_buffer)) {
     // Release any tensors that may have been allocated after setjmp.
     cmyk_line_tensor.reset();
-    tensor.reset();
+    output.reset();
 
-    /* If we get here, the JPEG code has signaled an error.
-     * We need to clean up the JPEG object.
-     */
-    jpeg_destroy_decompress(&cinfo);
-    STD_TORCH_CHECK(false, jerr.jpegLastErrorMsg);
+    // If we get here, the JPEG code has signaled an error.
+    // We need to clean up the JPEG object.
+    jpeg_destroy_decompress(&jpeg_ctx);
+    STD_TORCH_CHECK(false, error_ctx.last_error_message);
   }
 
-  jpeg_create_decompress(&cinfo);
-  set_source_mgr(&cinfo, datap, data.numel());
+  jpeg_create_decompress(&jpeg_ctx);
+  set_source_ctx(jpeg_ctx, datap, data.numel());
 
-  // read info from header.
-  jpeg_read_header(&cinfo, TRUE);
+  jpeg_read_header(&jpeg_ctx, TRUE);
 
-  int channels = cinfo.num_components;
+  int num_output_channels = jpeg_ctx.num_components;
   bool cmyk_to_rgb_or_gray = false;
 
   // TODO_IMAGE wait, what does this return on a CMYK image when mode is
@@ -240,68 +273,65 @@ torch::stable::Tensor decode_jpeg(
     // decode as CMYK and convert the lines ourselves (see the scanline loop),
     // like:
     // https://github.com/tensorflow/tensorflow/blob/86871065265b04e0db8ca360c046421efb2bdeb4/tensorflow/core/lib/jpeg/jpeg_mem.cc#L284-L313
-    cmyk_to_rgb_or_gray = cinfo.jpeg_color_space == JCS_CMYK ||
-        cinfo.jpeg_color_space == JCS_YCCK;
+    cmyk_to_rgb_or_gray = jpeg_ctx.jpeg_color_space == JCS_CMYK ||
+        jpeg_ctx.jpeg_color_space == JCS_YCCK;
     switch (mode) {
       case kImageReadModeGray:
-        cinfo.out_color_space = cmyk_to_rgb_or_gray ? JCS_CMYK : JCS_GRAYSCALE;
-        channels = 1;
+        jpeg_ctx.out_color_space =
+            cmyk_to_rgb_or_gray ? JCS_CMYK : JCS_GRAYSCALE;
+        num_output_channels = 1;
         break;
       case kImageReadModeRgb:
-        cinfo.out_color_space = cmyk_to_rgb_or_gray ? JCS_CMYK : JCS_RGB;
-        channels = 3;
+        jpeg_ctx.out_color_space = cmyk_to_rgb_or_gray ? JCS_CMYK : JCS_RGB;
+        num_output_channels = 3;
         break;
       default:
-        jpeg_destroy_decompress(&cinfo);
+        jpeg_destroy_decompress(&jpeg_ctx);
         STD_TORCH_CHECK(
             false, "The provided mode is not supported for JPEG files");
     }
 
-    jpeg_calc_output_dimensions(&cinfo);
+    jpeg_calc_output_dimensions(&jpeg_ctx);
   }
 
-  int exif_orientation = fetch_jpeg_exif_orientation(&cinfo);
+  jpeg_start_decompress(&jpeg_ctx);
 
-  jpeg_start_decompress(&cinfo);
+  int height = jpeg_ctx.output_height;
+  int width = jpeg_ctx.output_width;
 
-  int height = cinfo.output_height;
-  int width = cinfo.output_width;
-
-  int stride = width * channels;
-  tensor = torch::stable::empty(
-      {int64_t(height), int64_t(width), channels}, kStableUInt8);
-  auto ptr = tensor->mutable_data_ptr<uint8_t>();
+  int stride = width * num_output_channels; // we want channel-last output
+  output = torch::stable::empty(
+      {int64_t(height), int64_t(width), num_output_channels}, kStableUInt8);
+  auto outputp = output->mutable_data_ptr<uint8_t>();
 
   if (cmyk_to_rgb_or_gray) {
     cmyk_line_tensor = torch::stable::empty({int64_t(width), 4}, kStableUInt8);
   }
 
-  while (cinfo.output_scanline < cinfo.output_height) {
-    /* jpeg_read_scanlines expects an array of pointers to scanlines.
-     * Here the array is only one element long, but you could ask for
-     * more than one scanline at a time if that's more convenient.
-     */
+  while (jpeg_ctx.output_scanline < jpeg_ctx.output_height) {
     if (cmyk_to_rgb_or_gray) {
       auto cmyk_line_ptr = cmyk_line_tensor->mutable_data_ptr<uint8_t>();
-      jpeg_read_scanlines(&cinfo, &cmyk_line_ptr, 1);
+      jpeg_read_scanlines(&jpeg_ctx, &cmyk_line_ptr, 1);
 
-      if (channels == 3) {
-        convert_line_cmyk_to_rgb(cinfo, cmyk_line_ptr, ptr);
-      } else if (channels == 1) {
-        convert_line_cmyk_to_gray(cinfo, cmyk_line_ptr, ptr);
+      if (num_output_channels == 3) {
+        convert_line_cmyk_to_rgb(width, cmyk_line_ptr, outputp);
+      } else if (num_output_channels == 1) {
+        convert_line_cmyk_to_gray(width, cmyk_line_ptr, outputp);
       }
     } else {
-      jpeg_read_scanlines(&cinfo, &ptr, 1);
+      jpeg_read_scanlines(&jpeg_ctx, &outputp, 1);
     }
-    ptr += stride;
+    outputp += stride;
   }
 
-  jpeg_finish_decompress(&cinfo);
-  jpeg_destroy_decompress(&cinfo);
-  auto output = stable_permute(*tensor, {2, 0, 1});
+  // EXIF markers were parsed during jpeg_read_header so this is just an
+  // in-memory lookup (i.e. we're not going back to the beginning of the file)
+  int exif_orientation = fetch_jpeg_exif_orientation(&jpeg_ctx);
 
-  // EXIF orientation is always applied in torchcodec.
-  return exif_orientation_transform(output, exif_orientation);
+  jpeg_finish_decompress(&jpeg_ctx);
+  jpeg_destroy_decompress(&jpeg_ctx);
+  return exif_orientation_transform(
+      stable_permute(*output, {2, 0, 1}), exif_orientation);
 }
 
 } // namespace facebook::torchcodec

--- a/src/torchcodec/_core/Exif.h
+++ b/src/torchcodec/_core/Exif.h
@@ -55,10 +55,6 @@ direct,
 // to the JPEG path only (PNG EXIF is added when decode_png is migrated) and
 // made always-on: torchcodec always applies EXIF orientation after decoding.
 
-#if JPEG_FOUND
-#include <jpeglib.h>
-#endif
-
 #include <torch/csrc/stable/ops.h>
 #include <torch/headeronly/util/Exception.h>
 
@@ -67,7 +63,6 @@ direct,
 namespace facebook::torchcodec {
 namespace exif_private {
 
-constexpr uint16_t APP1 = 0xe1;
 constexpr uint16_t ENDIANNESS_INTEL = 0x49;
 constexpr uint16_t ENDIANNESS_MOTO = 0x4d;
 constexpr uint16_t REQ_EXIF_TAG_MARK = 0x2a;
@@ -137,6 +132,8 @@ inline uint32_t get_uint32(
 }
 
 inline int fetch_exif_orientation(unsigned char* exif_data_ptr, size_t size) {
+  STD_TORCH_CHECK(exif_data_ptr != nullptr, "exif_data_ptr cannot be null");
+
   int exif_orientation = -1;
 
   // Exif binary structure looks like this
@@ -175,34 +172,6 @@ inline int fetch_exif_orientation(unsigned char* exif_data_ptr, size_t size) {
   }
   return exif_orientation;
 }
-
-#if JPEG_FOUND
-inline int fetch_jpeg_exif_orientation(j_decompress_ptr cinfo) {
-  // Check for Exif marker APP1
-  jpeg_saved_marker_ptr exif_marker = 0;
-  jpeg_saved_marker_ptr cmarker = cinfo->marker_list;
-  while (cmarker && exif_marker == 0) {
-    if (cmarker->marker == APP1) {
-      exif_marker = cmarker;
-    }
-    cmarker = cmarker->next;
-  }
-
-  if (!exif_marker) {
-    return -1;
-  }
-
-  constexpr size_t start_offset = 6;
-  if (exif_marker->data_length <= start_offset) {
-    return -1;
-  }
-
-  auto* exif_data_ptr = exif_marker->data + start_offset;
-  auto size = exif_marker->data_length - start_offset;
-
-  return fetch_exif_orientation(exif_data_ptr, size);
-}
-#endif // #if JPEG_FOUND
 
 constexpr uint16_t IMAGE_ORIENTATION_TL = 1; // normal orientation
 constexpr uint16_t IMAGE_ORIENTATION_TR = 2; // needs horizontal flip

--- a/src/torchcodec/_core/Exif.h
+++ b/src/torchcodec/_core/Exif.h
@@ -83,7 +83,7 @@ class ExifDataReader {
   }
 
   const unsigned char& operator[](size_t index) const {
-    STD_TORCH_CHECK(index >= 0 && index < _size);
+    STD_TORCH_CHECK(index < _size);
     return _ptr[index];
   }
 

--- a/src/torchcodec/decoders/_image_decoders.py
+++ b/src/torchcodec/decoders/_image_decoders.py
@@ -29,6 +29,7 @@ from torchcodec._core.ops import decode_jpeg as _decode_jpeg
 class ImageColorMode(Enum):
     # TODO_IMAGE:  We'll probably need to keep that for BC but ugh. Let's type
     # stuff with Literal strings instead.
+
     """Color mode for image decoding.
 
     Integer values match torchvision's ``ImageReadMode`` and the C++
@@ -56,6 +57,9 @@ def decode_jpeg(
     # TODO_IMAGE: support bytes and file-like
     source: str | Path,
     *,
+    # TODO_IMAGE: The default value of all decoders should be "RGB", not "unchanged".
+    # TODO_IMAGE: we should honor the desired mode across all codecs regardless
+    # of the native codec support.
     mode: ImageColorMode = ImageColorMode.UNCHANGED,
 ) -> torch.Tensor:
     # TODO_IMAGE We should ensure we build and link against turbo. Maybe by

--- a/src/torchcodec/decoders/_image_decoders.py
+++ b/src/torchcodec/decoders/_image_decoders.py
@@ -53,6 +53,10 @@ def _read_file_to_tensor(path: str | Path) -> torch.Tensor:
         return torch.frombuffer(data, dtype=torch.uint8)
 
 
+# TODO_IMAGE: Since we're updating the decoders code a bit, we should run sanity
+# checks ensure we're not leaking anything (there was a leak on webp back then!).
+
+
 def decode_jpeg(
     # TODO_IMAGE: support bytes and file-like
     source: str | Path,


### PR DESCRIPTION
- Use names I actually understand
- avoid raw pointers when possible
- STD_TORCH_CHECK nullptr where relevant
- Cpp casts instead of C casts
- simplify / refac some stuff