### PR TITLE
Move image decoders into their own lib

### DIFF
--- a/packaging/repair_wheel.py
+++ b/packaging/repair_wheel.py
@@ -144,6 +144,9 @@ def check_bundling():
       ever try to bundle FFmpeg or torch/CUDA.
     - a wheel does NOT bundle libjpeg, libpng, libwebp or libwebpdemux.
     - (Linux only) the bundled libjpeg isn't libjpeg-turbo.
+    - (Linux only) libtorchcodec_image.so links FFmpeg or exports codec symbols
+      (it must stay isolated from the user's FFmpeg; see
+      _assert_linux_image_lib_isolated).
     """
 
     def _is_shared_lib(name):
@@ -189,6 +192,83 @@ def check_bundling():
         if platform.system() == "Darwin" and lib.startswith(("libc++", "libpython")):
             return True
         return False
+
+    def _assert_linux_image_lib_isolated(zf):
+        """Linux-only. Enforce that libtorchcodec_image.so, the standalone image
+        decoder library, stays isolated from FFmpeg:
+
+        (a) it must NOT link FFmpeg (no libav*/libsw*/libpostproc* in DT_NEEDED),
+            and
+        (b) it must NOT export any bundled-codec symbol (png_*/jpeg_*/WebP*/
+            giflib/...).
+
+        Together with the fact that it's loaded via its own torch.ops.load_library
+        call (its own RTLD_LOCAL symbol group), this is what keeps our bundled
+        libjpeg/libpng/libwebp from colliding with the codec libs the user's
+        FFmpeg links. (a) prevents the image lib from ever sharing a load group
+        with FFmpeg; (b) makes sure our lib itself never becomes a second
+        definition of a codec symbol (it only *imports* them, and giflib, which
+        we compile in, is built with hidden visibility). See
+        IMAGE_LIBS_BUNDLING_INVESTIGATION.md.
+        """
+        from elftools.elf.elffile import ELFFile
+        from elftools.elf.sections import SymbolTableSection
+
+        members = [
+            n for n in zf.namelist() if n.rsplit("/", 1)[-1] == "libtorchcodec_image.so"
+        ]
+        if not members:
+            raise RuntimeError(
+                "libtorchcodec_image.so not found in wheel; the image decoders "
+                "are expected to live in their own shared library."
+            )
+        elf = ELFFile(io.BytesIO(zf.read(members[0])))
+
+        # (a) No FFmpeg in DT_NEEDED.
+        dynamic = elf.get_section_by_name(".dynamic")
+        needed = [t.needed for t in dynamic.iter_tags("DT_NEEDED")] if dynamic else []
+        ffmpeg_needed = [
+            n for n in needed if n.startswith(("libav", "libsw", "libpostproc"))
+        ]
+        if ffmpeg_needed:
+            raise RuntimeError(
+                "libtorchcodec_image.so must not link FFmpeg, but its DT_NEEDED "
+                "lists: " + " ".join(ffmpeg_needed)
+            )
+
+        # (b) No *exported* (defined) codec symbols. Undefined symbols (imports)
+        # are expected and fine. Our own ops are C++ (mangled, "_Z" prefix) so we
+        # skip those; the codec APIs are C and appear under their bare names.
+        codec_prefixes = (
+            "png_",
+            "jpeg_",
+            "jpeg12_",
+            "jpeg16_",
+            "WebP",
+            "SharpYuv",
+            "sharpyuv",
+            "Gif",
+            "DGif",
+            "EGif",
+            "deflate",
+            "inflate",
+        )
+        dynsym = elf.get_section_by_name(".dynsym")
+        leaked = []
+        if isinstance(dynsym, SymbolTableSection):
+            for sym in dynsym.iter_symbols():
+                name = sym.name
+                if not name or name.startswith("_Z"):
+                    continue
+                if sym["st_shndx"] == "SHN_UNDEF":
+                    continue
+                if name.startswith(codec_prefixes):
+                    leaked.append(name)
+        if leaked:
+            raise RuntimeError(
+                "libtorchcodec_image.so must not export codec symbols (it should "
+                "only import them), but it exports: " + " ".join(sorted(set(leaked)))
+            )
 
     def _assert_linux_libjpeg_is_turbo(zf):
         jpeg_members = [
@@ -238,6 +318,7 @@ def check_bundling():
                 )
             if platform.system() == "Linux":
                 _assert_linux_libjpeg_is_turbo(zf)
+                _assert_linux_image_lib_isolated(zf)
         print("OK: only libjpeg (and allowed libs) bundled.")
 
 

--- a/packaging/repair_wheel.py
+++ b/packaging/repair_wheel.py
@@ -144,9 +144,7 @@ def check_bundling():
       ever try to bundle FFmpeg or torch/CUDA.
     - a wheel does NOT bundle libjpeg, libpng, libwebp or libwebpdemux.
     - (Linux only) the bundled libjpeg isn't libjpeg-turbo.
-    - (Linux only) libtorchcodec_image.so links FFmpeg or exports codec symbols
-      (it must stay isolated from the user's FFmpeg; see
-      _assert_linux_image_lib_isolated).
+    - (Linux only) libtorchcodec_image.so links FFmpeg
     """
 
     def _is_shared_lib(name):
