### PR TITLE
Fix wheel repair for 3.14t

### DIFF
--- a/src/torchcodec/_core/CMakeLists.txt
+++ b/src/torchcodec/_core/CMakeLists.txt
@@ -252,7 +252,12 @@ function(make_torchcodec_libraries
     )
     set(custom_ops_dependencies
         ${core_library_name}
-        ${Python3_LIBRARIES}
+        pybind11::module # Links Python correctly per-platform (nothing extra on
+                         # Linux, dynamic-lookup on Mac, import lib on Windows).
+                         # Using ${Python3_LIBRARIES} instead adds a DT_NEEDED on
+                         # a shared libpython (e.g. free-threaded builds ship
+                         # libpython3.XXt.so), which auditwheel then wrongly
+                         # bundles into the wheel.
     )
     make_torchcodec_sublibrary(
         "${custom_ops_library_name}"


### PR DESCRIPTION
Attempt to fix the free-threaded wheel repair failure we have on [`main`](https://github.com/meta-pytorch/torchcodec/actions/runs/29586475774/job/87904650776):

```
RuntimeError: Unexpected libraries bundled in torchcodec-0.16.0.dev20260717+cpu-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl: libpython3-045a6c73.14t.so.1.0
```


This seems very related to https://github.com/meta-pytorch/torchcodec/pull/1487 which can probably be closed if this gets merged