### PR TITLE
png decoder: cleanup and fixes

### DIFF
--- a/src/torchcodec/_core/DecodeJpeg.cpp
+++ b/src/torchcodec/_core/DecodeJpeg.cpp
@@ -55,12 +55,12 @@ constexpr uint16_t EXIF_APP1 = 0xe1;
 
 // Helpers to convert a CMYK line to RGB or grayscale, since libjpeg doesn't
 // handle that directly.
-using cmyk_line_converter_fn = void (*)(int, const uint8_t*, uint8_t*);
+using CmykLineConverterFn = void (*)(int, const uint8_t*, uint8_t*);
 
 struct CMYKHelper {
   uint8_t* cmyk_line_ptr = nullptr;
   // This is either convert_line_cmyk_to_rgb or convert_line_cmyk_to_gray
-  cmyk_line_converter_fn convert_fn = nullptr;
+  CmykLineConverterFn convert_fn = nullptr;
 };
 
 inline uint8_t cmyk_to_rgb(uint8_t k, uint8_t cmy) {
@@ -141,12 +141,12 @@ int fetch_jpeg_exif_orientation(j_decompress_ptr jpeg_ctx) {
 
 // Error context that gets passed by libjpeg to its callbacks
 // (error_exit_cb, fill_input_buffer_cb, etc.).
-// libjpeg doesn't actually pass this error_ctx_t, it passes the jpeg_ctx object
-// which has an `err` field. This `err` field is *still* not an error_ctx_t
+// libjpeg doesn't actually pass this ErrorCtx, it passes the jpeg_ctx object
+// which has an `err` field. This `err` field is *still* not an ErrorCtx
 // object, it's the jpeg_error_mgr base field, but we can cast it back to
-// error_ctx_t in the callbacks because the struct and its first field share the
+// ErrorCtx in the callbacks because the struct and its first field share the
 // same address.
-struct error_ctx_t {
+struct ErrorCtx {
   jpeg_error_mgr base;
   char last_error_message[JMSG_LENGTH_MAX];
   jmp_buf setjmp_buffer;
@@ -154,7 +154,7 @@ struct error_ctx_t {
 
 // Callback called by libjpeg when an error occurs.
 void error_exit_cb(j_common_ptr jpeg_ctx) {
-  auto error_ctx = reinterpret_cast<error_ctx_t*>(jpeg_ctx->err);
+  auto error_ctx = reinterpret_cast<ErrorCtx*>(jpeg_ctx->err);
   error_ctx->base.format_message(jpeg_ctx, error_ctx->last_error_message);
   longjmp(error_ctx->setjmp_buffer, 1);
 }
@@ -164,7 +164,7 @@ void error_exit_cb(j_common_ptr jpeg_ctx) {
 // Should we ever want to support truncated JPEGs, we could instead return a
 // fake EOI.
 boolean fill_input_buffer_cb(j_decompress_ptr jpeg_ctx) {
-  auto error_ctx = reinterpret_cast<error_ctx_t*>(jpeg_ctx->err);
+  auto error_ctx = reinterpret_cast<ErrorCtx*>(jpeg_ctx->err);
   strcpy(error_ctx->last_error_message, "Image is incomplete or truncated.");
   longjmp(error_ctx->setjmp_buffer, 1);
   return TRUE; // never reached, but keeps compiler happy
@@ -181,7 +181,7 @@ void skip_input_data_cb(j_decompress_ptr jpeg_ctx, long num_bytes) {
     // In TorchVision this would return a fake EOI, but that's inconsistent with
     // our fill_input_buffer_cb, which treats truncated JPEGs as an error.
     // So we error here too.
-    auto error_ctx = reinterpret_cast<error_ctx_t*>(jpeg_ctx->err);
+    auto error_ctx = reinterpret_cast<ErrorCtx*>(jpeg_ctx->err);
     strcpy(
         error_ctx->last_error_message,
         "Skipped over more data than is available in the input buffer.");
@@ -201,7 +201,7 @@ void term_source_cb(j_decompress_ptr) {}
 // function returns.
 std::tuple<int, bool> read_header_and_start(
     jpeg_decompress_struct& jpeg_ctx,
-    error_ctx_t& error_ctx,
+    ErrorCtx& error_ctx,
     const uint8_t* input_ptr,
     const size_t input_len,
     ImageReadMode mode) {
@@ -271,7 +271,7 @@ std::tuple<int, bool> read_header_and_start(
 // The actual decoding loop, row by row.
 void decode_rows(
     jpeg_decompress_struct& jpeg_ctx,
-    error_ctx_t& error_ctx,
+    ErrorCtx& error_ctx,
     uint8_t* output_ptr,
     int stride,
     CMYKHelper& cmyk_helper) {
@@ -419,7 +419,7 @@ torch::stable::Tensor decode_jpeg(
   torch::stable::Tensor cmyk_line_tensor;
 
   jpeg_decompress_struct jpeg_ctx;
-  error_ctx_t error_ctx;
+  ErrorCtx error_ctx;
   jpeg_ctx.err = jpeg_std_error(&error_ctx.base);
   error_ctx.base.error_exit = error_exit_cb;
 

--- a/src/torchcodec/_core/DecodeJpeg.cpp
+++ b/src/torchcodec/_core/DecodeJpeg.cpp
@@ -410,6 +410,9 @@ void decode_rows(
 //
 /* clang-format on */
 
+// TODO_IMAGE: align names. everywhere. this is input, other places it's data,
+// other places it's something else. Should align here, in the header, in the
+// custom op definition, etc. Across codecs.
 torch::stable::Tensor decode_jpeg(
     const torch::stable::Tensor& input,
     int64_t mode) {

--- a/src/torchcodec/_core/DecodePng.cpp
+++ b/src/torchcodec/_core/DecodePng.cpp
@@ -122,14 +122,11 @@ void read_callback(png_structp png_ptr, png_bytep output, png_size_t bytes) {
 struct PngHeader {
   png_uint_32 width;
   png_uint_32 height;
-  int channels;
+  int num_output_channels;
   int bit_depth;
-  int number_of_passes;
+  int num_passes;
 };
 
-// Reads the PNG header and configures the requested color transforms. Contains
-// a setjmp() point, so it must not declare anything needing a non-trivial
-// destructor. See Note [libpng error handling].
 PngHeader read_header_and_configure(
     png_structp& png_ptr,
     png_infop& info_ptr,
@@ -137,14 +134,10 @@ PngHeader read_header_and_configure(
     SourceCtx& source_ctx,
     ImageReadMode read_mode) {
   if (setjmp(png_jmpbuf(png_ptr)) != 0) {
-    // See Note [libpng error handling]
     png_destroy_read_struct(&png_ptr, &info_ptr, nullptr);
     STD_TORCH_CHECK(false, "decode_png failed: ", error_ctx.error_message);
   }
 
-  // The 8-byte offset in source_ctx (see decode_png) skips the PNG signature we
-  // already validated, so we tell libpng about those 8 bytes here.
-  png_set_sig_bytes(png_ptr, 8);
   png_set_read_fn(png_ptr, &source_ctx, read_callback);
   png_read_info(png_ptr, info_ptr);
 
@@ -164,7 +157,7 @@ PngHeader read_header_and_configure(
 
   if (retval != 1) {
     png_destroy_read_struct(&png_ptr, &info_ptr, nullptr);
-    STD_TORCH_CHECK(retval == 1, "Could read image metadata from content.")
+    STD_TORCH_CHECK(retval == 1, "Could not read image metadata from content.")
   }
 
   if (bit_depth > 8 && bit_depth != 16) {
@@ -176,17 +169,17 @@ PngHeader read_header_and_configure(
         ". Only <=8 and 16 are supported.")
   }
 
-  int channels = png_get_channels(png_ptr, info_ptr);
+  int num_output_channels = png_get_channels(png_ptr, info_ptr);
 
   if (color_type == PNG_COLOR_TYPE_GRAY && bit_depth < 8) {
     png_set_expand_gray_1_2_4_to_8(png_ptr);
   }
 
-  int number_of_passes;
+  int num_passes;
   if (interlace_type == PNG_INTERLACE_ADAM7) {
-    number_of_passes = png_set_interlace_handling(png_ptr);
+    num_passes = png_set_interlace_handling(png_ptr);
   } else {
-    number_of_passes = 1;
+    num_passes = 1;
   }
 
   if (read_mode != ImageReadMode::Unchanged) {
@@ -210,7 +203,7 @@ PngHeader read_header_and_configure(
           if (has_color) {
             png_set_rgb_to_gray(png_ptr, 1, 0.2989, 0.587);
           }
-          channels = 1;
+          num_output_channels = 1;
         }
         break;
       case ImageReadMode::GrayAlpha:
@@ -227,7 +220,7 @@ PngHeader read_header_and_configure(
           if (has_color) {
             png_set_rgb_to_gray(png_ptr, 1, 0.2989, 0.587);
           }
-          channels = 2;
+          num_output_channels = 2;
         }
         break;
       case ImageReadMode::Rgb:
@@ -242,7 +235,7 @@ PngHeader read_header_and_configure(
           if (has_alpha) {
             png_set_strip_alpha(png_ptr);
           }
-          channels = 3;
+          num_output_channels = 3;
         }
         break;
       case ImageReadMode::RgbAlpha:
@@ -257,7 +250,7 @@ PngHeader read_header_and_configure(
           if (!has_alpha) {
             png_set_add_alpha(png_ptr, (1 << bit_depth) - 1, PNG_FILLER_AFTER);
           }
-          channels = 4;
+          num_output_channels = 4;
         }
         break;
       default:
@@ -269,12 +262,9 @@ PngHeader read_header_and_configure(
     png_read_update_info(png_ptr, info_ptr);
   }
 
-  return {width, height, channels, bit_depth, number_of_passes};
+  return {width, height, num_output_channels, bit_depth, num_passes};
 }
 
-// The actual decoding loop, row by row. Contains a setjmp() point, so it must
-// not declare anything needing a non-trivial destructor, and `tensor` must be
-// owned by the caller (decode_png). See Note [libpng error handling].
 void decode_rows(
     png_structp& png_ptr,
     png_infop& info_ptr,
@@ -294,7 +284,7 @@ void decode_rows(
   }
 
   auto output_ptr = (uint8_t*)output.mutable_data_ptr();
-  for (int pass = 0; pass < header.number_of_passes; pass++) {
+  for (int pass = 0; pass < header.num_passes; pass++) {
     for (png_uint_32 i = 0; i < header.height; ++i) {
       png_read_row(png_ptr, output_ptr, nullptr);
       output_ptr += num_pixels_per_row * (is_16_bits ? 2 : 1);
@@ -311,29 +301,24 @@ torch::stable::Tensor decode_png(
   validate_encoded_data(input);
 
   auto input_ptr = input.const_data_ptr<uint8_t>();
-  STD_TORCH_CHECK(input.numel() >= 8, "Content is too small for png!")
-  STD_TORCH_CHECK(!png_sig_cmp(input_ptr, 0, 8), "Content is not png!")
 
   auto png_ptr =
       png_create_read_struct(PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr);
-  STD_TORCH_CHECK(png_ptr, "libpng read structure allocation failed!")
+  STD_TORCH_CHECK(
+      png_ptr != nullptr, "libpng read structure allocation failed!")
   auto info_ptr = png_create_info_struct(png_ptr);
-  if (!info_ptr) {
+  if (info_ptr == nullptr) {
     png_destroy_read_struct(&png_ptr, nullptr, nullptr);
-    // Seems redundant with the if statement. done here to avoid leaking memory.
     STD_TORCH_CHECK(info_ptr, "libpng info structure allocation failed!")
   }
 
   ErrorCtx error_ctx;
   png_set_error_fn(png_ptr, &error_ctx, error_callback, /*warn_fn=*/nullptr);
 
-  // The 8-byte offset skips the PNG signature we already validated above.
   SourceCtx source_ctx;
-  source_ctx.ptr = png_const_bytep(input_ptr) + 8;
-  source_ctx.count = input.numel() - 8;
+  source_ctx.ptr = png_const_bytep(input_ptr);
+  source_ctx.count = input.numel();
 
-  // `output` is declared here, in a function that does NOT call setjmp(). See
-  // Note [libpng error handling].
   torch::stable::Tensor output;
 
   auto header = read_header_and_configure(
@@ -343,10 +328,10 @@ torch::stable::Tensor decode_png(
       source_ctx,
       static_cast<ImageReadMode>(mode));
 
-  auto num_pixels_per_row = header.width * header.channels;
+  auto num_pixels_per_row = header.width * header.num_output_channels;
   auto is_16_bits = header.bit_depth == 16;
   output = torch::stable::empty(
-      {int64_t(header.height), int64_t(header.width), header.channels},
+      {int64_t(header.height), int64_t(header.width), header.num_output_channels},
       is_16_bits ? kStableUInt16 : kStableUInt8);
 
   decode_rows(

--- a/src/torchcodec/_core/DecodePng.cpp
+++ b/src/torchcodec/_core/DecodePng.cpp
@@ -84,21 +84,17 @@ int fetch_png_exif_orientation(png_structp png_ptr, png_infop info_ptr) {
   png_uint_32 num_exif = 0;
   png_bytep exif = 0;
 
-  // Exif info could be in info_ptr
   if (png_get_valid(png_ptr, info_ptr, PNG_INFO_eXIf)) {
     png_get_eXIf_1(png_ptr, info_ptr, &num_exif, &exif);
   }
 
-  if (exif && num_exif > 0) {
+  if (exif != nullptr && num_exif > 0) {
     return fetch_exif_orientation(exif, num_exif);
+  } else {
+    return 1;
   }
-  return -1;
 }
 
-// We decode from an in-memory buffer rather than a FILE*, so we feed libpng
-// through a custom read function. libpng hands our read callback back a single
-// user pointer (set via png_set_read_fn, retrieved with png_get_io_ptr): this
-// struct is that context, tracking the current read position and bytes left.
 struct SourceCtx {
   png_const_bytep ptr;
   png_size_t count;
@@ -107,9 +103,6 @@ struct SourceCtx {
 void read_callback(png_structp png_ptr, png_bytep output, png_size_t bytes) {
   auto* source_ctx = static_cast<SourceCtx*>(png_get_io_ptr(png_ptr));
   if (source_ctx->count < bytes) {
-    // Route the error through libpng's error handler (our error_callback),
-    // which longjmp()s. We must NOT throw a C++ exception through libpng's C
-    // stack. See Note [libpng error handling].
     png_error(
         png_ptr,
         "Out of bound read in decode_png. The input image might be corrupted?");
@@ -269,12 +262,11 @@ void decode_rows(
     png_structp& png_ptr,
     png_infop& info_ptr,
     ErrorCtx& error_ctx,
-    torch::stable::Tensor& output,
-    const PngHeader& header,
-    bool is_16_bits,
-    png_uint_32 num_pixels_per_row) {
+    uint8_t* output_ptr,
+    png_uint_32 height,
+    int num_passes,
+    int stride) {
   if (setjmp(png_jmpbuf(png_ptr)) != 0) {
-    // See Note [libpng error handling]
     png_destroy_read_struct(&png_ptr, &info_ptr, nullptr);
     STD_TORCH_CHECK(false, "decode_png failed: ", error_ctx.error_message);
   }
@@ -283,13 +275,12 @@ void decode_rows(
     png_set_swap(png_ptr);
   }
 
-  auto output_ptr = (uint8_t*)output.mutable_data_ptr();
-  for (int pass = 0; pass < header.num_passes; pass++) {
-    for (png_uint_32 i = 0; i < header.height; ++i) {
-      png_read_row(png_ptr, output_ptr, nullptr);
-      output_ptr += num_pixels_per_row * (is_16_bits ? 2 : 1);
+  for (int pass = 0; pass < num_passes; pass++) {
+    uint8_t* row_ptr = output_ptr;
+    for (png_uint_32 i = 0; i < height; ++i) {
+      png_read_row(png_ptr, row_ptr, nullptr);
+      row_ptr += stride;
     }
-    output_ptr = (uint8_t*)output.mutable_data_ptr();
   }
 }
 
@@ -331,20 +322,21 @@ torch::stable::Tensor decode_png(
   auto num_pixels_per_row = header.width * header.num_output_channels;
   auto is_16_bits = header.bit_depth == 16;
   output = torch::stable::empty(
-      {int64_t(header.height), int64_t(header.width), header.num_output_channels},
+      {int64_t(header.height),
+       int64_t(header.width),
+       header.num_output_channels},
       is_16_bits ? kStableUInt16 : kStableUInt8);
 
+  int stride = num_pixels_per_row * (is_16_bits ? 2 : 1);
   decode_rows(
       png_ptr,
       info_ptr,
       error_ctx,
-      output,
-      header,
-      is_16_bits,
-      num_pixels_per_row);
+      (uint8_t*)output.mutable_data_ptr(),
+      header.height,
+      header.num_passes,
+      stride);
 
-  // torchcodec always applies EXIF orientation (unlike torchvision, which gates
-  // this behind an apply_exif_orientation parameter).
   int exif_orientation = fetch_png_exif_orientation(png_ptr, info_ptr);
 
   png_destroy_read_struct(&png_ptr, &info_ptr, nullptr);

--- a/src/torchcodec/_core/DecodePng.cpp
+++ b/src/torchcodec/_core/DecodePng.cpp
@@ -59,16 +59,18 @@ using namespace exif_private;
 namespace {
 
 bool is_little_endian() {
-  uint32_t x = 1;
-  return *(uint8_t*)&x;
+  int64_t x = 1;
+  uint8_t first_byte;
+  std::memcpy(&first_byte, &x, 1);
+  return first_byte == 1;
 }
 
-struct PngErrorContext {
+struct ErrorCtx {
   char error_message[256] = "";
 };
 
-void png_error_callback(png_structp png_ptr, png_const_charp error_message) {
-  auto* error_ctx = static_cast<PngErrorContext*>(png_get_error_ptr(png_ptr));
+void error_callback(png_structp png_ptr, png_const_charp error_message) {
+  auto* error_ctx = static_cast<ErrorCtx*>(png_get_error_ptr(png_ptr));
   if (error_ctx != nullptr) {
     std::snprintf(
         error_ctx->error_message,
@@ -114,11 +116,10 @@ torch::stable::Tensor decode_png(
   auto datap = data.const_data_ptr<uint8_t>();
   auto datap_len = data.numel();
 
-  // Capture libpng's error message (see png_error_callback) so we can report it
+  // Capture libpng's error message (see error_callback) so we can report it
   // instead of a generic "internal error".
-  PngErrorContext error_ctx;
-  png_set_error_fn(
-      png_ptr, &error_ctx, png_error_callback, /*warn_fn=*/nullptr);
+  ErrorCtx error_ctx;
+  png_set_error_fn(png_ptr, &error_ctx, error_callback, /*warn_fn=*/nullptr);
 
   // NOTE: libpng uses setjmp/longjmp for error handling. longjmp does not
   // unwind C++ stack frames, so destructors of objects created after setjmp
@@ -135,27 +136,33 @@ torch::stable::Tensor decode_png(
   auto is_png = !png_sig_cmp(datap, 0, 8);
   STD_TORCH_CHECK(is_png, "Content is not png!")
 
-  struct Reader {
+  // We decode from an in-memory buffer rather than a FILE*, so we feed libpng
+  // through a custom read function. libpng hands our read callback back a
+  // single user pointer (set via png_set_read_fn, retrieved with
+  // png_get_io_ptr): this struct is that context, tracking the current read
+  // position and bytes left. The 8-byte offset skips the PNG signature we
+  // already validated.
+  struct SourceCtx {
     png_const_bytep ptr;
     png_size_t count;
-  } reader;
+  } source_ctx;
 
-  reader.ptr = png_const_bytep(datap) + 8;
-  reader.count = datap_len - 8;
+  source_ctx.ptr = png_const_bytep(datap) + 8;
+  source_ctx.count = datap_len - 8;
 
   auto read_callback = [](png_structp png_ptr,
                           png_bytep output,
                           png_size_t bytes) {
-    auto reader = static_cast<Reader*>(png_get_io_ptr(png_ptr));
+    auto source_ctx = static_cast<SourceCtx*>(png_get_io_ptr(png_ptr));
     STD_TORCH_CHECK(
-        reader->count >= bytes,
+        source_ctx->count >= bytes,
         "Out of bound read in decode_png. The input image might be corrupted?");
-    std::copy(reader->ptr, reader->ptr + bytes, output);
-    reader->ptr += bytes;
-    reader->count -= bytes;
+    std::copy(source_ctx->ptr, source_ctx->ptr + bytes, output);
+    source_ctx->ptr += bytes;
+    source_ctx->count -= bytes;
   };
   png_set_sig_bytes(png_ptr, 8);
-  png_set_read_fn(png_ptr, &reader, read_callback);
+  png_set_read_fn(png_ptr, &source_ctx, read_callback);
   png_read_info(png_ptr, info_ptr);
 
   png_uint_32 width, height;

--- a/src/torchcodec/_core/DecodePng.cpp
+++ b/src/torchcodec/_core/DecodePng.cpp
@@ -279,7 +279,7 @@ void decode_rows(
     png_structp& png_ptr,
     png_infop& info_ptr,
     ErrorCtx& error_ctx,
-    torch::stable::Tensor& tensor,
+    torch::stable::Tensor& output,
     const PngHeader& header,
     bool is_16_bits,
     png_uint_32 num_pixels_per_row) {
@@ -293,48 +293,26 @@ void decode_rows(
     png_set_swap(png_ptr);
   }
 
-  auto t_ptr = (uint8_t*)tensor.mutable_data_ptr();
+  auto output_ptr = (uint8_t*)output.mutable_data_ptr();
   for (int pass = 0; pass < header.number_of_passes; pass++) {
     for (png_uint_32 i = 0; i < header.height; ++i) {
-      png_read_row(png_ptr, t_ptr, nullptr);
-      t_ptr += num_pixels_per_row * (is_16_bits ? 2 : 1);
+      png_read_row(png_ptr, output_ptr, nullptr);
+      output_ptr += num_pixels_per_row * (is_16_bits ? 2 : 1);
     }
-    t_ptr = (uint8_t*)tensor.mutable_data_ptr();
+    output_ptr = (uint8_t*)output.mutable_data_ptr();
   }
 }
 
 } // namespace
 
-// Note [libpng error handling]
-//
-// This mirrors Note [libjpeg error handling] in DecodeJpeg.cpp - see that note
-// for the full explanation. The short version:
-//
-// libpng uses setjmp/longjmp for error handling. Per C11 7.13.2.1, a non-
-// volatile automatic object that is local to the function containing the
-// setjmp() and is modified between the setjmp() and the longjmp() has an
-// *indeterminate* value once we longjmp() back into the setjmp() block. Running
-// its destructor (or otherwise using it) there is undefined behavior.
-//
-// So the `output` tensor - and anything else needing a non-trivial destructor -
-// must NOT live in a function that calls setjmp(). We keep it in decode_png(),
-// which never calls setjmp(), and confine the setjmp() points to the
-// read_header_and_configure() and decode_rows() helpers, which declare nothing
-// needing destruction. Those helpers destroy the libpng structs and STD_TORCH_-
-// CHECK(false) on the error path.
-//
-// Relatedly, we must never let a C++ exception (e.g. from STD_TORCH_CHECK)
-// propagate through libpng's C stack: our libpng callbacks (error_callback,
-// read_callback) route errors through longjmp() instead of throwing.
 torch::stable::Tensor decode_png(
-    const torch::stable::Tensor& data,
+    const torch::stable::Tensor& input,
     int64_t mode) {
-  validate_encoded_data(data);
+  validate_encoded_data(input);
 
-  auto datap = data.const_data_ptr<uint8_t>();
-  auto datap_len = data.numel();
-  STD_TORCH_CHECK(datap_len >= 8, "Content is too small for png!")
-  STD_TORCH_CHECK(!png_sig_cmp(datap, 0, 8), "Content is not png!")
+  auto input_ptr = input.const_data_ptr<uint8_t>();
+  STD_TORCH_CHECK(input.numel() >= 8, "Content is too small for png!")
+  STD_TORCH_CHECK(!png_sig_cmp(input_ptr, 0, 8), "Content is not png!")
 
   auto png_ptr =
       png_create_read_struct(PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr);
@@ -351,12 +329,12 @@ torch::stable::Tensor decode_png(
 
   // The 8-byte offset skips the PNG signature we already validated above.
   SourceCtx source_ctx;
-  source_ctx.ptr = png_const_bytep(datap) + 8;
-  source_ctx.count = datap_len - 8;
+  source_ctx.ptr = png_const_bytep(input_ptr) + 8;
+  source_ctx.count = input.numel() - 8;
 
-  // `tensor` is declared here, in a function that does NOT call setjmp(). See
+  // `output` is declared here, in a function that does NOT call setjmp(). See
   // Note [libpng error handling].
-  torch::stable::Tensor tensor;
+  torch::stable::Tensor output;
 
   auto header = read_header_and_configure(
       png_ptr,
@@ -367,7 +345,7 @@ torch::stable::Tensor decode_png(
 
   auto num_pixels_per_row = header.width * header.channels;
   auto is_16_bits = header.bit_depth == 16;
-  tensor = torch::stable::empty(
+  output = torch::stable::empty(
       {int64_t(header.height), int64_t(header.width), header.channels},
       is_16_bits ? kStableUInt16 : kStableUInt8);
 
@@ -375,7 +353,7 @@ torch::stable::Tensor decode_png(
       png_ptr,
       info_ptr,
       error_ctx,
-      tensor,
+      output,
       header,
       is_16_bits,
       num_pixels_per_row);
@@ -387,7 +365,7 @@ torch::stable::Tensor decode_png(
   png_destroy_read_struct(&png_ptr, &info_ptr, nullptr);
 
   return exif_orientation_transform(
-      stable_permute(tensor, {2, 0, 1}), exif_orientation);
+      stable_permute(output, {2, 0, 1}), exif_orientation);
 }
 
 } // namespace facebook::torchcodec

--- a/src/torchcodec/_core/DecodePng.cpp
+++ b/src/torchcodec/_core/DecodePng.cpp
@@ -46,8 +46,7 @@ torch::stable::Tensor decode_png(
 #include <algorithm>
 #include <cstdint>
 #include <cstdio>
-#include <optional>
-#include <string>
+#include <cstring>
 
 #include "Exif.h"
 #include "ImageCommon.h"
@@ -96,71 +95,55 @@ int fetch_png_exif_orientation(png_structp png_ptr, png_infop info_ptr) {
   return -1;
 }
 
-} // namespace
+// We decode from an in-memory buffer rather than a FILE*, so we feed libpng
+// through a custom read function. libpng hands our read callback back a single
+// user pointer (set via png_set_read_fn, retrieved with png_get_io_ptr): this
+// struct is that context, tracking the current read position and bytes left.
+struct SourceCtx {
+  png_const_bytep ptr;
+  png_size_t count;
+};
 
-torch::stable::Tensor decode_png(
-    const torch::stable::Tensor& data,
-    int64_t mode) {
-  validate_encoded_data(data);
-
-  auto png_ptr =
-      png_create_read_struct(PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr);
-  STD_TORCH_CHECK(png_ptr, "libpng read structure allocation failed!")
-  auto info_ptr = png_create_info_struct(png_ptr);
-  if (!info_ptr) {
-    png_destroy_read_struct(&png_ptr, nullptr, nullptr);
-    // Seems redundant with the if statement. done here to avoid leaking memory.
-    STD_TORCH_CHECK(info_ptr, "libpng info structure allocation failed!")
+void read_callback(png_structp png_ptr, png_bytep output, png_size_t bytes) {
+  auto* source_ctx = static_cast<SourceCtx*>(png_get_io_ptr(png_ptr));
+  if (source_ctx->count < bytes) {
+    // Route the error through libpng's error handler (our error_callback),
+    // which longjmp()s. We must NOT throw a C++ exception through libpng's C
+    // stack. See Note [libpng error handling].
+    png_error(
+        png_ptr,
+        "Out of bound read in decode_png. The input image might be corrupted?");
   }
+  std::copy(source_ctx->ptr, source_ctx->ptr + bytes, output);
+  source_ctx->ptr += bytes;
+  source_ctx->count -= bytes;
+}
 
-  auto datap = data.const_data_ptr<uint8_t>();
-  auto datap_len = data.numel();
+struct PngHeader {
+  png_uint_32 width;
+  png_uint_32 height;
+  int channels;
+  int bit_depth;
+  int number_of_passes;
+};
 
-  // Capture libpng's error message (see error_callback) so we can report it
-  // instead of a generic "internal error".
-  ErrorCtx error_ctx;
-  png_set_error_fn(png_ptr, &error_ctx, error_callback, /*warn_fn=*/nullptr);
-
-  // NOTE: libpng uses setjmp/longjmp for error handling. longjmp does not
-  // unwind C++ stack frames, so destructors of objects created after setjmp
-  // won't run. We use std::optional to declare tensors before setjmp while
-  // deferring construction, and explicitly reset them on the error path.
-  std::optional<torch::stable::Tensor> tensor;
-
+// Reads the PNG header and configures the requested color transforms. Contains
+// a setjmp() point, so it must not declare anything needing a non-trivial
+// destructor. See Note [libpng error handling].
+PngHeader read_header_and_configure(
+    png_structp& png_ptr,
+    png_infop& info_ptr,
+    ErrorCtx& error_ctx,
+    SourceCtx& source_ctx,
+    ImageReadMode read_mode) {
   if (setjmp(png_jmpbuf(png_ptr)) != 0) {
-    tensor.reset();
+    // See Note [libpng error handling]
     png_destroy_read_struct(&png_ptr, &info_ptr, nullptr);
     STD_TORCH_CHECK(false, "decode_png failed: ", error_ctx.error_message);
   }
-  STD_TORCH_CHECK(datap_len >= 8, "Content is too small for png!")
-  auto is_png = !png_sig_cmp(datap, 0, 8);
-  STD_TORCH_CHECK(is_png, "Content is not png!")
 
-  // We decode from an in-memory buffer rather than a FILE*, so we feed libpng
-  // through a custom read function. libpng hands our read callback back a
-  // single user pointer (set via png_set_read_fn, retrieved with
-  // png_get_io_ptr): this struct is that context, tracking the current read
-  // position and bytes left. The 8-byte offset skips the PNG signature we
-  // already validated.
-  struct SourceCtx {
-    png_const_bytep ptr;
-    png_size_t count;
-  } source_ctx;
-
-  source_ctx.ptr = png_const_bytep(datap) + 8;
-  source_ctx.count = datap_len - 8;
-
-  auto read_callback = [](png_structp png_ptr,
-                          png_bytep output,
-                          png_size_t bytes) {
-    auto source_ctx = static_cast<SourceCtx*>(png_get_io_ptr(png_ptr));
-    STD_TORCH_CHECK(
-        source_ctx->count >= bytes,
-        "Out of bound read in decode_png. The input image might be corrupted?");
-    std::copy(source_ctx->ptr, source_ctx->ptr + bytes, output);
-    source_ctx->ptr += bytes;
-    source_ctx->count -= bytes;
-  };
+  // The 8-byte offset in source_ctx (see decode_png) skips the PNG signature we
+  // already validated, so we tell libpng about those 8 bytes here.
   png_set_sig_bytes(png_ptr, 8);
   png_set_read_fn(png_ptr, &source_ctx, read_callback);
   png_read_info(png_ptr, info_ptr);
@@ -188,8 +171,9 @@ torch::stable::Tensor decode_png(
     png_destroy_read_struct(&png_ptr, &info_ptr, nullptr);
     STD_TORCH_CHECK(
         false,
-        "bit depth of png image is " + std::to_string(bit_depth) +
-            ". Only <=8 and 16 are supported.")
+        "bit depth of png image is ",
+        bit_depth,
+        ". Only <=8 and 16 are supported.")
   }
 
   int channels = png_get_channels(png_ptr, info_ptr);
@@ -205,7 +189,6 @@ torch::stable::Tensor decode_png(
     number_of_passes = 1;
   }
 
-  auto read_mode = static_cast<ImageReadMode>(mode);
   if (read_mode != ImageReadMode::Unchanged) {
     // TODO: consider supporting PNG_INFO_tRNS
     bool is_palette = (color_type & PNG_COLOR_MASK_PALETTE) != 0;
@@ -286,22 +269,116 @@ torch::stable::Tensor decode_png(
     png_read_update_info(png_ptr, info_ptr);
   }
 
-  auto num_pixels_per_row = width * channels;
-  auto is_16_bits = bit_depth == 16;
-  tensor = torch::stable::empty(
-      {int64_t(height), int64_t(width), channels},
-      is_16_bits ? kStableUInt16 : kStableUInt8);
+  return {width, height, channels, bit_depth, number_of_passes};
+}
+
+// The actual decoding loop, row by row. Contains a setjmp() point, so it must
+// not declare anything needing a non-trivial destructor, and `tensor` must be
+// owned by the caller (decode_png). See Note [libpng error handling].
+void decode_rows(
+    png_structp& png_ptr,
+    png_infop& info_ptr,
+    ErrorCtx& error_ctx,
+    torch::stable::Tensor& tensor,
+    const PngHeader& header,
+    bool is_16_bits,
+    png_uint_32 num_pixels_per_row) {
+  if (setjmp(png_jmpbuf(png_ptr)) != 0) {
+    // See Note [libpng error handling]
+    png_destroy_read_struct(&png_ptr, &info_ptr, nullptr);
+    STD_TORCH_CHECK(false, "decode_png failed: ", error_ctx.error_message);
+  }
+
   if (is_little_endian()) {
     png_set_swap(png_ptr);
   }
-  auto t_ptr = (uint8_t*)tensor->mutable_data_ptr();
-  for (int pass = 0; pass < number_of_passes; pass++) {
-    for (png_uint_32 i = 0; i < height; ++i) {
+
+  auto t_ptr = (uint8_t*)tensor.mutable_data_ptr();
+  for (int pass = 0; pass < header.number_of_passes; pass++) {
+    for (png_uint_32 i = 0; i < header.height; ++i) {
       png_read_row(png_ptr, t_ptr, nullptr);
       t_ptr += num_pixels_per_row * (is_16_bits ? 2 : 1);
     }
-    t_ptr = (uint8_t*)tensor->mutable_data_ptr();
+    t_ptr = (uint8_t*)tensor.mutable_data_ptr();
   }
+}
+
+} // namespace
+
+// Note [libpng error handling]
+//
+// This mirrors Note [libjpeg error handling] in DecodeJpeg.cpp - see that note
+// for the full explanation. The short version:
+//
+// libpng uses setjmp/longjmp for error handling. Per C11 7.13.2.1, a non-
+// volatile automatic object that is local to the function containing the
+// setjmp() and is modified between the setjmp() and the longjmp() has an
+// *indeterminate* value once we longjmp() back into the setjmp() block. Running
+// its destructor (or otherwise using it) there is undefined behavior.
+//
+// So the `output` tensor - and anything else needing a non-trivial destructor -
+// must NOT live in a function that calls setjmp(). We keep it in decode_png(),
+// which never calls setjmp(), and confine the setjmp() points to the
+// read_header_and_configure() and decode_rows() helpers, which declare nothing
+// needing destruction. Those helpers destroy the libpng structs and STD_TORCH_-
+// CHECK(false) on the error path.
+//
+// Relatedly, we must never let a C++ exception (e.g. from STD_TORCH_CHECK)
+// propagate through libpng's C stack: our libpng callbacks (error_callback,
+// read_callback) route errors through longjmp() instead of throwing.
+torch::stable::Tensor decode_png(
+    const torch::stable::Tensor& data,
+    int64_t mode) {
+  validate_encoded_data(data);
+
+  auto datap = data.const_data_ptr<uint8_t>();
+  auto datap_len = data.numel();
+  STD_TORCH_CHECK(datap_len >= 8, "Content is too small for png!")
+  STD_TORCH_CHECK(!png_sig_cmp(datap, 0, 8), "Content is not png!")
+
+  auto png_ptr =
+      png_create_read_struct(PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr);
+  STD_TORCH_CHECK(png_ptr, "libpng read structure allocation failed!")
+  auto info_ptr = png_create_info_struct(png_ptr);
+  if (!info_ptr) {
+    png_destroy_read_struct(&png_ptr, nullptr, nullptr);
+    // Seems redundant with the if statement. done here to avoid leaking memory.
+    STD_TORCH_CHECK(info_ptr, "libpng info structure allocation failed!")
+  }
+
+  ErrorCtx error_ctx;
+  png_set_error_fn(png_ptr, &error_ctx, error_callback, /*warn_fn=*/nullptr);
+
+  // The 8-byte offset skips the PNG signature we already validated above.
+  SourceCtx source_ctx;
+  source_ctx.ptr = png_const_bytep(datap) + 8;
+  source_ctx.count = datap_len - 8;
+
+  // `tensor` is declared here, in a function that does NOT call setjmp(). See
+  // Note [libpng error handling].
+  torch::stable::Tensor tensor;
+
+  auto header = read_header_and_configure(
+      png_ptr,
+      info_ptr,
+      error_ctx,
+      source_ctx,
+      static_cast<ImageReadMode>(mode));
+
+  auto num_pixels_per_row = header.width * header.channels;
+  auto is_16_bits = header.bit_depth == 16;
+  tensor = torch::stable::empty(
+      {int64_t(header.height), int64_t(header.width), header.channels},
+      is_16_bits ? kStableUInt16 : kStableUInt8);
+
+  decode_rows(
+      png_ptr,
+      info_ptr,
+      error_ctx,
+      tensor,
+      header,
+      is_16_bits,
+      num_pixels_per_row);
 
   // torchcodec always applies EXIF orientation (unlike torchvision, which gates
   // this behind an apply_exif_orientation parameter).
@@ -310,7 +387,7 @@ torch::stable::Tensor decode_png(
   png_destroy_read_struct(&png_ptr, &info_ptr, nullptr);
 
   return exif_orientation_transform(
-      stable_permute(*tensor, {2, 0, 1}), exif_orientation);
+      stable_permute(tensor, {2, 0, 1}), exif_orientation);
 }
 
 } // namespace facebook::torchcodec

--- a/src/torchcodec/_core/DecodePng.cpp
+++ b/src/torchcodec/_core/DecodePng.cpp
@@ -103,6 +103,7 @@ struct SourceCtx {
 void read_callback(png_structp png_ptr, png_bytep output, png_size_t bytes) {
   auto* source_ctx = static_cast<SourceCtx*>(png_get_io_ptr(png_ptr));
   if (source_ctx->count < bytes) {
+    // trigger our error callback
     png_error(
         png_ptr,
         "Out of bound read in decode_png. The input image might be corrupted?");
@@ -285,6 +286,13 @@ void decode_rows(
 }
 
 } // namespace
+
+// Important: see the [libjpeg error handling] in the jpeg decoder: everything
+// applies here too. Critically, we must not throw a C++ exception through
+// libpng's C stack (and callbacks), and we also shouldn't allocate anything
+// that needs proper destruction in a function that defines a setjmp() point.
+// This is why the output tensor is allocated here in decode_png() and
+// decode_png() does *not* define a setjmp() point.
 
 torch::stable::Tensor decode_png(
     const torch::stable::Tensor& input,

--- a/src/torchcodec/_core/DecodePng.cpp
+++ b/src/torchcodec/_core/DecodePng.cpp
@@ -45,6 +45,7 @@ torch::stable::Tensor decode_png(
 
 #include <algorithm>
 #include <cstdint>
+#include <cstdio>
 #include <optional>
 #include <string>
 
@@ -60,6 +61,22 @@ namespace {
 bool is_little_endian() {
   uint32_t x = 1;
   return *(uint8_t*)&x;
+}
+
+struct PngErrorContext {
+  char error_message[256] = "";
+};
+
+void png_error_callback(png_structp png_ptr, png_const_charp error_message) {
+  auto* error_ctx = static_cast<PngErrorContext*>(png_get_error_ptr(png_ptr));
+  if (error_ctx != nullptr) {
+    std::snprintf(
+        error_ctx->error_message,
+        sizeof(error_ctx->error_message),
+        "%s",
+        error_message);
+  }
+  png_longjmp(png_ptr, 1);
 }
 
 int fetch_png_exif_orientation(png_structp png_ptr, png_infop info_ptr) {
@@ -97,6 +114,12 @@ torch::stable::Tensor decode_png(
   auto datap = data.const_data_ptr<uint8_t>();
   auto datap_len = data.numel();
 
+  // Capture libpng's error message (see png_error_callback) so we can report it
+  // instead of a generic "internal error".
+  PngErrorContext error_ctx;
+  png_set_error_fn(
+      png_ptr, &error_ctx, png_error_callback, /*warn_fn=*/nullptr);
+
   // NOTE: libpng uses setjmp/longjmp for error handling. longjmp does not
   // unwind C++ stack frames, so destructors of objects created after setjmp
   // won't run. We use std::optional to declare tensors before setjmp while
@@ -106,7 +129,7 @@ torch::stable::Tensor decode_png(
   if (setjmp(png_jmpbuf(png_ptr)) != 0) {
     tensor.reset();
     png_destroy_read_struct(&png_ptr, &info_ptr, nullptr);
-    STD_TORCH_CHECK(false, "Internal error.");
+    STD_TORCH_CHECK(false, "decode_png failed: ", error_ctx.error_message);
   }
   STD_TORCH_CHECK(datap_len >= 8, "Content is too small for png!")
   auto is_png = !png_sig_cmp(datap, 0, 8);
@@ -126,7 +149,7 @@ torch::stable::Tensor decode_png(
     auto reader = static_cast<Reader*>(png_get_io_ptr(png_ptr));
     STD_TORCH_CHECK(
         reader->count >= bytes,
-        "Out of bound read in decode_png. Probably, the input image is corrupted");
+        "Out of bound read in decode_png. The input image might be corrupted?");
     std::copy(reader->ptr, reader->ptr + bytes, output);
     reader->ptr += bytes;
     reader->count -= bytes;

--- a/test/test_decoders.py
+++ b/test/test_decoders.py
@@ -3552,16 +3552,35 @@ class TestImageDecoder:
         with pytest.raises(RuntimeError, match=match):
             decode_fn(path)
 
-    @needs_jpeg
+    @pytest.mark.parametrize(
+        "decode_fn, asset, ext, match",
+        (
+            pytest.param(
+                decode_jpeg,
+                GRADIENT_JPEG,
+                "jpg",
+                "Image is incomplete or truncated",
+                marks=pytest.mark.needs_jpeg,
+                id="jpeg",
+            ),
+            pytest.param(
+                decode_png,
+                GRADIENT_PNG,
+                "png",
+                "Out of bound read",
+                marks=pytest.mark.needs_png,
+                id="png",
+            ),
+        ),
+    )
     @pytest.mark.parametrize("div", (2, 3, 4))
-    def test_truncated_jpeg_raises(self, tmp_path, div):
-        # A JPEG truncated mid-scan must raise, not crash.
-        # See TODO for details.
-        data = GRADIENT_JPEG.path.read_bytes()
-        path = tmp_path / "truncated.jpg"
+    def test_truncated_raises(self, tmp_path, div, decode_fn, asset, ext, match):
+        # A file truncated mid-stream must raise, not crash.
+        data = asset.path.read_bytes()
+        path = tmp_path / f"truncated.{ext}"
         path.write_bytes(data[: len(data) // div])
-        with pytest.raises(RuntimeError, match="Image is incomplete or truncated"):
-            decode_jpeg(path)
+        with pytest.raises(RuntimeError, match=match):
+            decode_fn(path)
 
     @needs_png
     @pytest.mark.parametrize("asset", (GRADIENT_PNG, GRAYSCALE_PNG, RGBA_PNG))
@@ -3584,15 +3603,13 @@ class TestImageDecoder:
         assert_tensor_close_on_at_least(decoded, reference, percentage=99, atol=2)
 
     @needs_png
-    @pytest.mark.skip(
-        reason="Truncated PNG may segfault with torchvision's setjmp/longjmp "
-        "structure; to be addressed later."
-    )
-    @pytest.mark.parametrize("div", (2, 3, 4))
-    def test_truncated_png_raises(self, tmp_path, div):
-        # A PNG truncated mid-stream must raise, not crash.
-        data = GRADIENT_PNG.path.read_bytes()
-        path = tmp_path / "truncated.png"
-        path.write_bytes(data[: len(data) // div])
-        with pytest.raises(RuntimeError):
+    def test_corrupt_png_raises(self, tmp_path):
+        # Corrupting the IHDR chunk type makes libpng raise an error (its stored
+        # CRC no longer matches). This exercizes the error callback and the
+        # setjmp/longjmp handling.
+        data = bytearray(GRADIENT_PNG.path.read_bytes())
+        data[12:16] = b"XXXX"  # the "IHDR" chunk type, at a fixed offset
+        path = tmp_path / "corrupt.png"
+        path.write_bytes(bytes(data))
+        with pytest.raises(RuntimeError, match="CRC error"):
             decode_png(path)

--- a/test/test_decoders.py
+++ b/test/test_decoders.py
@@ -3416,6 +3416,15 @@ class TestBlocks:
             torch.testing.assert_close(got.data, ref.data, atol=0, rtol=0)
 
 
+# Small helpers to avoid having to always specify the same skip marks and decode_fn
+def _jpeg_param(*values):
+    return pytest.param(decode_jpeg, *values, marks=pytest.mark.needs_jpeg, id="jpeg")
+
+
+def _png_param(*values):
+    return pytest.param(decode_png, *values, marks=pytest.mark.needs_png, id="png")
+
+
 class TestImageDecoder:
     def _save_debug(self, decoded, reference, path="debug.png"):
         # Debugging helper: dump decoded and reference frames side-by-side.
@@ -3452,21 +3461,11 @@ class TestImageDecoder:
         assert_tensor_close_on_at_least(decoded, reference, percentage=99, atol=2)
 
     # TODO_IMAGE: Maybe create a parametrization helper, or store those
-    # pytest.params for each codec somewhere
     @pytest.mark.parametrize(
         "decode_fn, fmt, ext, save_kwargs",
         (
-            pytest.param(
-                decode_jpeg,
-                "JPEG",
-                "jpg",
-                {"quality": 95},
-                marks=pytest.mark.needs_jpeg,
-                id="jpeg",
-            ),
-            pytest.param(
-                decode_png, "PNG", "png", {}, marks=pytest.mark.needs_png, id="png"
-            ),
+            _jpeg_param("JPEG", "jpg", {"quality": 95}),
+            _png_param("PNG", "png", {}),
         ),
     )
     @pytest.mark.parametrize("orientation", (0, 1, 2, 3, 4, 5, 6, 7, 8))
@@ -3489,17 +3488,8 @@ class TestImageDecoder:
     @pytest.mark.parametrize(
         "decode_fn, fmt, ext, save_kwargs",
         (
-            pytest.param(
-                decode_jpeg,
-                "JPEG",
-                "jpg",
-                {"quality": 95},
-                marks=pytest.mark.needs_jpeg,
-                id="jpeg",
-            ),
-            pytest.param(
-                decode_png, "PNG", "png", {}, marks=pytest.mark.needs_png, id="png"
-            ),
+            _jpeg_param("JPEG", "jpg", {"quality": 95}),
+            _png_param("PNG", "png", {}),
         ),
     )
     @pytest.mark.parametrize("size", (65533, 1, 7, 10, 23, 33))
@@ -3530,20 +3520,8 @@ class TestImageDecoder:
     @pytest.mark.parametrize(
         "decode_fn, ext, match",
         (
-            pytest.param(
-                decode_jpeg,
-                "jpg",
-                "Not a JPEG",
-                marks=pytest.mark.needs_jpeg,
-                id="jpeg",
-            ),
-            pytest.param(
-                decode_png,
-                "png",
-                "Content is not png",
-                marks=pytest.mark.needs_png,
-                id="png",
-            ),
+            _jpeg_param("jpg", "Not a JPEG"),
+            _png_param("png", "Content is not png"),
         ),
     )
     def test_not_an_image_raises(self, tmp_path, decode_fn, ext, match):
@@ -3555,22 +3533,8 @@ class TestImageDecoder:
     @pytest.mark.parametrize(
         "decode_fn, asset, ext, match",
         (
-            pytest.param(
-                decode_jpeg,
-                GRADIENT_JPEG,
-                "jpg",
-                "Image is incomplete or truncated",
-                marks=pytest.mark.needs_jpeg,
-                id="jpeg",
-            ),
-            pytest.param(
-                decode_png,
-                GRADIENT_PNG,
-                "png",
-                "Out of bound read",
-                marks=pytest.mark.needs_png,
-                id="png",
-            ),
+            _jpeg_param(GRADIENT_JPEG, "jpg", "Image is incomplete or truncated"),
+            _png_param(GRADIENT_PNG, "png", "Out of bound read"),
         ),
     )
     @pytest.mark.parametrize("div", (2, 3, 4))

--- a/test/test_decoders.py
+++ b/test/test_decoders.py
@@ -3521,7 +3521,7 @@ class TestImageDecoder:
         "decode_fn, ext, match",
         (
             _jpeg_param("jpg", "Not a JPEG"),
-            _png_param("png", "Content is not png"),
+            _png_param("png", "Not a PNG file"),
         ),
     )
     def test_not_an_image_raises(self, tmp_path, decode_fn, ext, match):


### PR DESCRIPTION
Bunch of cleanups and  fixes for the png decoder. Importantly, same fix as in https://github.com/meta-pytorch/torchcodec/pull/1524https://github.com/meta-pytorch/torchcodec/pull/1524.

Interestingly it wasn't triggering a segfault here, but this was still UB.