@@ -193,26 +191,21 @@ def check_bundling():
             return True
         return False
 
-    def _assert_linux_image_lib_isolated(zf):
-        """Linux-only. Enforce that libtorchcodec_image.so, the standalone image
-        decoder library, stays isolated from FFmpeg:
+    def _assert_linux_image_lib_no_ffmpeg(zf):
+        """Enforce that libtorchcodec_image.so NOT link FFmpeg (no
+        libav*/libsw*/libpostproc* in DT_NEEDED).
 
-        (a) it must NOT link FFmpeg (no libav*/libsw*/libpostproc* in DT_NEEDED),
-            and
-        (b) it must NOT export any bundled-codec symbol (png_*/jpeg_*/WebP*/
-            giflib/...).
+        We built libtorchcodec_image.so separately from the FFmpeg-dependent
+        core{4,5,6,7,8}.so libraries: the whole point is to avoid symbol
+        interposition between the bundled image codec libs
+        (libjpeg/libpng/libwebp) and the user's FFmpeg: FFmpeg may come with its
+        own libjpeg/libpng too!
 
-        Together with the fact that it's loaded via its own torch.ops.load_library
-        call (its own RTLD_LOCAL symbol group), this is what keeps our bundled
-        libjpeg/libpng/libwebp from colliding with the codec libs the user's
-        FFmpeg links. (a) prevents the image lib from ever sharing a load group
-        with FFmpeg; (b) makes sure our lib itself never becomes a second
-        definition of a codec symbol (it only *imports* them, and giflib, which
-        we compile in, is built with hidden visibility). See
-        IMAGE_LIBS_BUNDLING_INVESTIGATION.md.
+        This check ensures that we didn't accidentally link FFmpeg into
+        libtorchcodec_image.so, which would defeat the purpose of building it
+        separately.
         """
         from elftools.elf.elffile import ELFFile
-        from elftools.elf.sections import SymbolTableSection
 
         members = [
             n for n in zf.namelist() if n.rsplit("/", 1)[-1] == "libtorchcodec_image.so"
@@ -223,8 +216,6 @@ def check_bundling():
                 "are expected to live in their own shared library."
             )
         elf = ELFFile(io.BytesIO(zf.read(members[0])))
-
-        # (a) No FFmpeg in DT_NEEDED.
         dynamic = elf.get_section_by_name(".dynamic")
         needed = [t.needed for t in dynamic.iter_tags("DT_NEEDED")] if dynamic else []
         ffmpeg_needed = [
@@ -234,40 +225,6 @@ def check_bundling():
             raise RuntimeError(
                 "libtorchcodec_image.so must not link FFmpeg, but its DT_NEEDED "
                 "lists: " + " ".join(ffmpeg_needed)
-            )
-
-        # (b) No *exported* (defined) codec symbols. Undefined symbols (imports)
-        # are expected and fine. Our own ops are C++ (mangled, "_Z" prefix) so we
-        # skip those; the codec APIs are C and appear under their bare names.
-        codec_prefixes = (
-            "png_",
-            "jpeg_",
-            "jpeg12_",
-            "jpeg16_",
-            "WebP",
-            "SharpYuv",
-            "sharpyuv",
-            "Gif",
-            "DGif",
-            "EGif",
-            "deflate",
-            "inflate",
-        )
-        dynsym = elf.get_section_by_name(".dynsym")
-        leaked = []
-        if isinstance(dynsym, SymbolTableSection):
-            for sym in dynsym.iter_symbols():
-                name = sym.name
-                if not name or name.startswith("_Z"):
-                    continue
-                if sym["st_shndx"] == "SHN_UNDEF":
-                    continue
-                if name.startswith(codec_prefixes):
-                    leaked.append(name)
-        if leaked:
-            raise RuntimeError(
-                "libtorchcodec_image.so must not export codec symbols (it should "
-                "only import them), but it exports: " + " ".join(sorted(set(leaked)))
             )
 
     def _assert_linux_libjpeg_is_turbo(zf):
@@ -318,7 +275,7 @@ def check_bundling():
                 )
             if platform.system() == "Linux":
                 _assert_linux_libjpeg_is_turbo(zf)
-                _assert_linux_image_lib_isolated(zf)
+                _assert_linux_image_lib_no_ffmpeg(zf)
         print("OK: only libjpeg (and allowed libs) bundled.")
 
 

--- a/src/torchcodec/_core/CMakeLists.txt
+++ b/src/torchcodec/_core/CMakeLists.txt
@@ -241,10 +241,6 @@ function(make_torchcodec_libraries
     #    Windows, it's pyd.
 
     # 1. Create libtorchcodec_coreN.{ext}.
-    # NOTE: the image decoders (image_sources + giflib) are intentionally NOT
-    # compiled here. They live in the separate, FFmpeg-free libtorchcodec_image
-    # library (see make_torchcodec_image_library) so that our bundled image codec
-    # libs don't share a symbol-resolution scope with the user's FFmpeg.
     set(core_library_name "libtorchcodec_core${ffmpeg_major_version}")
     set(core_sources
         ${TORCHCODEC_DECODER_CORE_SOURCES}
@@ -267,9 +263,6 @@ function(make_torchcodec_libraries
         "${core_sources}"
         "${core_library_dependencies}"
     )
-
-    # NOTE: the image codec libs (libjpeg/libpng/libwebp) are linked into
-    # libtorchcodec_image, not core (see make_torchcodec_image_library).
 
     if(ENABLE_CUDA)
         # We define USE_CUDA to guard CUDA-specific code paths (e.g.
@@ -461,10 +454,6 @@ endfunction()
 # (libjpeg/libpng/libwebp) and the codec libs pulled in by the user's FFmpeg
 # (which also links libpng/libjpeg/... with the same sonames) then live in
 # separate scopes and cannot interpose on each other.
-#
-# Because it is FFmpeg-free and relies only on the version-stable torch ABI, it
-# is a SINGLE library rather than one-per-FFmpeg-version, which also de-duplicates
-# the image decoder code that used to be compiled into every core{4..8} library.
 function(make_torchcodec_image_library)
     set(image_library_name "libtorchcodec_image")
     set(image_library_sources

--- a/src/torchcodec/_core/CMakeLists.txt
+++ b/src/torchcodec/_core/CMakeLists.txt
@@ -114,6 +114,7 @@ read_sources_from_bzl(TORCHCODEC_FILE_LIKE_CONTEXT_SOURCES file_like_context_sou
 read_sources_from_bzl(TORCHCODEC_CUSTOM_OPS_SOURCES custom_ops_sources)
 read_sources_from_bzl(TORCHCODEC_PYBIND_OPS_SOURCES pybind_ops_sources)
 read_sources_from_bzl(TORCHCODEC_IMAGE_SOURCES image_sources)
+read_sources_from_bzl(TORCHCODEC_IMAGE_OPS_SOURCES image_ops_sources)
 read_sources_from_bzl(TORCHCODEC_GIFLIB_SOURCES giflib_sources)
 
 if(DEFINED TORCHCODEC_DISABLE_COMPILE_WARNING_AS_ERROR AND TORCHCODEC_DISABLE_COMPILE_WARNING_AS_ERROR)
@@ -240,12 +241,14 @@ function(make_torchcodec_libraries
     #    Windows, it's pyd.
 
     # 1. Create libtorchcodec_coreN.{ext}.
+    # NOTE: the image decoders (image_sources + giflib) are intentionally NOT
+    # compiled here. They live in the separate, FFmpeg-free libtorchcodec_image
+    # library (see make_torchcodec_image_library) so that our bundled image codec
+    # libs don't share a symbol-resolution scope with the user's FFmpeg.
     set(core_library_name "libtorchcodec_core${ffmpeg_major_version}")
     set(core_sources
         ${TORCHCODEC_DECODER_CORE_SOURCES}
         ${TORCHCODEC_FFMPEG_COMMON_SOURCES}
-        ${TORCHCODEC_IMAGE_SOURCES}
-        ${TORCHCODEC_GIFLIB_SOURCES}
     )
 
     if(ENABLE_CUDA)
@@ -265,28 +268,8 @@ function(make_torchcodec_libraries
         "${core_library_dependencies}"
     )
 
-    # Optional libjpeg support for the CPU JPEG image decoder (DecodeJpeg.cpp).
-    # JPEG_FOUND gates both the compile-time code path and the link.
-    if(JPEG_FOUND)
-        target_compile_definitions(${core_library_name} PRIVATE JPEG_FOUND=1)
-        target_link_libraries(${core_library_name} PRIVATE JPEG::JPEG)
-    endif()
-
-    # Optional libpng support for the CPU PNG image decoder (DecodePng.cpp).
-    # PNG_FOUND gates both the compile-time code path and the link.
-    if(PNG_FOUND)
-        target_compile_definitions(${core_library_name} PRIVATE PNG_FOUND=1)
-        target_link_libraries(${core_library_name} PRIVATE PNG::PNG)
-    endif()
-
-    # Optional libwebp support for the CPU WebP image decoder (DecodeWebp.cpp).
-    # WebP_FOUND gates both the compile-time code path and the link.
-    if(WebP_FOUND)
-        target_compile_definitions(${core_library_name} PRIVATE WEBP_FOUND=1)
-        # WebP::webpdemux provides the WebPAnimDecoder API used for animated
-        # webp files
-        target_link_libraries(${core_library_name} PRIVATE WebP::webp WebP::webpdemux)
-    endif()
+    # NOTE: the image codec libs (libjpeg/libpng/libwebp) are linked into
+    # libtorchcodec_image, not core (see make_torchcodec_image_library).
 
     if(ENABLE_CUDA)
         # We define USE_CUDA to guard CUDA-specific code paths (e.g.
@@ -467,6 +450,82 @@ function(make_torchcodec_libraries
     endif()
 
 endfunction()
+
+# Create libtorchcodec_image, the shared library holding the CPU image decoders
+# (JPEG/PNG/WebP/GIF) and their custom-op registration.
+#
+# This is deliberately SEPARATE from the FFmpeg-linked core libraries and links
+# NO FFmpeg. It is loaded at runtime via its own torch.ops.load_library call (see
+# load_torchcodec_shared_libraries), which puts it in its own RTLD_LOCAL symbol
+# group. That isolation is the whole point: our bundled image codec libs
+# (libjpeg/libpng/libwebp) and the codec libs pulled in by the user's FFmpeg
+# (which also links libpng/libjpeg/... with the same sonames) then live in
+# separate scopes and cannot interpose on each other.
+#
+# Because it is FFmpeg-free and relies only on the version-stable torch ABI, it
+# is a SINGLE library rather than one-per-FFmpeg-version, which also de-duplicates
+# the image decoder code that used to be compiled into every core{4..8} library.
+function(make_torchcodec_image_library)
+    set(image_library_name "libtorchcodec_image")
+    set(image_library_sources
+        ${TORCHCODEC_IMAGE_SOURCES}
+        ${TORCHCODEC_IMAGE_OPS_SOURCES}
+        ${TORCHCODEC_GIFLIB_SOURCES}
+    )
+
+    make_torchcodec_sublibrary(
+        "${image_library_name}"
+        SHARED
+        "${image_library_sources}"
+        "${TORCH_LIBRARIES}"
+    )
+
+    # Optional image codec support. Each *_FOUND gates both the compile-time code
+    # path (the decoder falls back to an actionable runtime-error stub when
+    # absent) and the link. These are linked here, NOT into core.
+    if(JPEG_FOUND)
+        target_compile_definitions(${image_library_name} PRIVATE JPEG_FOUND=1)
+        target_link_libraries(${image_library_name} PRIVATE JPEG::JPEG)
+    endif()
+    if(PNG_FOUND)
+        target_compile_definitions(${image_library_name} PRIVATE PNG_FOUND=1)
+        target_link_libraries(${image_library_name} PRIVATE PNG::PNG)
+    endif()
+    if(WebP_FOUND)
+        target_compile_definitions(${image_library_name} PRIVATE WEBP_FOUND=1)
+        # WebP::webpdemux provides the WebPAnimDecoder API used for animated
+        # webp files.
+        target_link_libraries(${image_library_name} PRIVATE WebP::webp WebP::webpdemux)
+    endif()
+
+    # Hide our own (and vendored giflib's) symbols so the only thing exported is
+    # the torch op registration. Belt-and-suspenders on top of the RTLD_LOCAL
+    # isolation. Matches what custom_ops/pybind_ops already do. Linux only (see
+    # the note in make_torchcodec_libraries).
+    if(LINUX)
+        target_compile_options(${image_library_name} PRIVATE "-fvisibility=hidden")
+    endif()
+
+    # Same editable-vs-wheel output/install logic as make_torchcodec_libraries.
+    if(SKBUILD_STATE STREQUAL "editable")
+        get_filename_component(
+            TORCHCODEC_PACKAGE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/.." ABSOLUTE)
+        set_target_properties(${image_library_name} PROPERTIES
+            LIBRARY_OUTPUT_DIRECTORY "${TORCHCODEC_PACKAGE_DIR}"
+            RUNTIME_OUTPUT_DIRECTORY "${TORCHCODEC_PACKAGE_DIR}"  # Windows
+        )
+    else()
+        install(
+            TARGETS ${image_library_name}
+            LIBRARY DESTINATION torchcodec
+            RUNTIME DESTINATION torchcodec  # For Windows
+        )
+    endif()
+endfunction()
+
+# The image library is FFmpeg-independent, so it's built exactly once regardless
+# of which FFmpeg version(s) we build the core libraries against.
+make_torchcodec_image_library()
 
 if(DEFINED ENV{BUILD_AGAINST_ALL_FFMPEG_FROM_S3})
     message(

--- a/src/torchcodec/_core/CMakeLists.txt
+++ b/src/torchcodec/_core/CMakeLists.txt
@@ -487,10 +487,9 @@ function(make_torchcodec_image_library)
         target_link_libraries(${image_library_name} PRIVATE WebP::webp WebP::webpdemux)
     endif()
 
-    # Hide our own (and vendored giflib's) symbols so the only thing exported is
-    # the torch op registration. Belt-and-suspenders on top of the RTLD_LOCAL
-    # isolation. Matches what custom_ops/pybind_ops already do. Linux only (see
-    # the note in make_torchcodec_libraries).
+    # Hide our own (and statically linked giflib's) symbols so the only thing
+    # exported is the torch op registration. Belt-and-suspenders on top of the
+    # RTLD_LOCAL isolation.
     if(LINUX)
         target_compile_options(${image_library_name} PRIVATE "-fvisibility=hidden")
     endif()
@@ -512,8 +511,6 @@ function(make_torchcodec_image_library)
     endif()
 endfunction()
 
-# The image library is FFmpeg-independent, so it's built exactly once regardless
-# of which FFmpeg version(s) we build the core libraries against.
 make_torchcodec_image_library()
 
 if(DEFINED ENV{BUILD_AGAINST_ALL_FFMPEG_FROM_S3})

--- a/src/torchcodec/_core/custom_ops.cpp
+++ b/src/torchcodec/_core/custom_ops.cpp
@@ -23,10 +23,6 @@ extern "C" {
 #include "AVIOFileLikeContext.h"
 #include "AVIOTensorContext.h"
 #include "ColorConverter.h"
-#include "DecodeGif.h"
-#include "DecodeJpeg.h"
-#include "DecodePng.h"
-#include "DecodeWebp.h"
 #include "Demuxer.h"
 #include "Encoder.h"
 #include "Logging.h"
@@ -47,7 +43,13 @@ namespace facebook::torchcodec {
 // mutated in place. We need it to make sure that torch.compile does not reorder
 // calls to these functions. For more detail, see:
 //   https://github.com/pytorch/pytorch/tree/main/aten/src/ATen/native#readme
-STABLE_TORCH_LIBRARY(torchcodec_ns, m) {
+//
+// We use STABLE_TORCH_LIBRARY_FRAGMENT rather than STABLE_TORCH_LIBRARY because
+// the image decoders register into this same torchcodec_ns namespace from a
+// separate library (image_custom_ops.cpp in libtorchcodec_image). A namespace
+// may have at most one STABLE_TORCH_LIBRARY (exclusive) owner; using FRAGMENT
+// in both libraries lets them be loaded in either order.
+STABLE_TORCH_LIBRARY_FRAGMENT(torchcodec_ns, m) {
   m.def("create_from_file(str filename, str? seek_mode=None) -> Tensor");
   m.def(
       "create_from_tensor(Tensor video_tensor, str? seek_mode=None) -> Tensor");
@@ -122,10 +124,8 @@ STABLE_TORCH_LIBRARY(torchcodec_ns, m) {
   m.def(
       "get_wav_samples_in_range(Tensor(a!) decoder, float start_seconds, float? stop_seconds) -> (Tensor, Tensor)");
   m.def("get_wav_metadata_from_decoder(Tensor(a!) decoder) -> str");
-  m.def("decode_jpeg(Tensor data, int mode) -> Tensor");
-  m.def("decode_png(Tensor data, int mode) -> Tensor");
-  m.def("decode_webp(Tensor data, int mode) -> Tensor");
-  m.def("decode_gif(Tensor data, int mode) -> Tensor");
+  // NOTE: the image decoder ops (decode_jpeg/png/webp/gif) are defined and
+  // implemented in image_custom_ops.cpp, compiled into libtorchcodec_image.
 }
 
 namespace {
@@ -1532,10 +1532,8 @@ STABLE_TORCH_LIBRARY_IMPL(torchcodec_ns, CPU, m) {
   m.impl(
       "streaming_encoder_add_samples",
       TORCH_BOX(&streaming_encoder_add_samples));
-  m.impl("decode_jpeg", TORCH_BOX(&decode_jpeg));
-  m.impl("decode_png", TORCH_BOX(&decode_png));
-  m.impl("decode_webp", TORCH_BOX(&decode_webp));
-  m.impl("decode_gif", TORCH_BOX(&decode_gif));
+  // NOTE: decode_jpeg/png/webp/gif are implemented in image_custom_ops.cpp
+  // (libtorchcodec_image), not here.
 }
 
 } // namespace facebook::torchcodec

--- a/src/torchcodec/_core/custom_ops.cpp
+++ b/src/torchcodec/_core/custom_ops.cpp
@@ -44,11 +44,6 @@ namespace facebook::torchcodec {
 // calls to these functions. For more detail, see:
 //   https://github.com/pytorch/pytorch/tree/main/aten/src/ATen/native#readme
 //
-// We use STABLE_TORCH_LIBRARY_FRAGMENT rather than STABLE_TORCH_LIBRARY because
-// the image decoders register into this same torchcodec_ns namespace from a
-// separate library (image_custom_ops.cpp in libtorchcodec_image). A namespace
-// may have at most one STABLE_TORCH_LIBRARY (exclusive) owner; using FRAGMENT
-// in both libraries lets them be loaded in either order.
 STABLE_TORCH_LIBRARY_FRAGMENT(torchcodec_ns, m) {
   m.def("create_from_file(str filename, str? seek_mode=None) -> Tensor");
   m.def(
@@ -124,8 +119,6 @@ STABLE_TORCH_LIBRARY_FRAGMENT(torchcodec_ns, m) {
   m.def(
       "get_wav_samples_in_range(Tensor(a!) decoder, float start_seconds, float? stop_seconds) -> (Tensor, Tensor)");
   m.def("get_wav_metadata_from_decoder(Tensor(a!) decoder) -> str");
-  // NOTE: the image decoder ops (decode_jpeg/png/webp/gif) are defined and
-  // implemented in image_custom_ops.cpp, compiled into libtorchcodec_image.
 }
 
 namespace {
@@ -1532,8 +1525,6 @@ STABLE_TORCH_LIBRARY_IMPL(torchcodec_ns, CPU, m) {
   m.impl(
       "streaming_encoder_add_samples",
       TORCH_BOX(&streaming_encoder_add_samples));
-  // NOTE: decode_jpeg/png/webp/gif are implemented in image_custom_ops.cpp
-  // (libtorchcodec_image), not here.
 }
 
 } // namespace facebook::torchcodec

--- a/src/torchcodec/_core/image_custom_ops.cpp
+++ b/src/torchcodec/_core/image_custom_ops.cpp
@@ -1,0 +1,41 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+// PyTorch custom-op registration for the image decoders. This lives in the
+// libtorchcodec_image library, which is FFmpeg-free and loaded in its own
+// RTLD_LOCAL symbol group (see load_torchcodec_shared_libraries): that keeps
+// our bundled image codec libs (libjpeg/libpng/libwebp) isolated from the codec
+// libs pulled in by the user's FFmpeg, so they can't collide.
+//
+// We register into the SAME torchcodec_ns namespace as the FFmpeg custom ops
+// (custom_ops.cpp) using STABLE_TORCH_LIBRARY_FRAGMENT. Both this library and
+// custom_ops.cpp use the FRAGMENT variant (rather than STABLE_TORCH_LIBRARY,
+// which requires a single exclusive owner of the namespace), so the two
+// libraries can be loaded in either order.
+
+#include "DecodeGif.h"
+#include "DecodeJpeg.h"
+#include "DecodePng.h"
+#include "DecodeWebp.h"
+#include "StableABICompat.h"
+
+namespace facebook::torchcodec {
+
+STABLE_TORCH_LIBRARY_FRAGMENT(torchcodec_ns, m) {
+  m.def("decode_jpeg(Tensor data, int mode) -> Tensor");
+  m.def("decode_png(Tensor data, int mode) -> Tensor");
+  m.def("decode_webp(Tensor data, int mode) -> Tensor");
+  m.def("decode_gif(Tensor data, int mode) -> Tensor");
+}
+
+STABLE_TORCH_LIBRARY_IMPL(torchcodec_ns, CPU, m) {
+  m.impl("decode_jpeg", TORCH_BOX(&decode_jpeg));
+  m.impl("decode_png", TORCH_BOX(&decode_png));
+  m.impl("decode_webp", TORCH_BOX(&decode_webp));
+  m.impl("decode_gif", TORCH_BOX(&decode_gif));
+}
+
+} // namespace facebook::torchcodec

--- a/src/torchcodec/_core/image_custom_ops.cpp
+++ b/src/torchcodec/_core/image_custom_ops.cpp
@@ -9,12 +9,6 @@
 // RTLD_LOCAL symbol group (see load_torchcodec_shared_libraries): that keeps
 // our bundled image codec libs (libjpeg/libpng/libwebp) isolated from the codec
 // libs pulled in by the user's FFmpeg, so they can't collide.
-//
-// We register into the SAME torchcodec_ns namespace as the FFmpeg custom ops
-// (custom_ops.cpp) using STABLE_TORCH_LIBRARY_FRAGMENT. Both this library and
-// custom_ops.cpp use the FRAGMENT variant (rather than STABLE_TORCH_LIBRARY,
-// which requires a single exclusive owner of the namespace), so the two
-// libraries can be loaded in either order.
 
 #include "DecodeGif.h"
 #include "DecodeJpeg.h"

--- a/src/torchcodec/_core/sources.bzl
+++ b/src/torchcodec/_core/sources.bzl
@@ -84,7 +84,9 @@ image_ops_sources = [
     "image_custom_ops.cpp",
 ]
 
-# Vendored giflib (decode-only subset, MIT licensed).
+# Vendored giflib (decode-only subset, MIT licensed). Compiled directly from
+# source into the core library, so the GIF decoder needs no external dependency
+# and is always available. See giflib/README for the license and local mods.
 giflib_sources = [
     "giflib/dgif_lib.c",
     "giflib/gifalloc.c",

--- a/src/torchcodec/_core/sources.bzl
+++ b/src/torchcodec/_core/sources.bzl
@@ -73,12 +73,6 @@ custom_ops_sources = [
     "custom_ops.cpp",
 ]
 
-# Image decoder implementations. Under CMake these are compiled into a dedicated
-# libtorchcodec_image library (NOT the FFmpeg-linked core library) so that our
-# bundled image codec libs (libjpeg/libpng/libwebp) load in a separate
-# RTLD_LOCAL symbol group from the user's FFmpeg and cannot collide with it. The
-# sources are FFmpeg-free (they use only the version-stable torch ABI + the codec
-# headers), which is what lets them live in their own library.
 image_sources = [
     "DecodeJpeg.cpp",
     "DecodePng.cpp",
@@ -86,19 +80,11 @@ image_sources = [
     "DecodeGif.cpp",
 ]
 
-# PyTorch custom-op registration for the image decoders (decode_jpeg/png/webp/
-# gif). Kept in its own translation unit so it can be compiled into the
-# libtorchcodec_image library alongside image_sources, separately from the
-# FFmpeg custom ops in custom_ops.cpp. Registers into the shared torchcodec_ns
-# namespace via STABLE_TORCH_LIBRARY_FRAGMENT.
 image_ops_sources = [
     "image_custom_ops.cpp",
 ]
 
-# Vendored giflib (decode-only subset, MIT licensed). Compiled directly from
-# source into the libtorchcodec_image library, so the GIF decoder needs no
-# external dependency and is always available. See giflib/README for the license
-# and local mods.
+# Vendored giflib (decode-only subset, MIT licensed).
 giflib_sources = [
     "giflib/dgif_lib.c",
     "giflib/gifalloc.c",

--- a/src/torchcodec/_core/sources.bzl
+++ b/src/torchcodec/_core/sources.bzl
@@ -73,6 +73,12 @@ custom_ops_sources = [
     "custom_ops.cpp",
 ]
 
+# Image decoder implementations. Under CMake these are compiled into a dedicated
+# libtorchcodec_image library (NOT the FFmpeg-linked core library) so that our
+# bundled image codec libs (libjpeg/libpng/libwebp) load in a separate
+# RTLD_LOCAL symbol group from the user's FFmpeg and cannot collide with it. The
+# sources are FFmpeg-free (they use only the version-stable torch ABI + the codec
+# headers), which is what lets them live in their own library.
 image_sources = [
     "DecodeJpeg.cpp",
     "DecodePng.cpp",
@@ -80,9 +86,19 @@ image_sources = [
     "DecodeGif.cpp",
 ]
 
+# PyTorch custom-op registration for the image decoders (decode_jpeg/png/webp/
+# gif). Kept in its own translation unit so it can be compiled into the
+# libtorchcodec_image library alongside image_sources, separately from the
+# FFmpeg custom ops in custom_ops.cpp. Registers into the shared torchcodec_ns
+# namespace via STABLE_TORCH_LIBRARY_FRAGMENT.
+image_ops_sources = [
+    "image_custom_ops.cpp",
+]
+
 # Vendored giflib (decode-only subset, MIT licensed). Compiled directly from
-# source into the core library, so the GIF decoder needs no external dependency
-# and is always available. See giflib/README for the license and local mods.
+# source into the libtorchcodec_image library, so the GIF decoder needs no
+# external dependency and is always available. See giflib/README for the license
+# and local mods.
 giflib_sources = [
     "giflib/dgif_lib.c",
     "giflib/gifalloc.c",

--- a/src/torchcodec/_internally_replaced_utils.py
+++ b/src/torchcodec/_internally_replaced_utils.py
@@ -83,6 +83,21 @@ def load_torchcodec_shared_libraries() -> tuple[int, str, ModuleType]:
          works when the module name and file name match exactly. Our shared
          libraries do not meet those conditions.
     """
+    # Load the image decoder library (libtorchcodec_image) first, via its own
+    # torch.ops.load_library call. This is deliberate: loading it separately puts
+    # it in its own RTLD_LOCAL symbol group, isolated from the FFmpeg-linked core
+    # libraries below. Our bundled image codec libs (libjpeg/libpng/libwebp) and
+    # the codec libs pulled in by the user's FFmpeg (same sonames!) then never
+    # share a symbol-resolution scope, so they can't interpose on each other.
+    #
+    # It is a single, FFmpeg-independent library (not one-per-FFmpeg-version), so
+    # it is loaded outside the version loop below. It registers decode_jpeg/png/
+    # webp/gif into the torchcodec_ns namespace via STABLE_TORCH_LIBRARY_FRAGMENT;
+    # custom_ops.cpp uses a FRAGMENT too, so the load order relative to the core
+    # libraries does not matter.
+    image_library_path = _get_extension_path("libtorchcodec_image")
+    torch.ops.load_library(image_library_path)
+
     exceptions = []
     for ffmpeg_major_version in (8, 7, 6, 5, 4):
         core_library_name = f"libtorchcodec_core{ffmpeg_major_version}"

--- a/src/torchcodec/_internally_replaced_utils.py
+++ b/src/torchcodec/_internally_replaced_utils.py
@@ -83,18 +83,9 @@ def load_torchcodec_shared_libraries() -> tuple[int, str, ModuleType]:
          works when the module name and file name match exactly. Our shared
          libraries do not meet those conditions.
     """
-    # Load the image decoder library (libtorchcodec_image) first, via its own
-    # torch.ops.load_library call. This is deliberate: loading it separately puts
-    # it in its own RTLD_LOCAL symbol group, isolated from the FFmpeg-linked core
-    # libraries below. Our bundled image codec libs (libjpeg/libpng/libwebp) and
-    # the codec libs pulled in by the user's FFmpeg (same sonames!) then never
-    # share a symbol-resolution scope, so they can't interpose on each other.
-    #
-    # It is a single, FFmpeg-independent library (not one-per-FFmpeg-version), so
-    # it is loaded outside the version loop below. It registers decode_jpeg/png/
-    # webp/gif into the torchcodec_ns namespace via STABLE_TORCH_LIBRARY_FRAGMENT;
-    # custom_ops.cpp uses a FRAGMENT too, so the load order relative to the core
-    # libraries does not matter.
+
+    # TODO_IMAGE: Maybe we should only load that upon first use of an image
+    # decoder.
     image_library_path = _get_extension_path("libtorchcodec_image")
     torch.ops.load_library(image_library_path)
 

--- a/src/torchcodec/decoders/_image_decoders.py
+++ b/src/torchcodec/decoders/_image_decoders.py
@@ -25,6 +25,10 @@ from torchcodec._core.ops import (
 
 # TODO_IMAGE We probably need CI jobs for both TODOs above.
 
+# TODO_IMAGE Some codecs expose threading options - we should make sure the
+# default is 1 thread and allow the user to override it. (similar to
+# num_ffmpeg_threads)
+
 # TODO_IMAGE: Support torchscript?
 
 # TODO_IMAGE: We'll need to support all output modes consistently across all


### PR DESCRIPTION
This moves the images decoders into their own library, separate from `libtorchcodec_coreN.so` which links against FFmpeg.

The main goal is to minimize the risk of symbol collision / interposition between our own codec libs that we ship in the wheel (libjpeg, libpng, libwebp etc.) and their equivalent that the FFmpeg libraries may also link against.

Each of the `libtorchcodec_coreN.so` and the `libtorchcodec_image.so` are 'contained' within their own RTLD_LOCAL symbol
group, so they shouldn't clash.

Note that this doesn't guarantee that there won't be symbol collision or interposition in general: there might still be conflicts at the global symbol group, but there's nothing we can do about this.