### PR TITLE
Make image decoder build optional

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -44,6 +44,8 @@ jobs:
 
   mypy:
     runs-on: ubuntu-latest
+    env:
+      TORCHCODEC_BUILD_IMAGE: "0"
     strategy:
       fail-fast: false
       matrix:
@@ -63,8 +65,7 @@ jobs:
       - name: Install dependencies and FFmpeg
         run: |
           bash packaging/install_pytorch.sh cpu "torch torchvision"
-          # No need to install image codecs, we can just compile the stubs
-          TORCHCODEC_SKIP_IMAGE_DEPS=1 bash packaging/install_build_dependencies.sh
+          bash packaging/install_build_dependencies.sh
           conda install "ffmpeg=7.0.1" pkg-config -c conda-forge
           ffmpeg -version
       - name: Build and install torchcodec

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,7 @@ test locally you will need the following dependencies:
 - pybind11
 - scikit-build-core (our build backend)
 - FFmpeg
+- (Optional) image codec libraries - see image decoder section below
 - PyTorch nightly
 
 Start by installing the **nightly** build of PyTorch following the
@@ -51,6 +52,22 @@ export TORCHCODEC_CMAKE_BUILD_DIR="${PWD}/build"
 pip install -e ".[dev]" --no-build-isolation -vv
 # Or, for cuda support: ENABLE_CUDA=1 pip install -e ".[dev]" --no-build-isolation -vv
 ```
+
+### Image decoder build options
+
+By default, TorchCodec builds all of its image decoders (currently jpeg, png,
+avif, webp, and gif) and **requires** them: if a codec's library can't be found,
+the build fails.
+
+The libraries that need to be externally sourced are libjpeg, libpng, and
+libwebp (TorchCodec will provide libavif and giflib). You can typically install
+them via `conda install libjpeg-turbo libpng libwebp -c conda-forge`.
+
+You can opt-out from building all the image decoders by setting
+`TORCHCODEC_BUILD_IMAGE=0`, or from building individual image decoders by
+setting one of `TORCHCODEC_BUILD_{JPEG,PNG,WEBP,AVIF,GIF}=0`. To build a single
+image decoder, e.g. jpeg, set `TORCHCODEC_BUILD_IMAGE=0
+TORCHCODEC_BUILD_JPEG=1`.
 
 ### Running unit tests
 

--- a/packaging/install_build_dependencies.sh
+++ b/packaging/install_build_dependencies.sh
@@ -13,8 +13,7 @@
 #
 # Also installs the image decoder libs (libjpeg-turbo, libpng, libwebp) by
 # default. Builds that don't need image decoding (e.g. the mypy CI job) can skip
-# them by setting TORCHCODEC_SKIP_IMAGE_DEPS=1, in which case the decoders
-# compile as no-op stubs.
+# them by setting TORCHCODEC_BUILD_IMAGE=0.
 #
 # This script intentionally does NOT install:
 # - torch: install it separately (a nightly matching your CPU/CUDA variant).
@@ -30,7 +29,7 @@ set -ex
 conda install -y pybind11 -c conda-forge
 python -m pip install "scikit-build-core>=0.10" ninja
 
-if [[ "${TORCHCODEC_SKIP_IMAGE_DEPS:-0}" != "1" ]]; then
+if [[ "${TORCHCODEC_BUILD_IMAGE:-ON}" != "0" ]]; then
     conda install -y libjpeg-turbo -c pytorch
     conda install -y libpng -c conda-forge
     conda install -y "libwebp>=1.3" -c conda-forge

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,16 @@ ENABLE_CUDA = {env = "ENABLE_CUDA", default = ""}
 TORCHCODEC_DISABLE_COMPILE_WARNING_AS_ERROR = {env = "TORCHCODEC_DISABLE_COMPILE_WARNING_AS_ERROR", default = "OFF"}
 TORCHCODEC_DISABLE_HOMEBREW_RPATH = {env = "TORCHCODEC_DISABLE_HOMEBREW_RPATH", default = "OFF"}
 
+# Image decoder build toggles. By default all image decoders are built and
+# *required*: if a codec's lib can't be found/fetched the build fails loudly.
+# flags default to "AUTO", meaning they inherit from TORCHCODEC_BUILD_IMAGE.
+TORCHCODEC_BUILD_IMAGE = {env = "TORCHCODEC_BUILD_IMAGE", default = "ON"}
+TORCHCODEC_BUILD_JPEG = {env = "TORCHCODEC_BUILD_JPEG", default = "AUTO"}
+TORCHCODEC_BUILD_PNG = {env = "TORCHCODEC_BUILD_PNG", default = "AUTO"}
+TORCHCODEC_BUILD_WEBP = {env = "TORCHCODEC_BUILD_WEBP", default = "AUTO"}
+TORCHCODEC_BUILD_AVIF = {env = "TORCHCODEC_BUILD_AVIF", default = "AUTO"}
+TORCHCODEC_BUILD_GIF = {env = "TORCHCODEC_BUILD_GIF", default = "AUTO"}
+
 [project.optional-dependencies]
 dev = [
     "numpy",

--- a/src/torchcodec/_core/CMakeLists.txt
+++ b/src/torchcodec/_core/CMakeLists.txt
@@ -30,67 +30,136 @@ if(APPLE)
     set(CMAKE_FIND_FRAMEWORK LAST)
 endif()
 
-# libjpeg is an optional build-time dependency for the CPU JPEG image decoder.
-# When found, we compile decode_jpeg with libjpeg support and link against it.
-# When absent, decode_jpeg still exists but raises an actionable error at call
-# time (see DecodeJpeg.cpp's !JPEG_FOUND stub).
-if(NOT DEFINED JPEG_ROOT AND DEFINED ENV{CONDA_PREFIX})
-    # JPEG_ROOT will automatically be passed to find_package(JPEG) by CMake if it is
-    # set. We fallback to the conda prefix if it is not set.
-    if(WIN32)
-        set(JPEG_ROOT "$ENV{CONDA_PREFIX}/Library")
-    else()
-        set(JPEG_ROOT "$ENV{CONDA_PREFIX}")
+# Image decoder build toggles. By default all image decoders are built and
+# *required*: if a codec's lib can't be found/fetched the build fails loudly,
+# telling the user how to opt out. This is controlled by:
+#   - TORCHCODEC_BUILD_IMAGE (catch-all, default ON)
+#   - TORCHCODEC_BUILD_{JPEG,PNG,WEBP,AVIF,GIF} (default AUTO = inherit catch-all)
+# A codec set to OFF is not built; its decode_*() then raises an actionable error
+# at call time (see e.g. DecodeJpeg.cpp's !TORCHCODEC_ENABLE_JPEG stub), while importing
+# torchcodec still works. We default the flags here too so that direct `cmake`
+# invocations (e.g. the C++ tests build) behave like the scikit-build path,
+# which passes them via pyproject.toml.
+if(NOT DEFINED TORCHCODEC_BUILD_IMAGE)
+    set(TORCHCODEC_BUILD_IMAGE "ON")
+endif()
+foreach(_codec JPEG PNG WEBP AVIF GIF)
+    if(NOT DEFINED TORCHCODEC_BUILD_${_codec})
+        set(TORCHCODEC_BUILD_${_codec} "AUTO")
     endif()
-endif()
-find_package(JPEG)  # Not REQUIRED on purpose.
-# TODO_IMAGE: we should probably make it mandatory by default and allow to make
-# it optional via a flag?
-if(JPEG_FOUND)
-    message(STATUS "libjpeg found: building torchcodec with JPEG image decoding support.")
-else()
-    message(STATUS "libjpeg NOT found: torchcodec.decode_jpeg will raise at runtime.")
-endif()
+endforeach()
 
-# same as libjpeg, libpng is an optional build-time dependency for the CPU PNG
-# image decoder.
-if(NOT DEFINED PNG_ROOT AND DEFINED ENV{CONDA_PREFIX})
-    if(WIN32)
-        set(PNG_ROOT "$ENV{CONDA_PREFIX}/Library")
+# Returns true (via out_want) if TORCHCODEC_BUILD_IMAGE is on, or if that
+# specific codec flag is explicitly on, and false otherwise.
+function(resolve_image_codec codec_flag out_want)
+    if(codec_flag STREQUAL "AUTO")
+        set(_resolved "${TORCHCODEC_BUILD_IMAGE}")
     else()
-        set(PNG_ROOT "$ENV{CONDA_PREFIX}")
+        set(_resolved "${codec_flag}")
     endif()
-endif()
-find_package(PNG)  # Not REQUIRED on purpose. Transitively pulls in ZLIB.
-if(PNG_FOUND)
-    message(STATUS "libpng found: building torchcodec with PNG image decoding support.")
-else()
-    message(STATUS "libpng NOT found: torchcodec.decode_png will raise at runtime.")
-endif()
-
-# same as libjpeg/libpng, libwebp is an optional build-time dependency for the
-# CPU WebP image decoder (DecodeWebp.cpp).
-if(NOT DEFINED WebP_ROOT AND DEFINED ENV{CONDA_PREFIX})
-    if(WIN32)
-        set(WebP_ROOT "$ENV{CONDA_PREFIX}/Library")
+    if(_resolved)
+        set(${out_want} TRUE PARENT_SCOPE)
     else()
-        set(WebP_ROOT "$ENV{CONDA_PREFIX}")
+        set(${out_want} FALSE PARENT_SCOPE)
     endif()
-endif()
-find_package(WebP)  # Not REQUIRED on purpose. Provides the WebP::webp and
-                    # WebP::webpdemux targets.
-if(WebP_FOUND)
-    message(STATUS "libwebp found: building torchcodec with WebP image decoding support.")
-else()
-    message(STATUS "libwebp NOT found: torchcodec.decode_webp will raise at runtime.")
-endif()
+endfunction()
 
-# TODO_IMAGE: fetch and building with avif is unconditional for now. We should
-# make image support opt-in/opt-out (mirroring the TODO_IMAGE in
-# _image_decoders.py about building without image dependencies)
-include(${CMAKE_CURRENT_SOURCE_DIR}/fetch_avif_from_s3.cmake)
-set(libavif_FOUND TRUE)
-message(STATUS "Building torchcodec with AVIF image decoding support (libavif from S3).")
+function(discover_image_codecs)
+    resolve_image_codec("${TORCHCODEC_BUILD_JPEG}" want_jpeg)
+    if(want_jpeg)
+        if(NOT DEFINED JPEG_ROOT AND DEFINED ENV{CONDA_PREFIX})
+            # JPEG_ROOT will automatically be passed to find_package(JPEG) by CMake
+            # if it is set. We fallback to the conda prefix if it is not set.
+            if(WIN32)
+                set(JPEG_ROOT "$ENV{CONDA_PREFIX}/Library")
+            else()
+                set(JPEG_ROOT "$ENV{CONDA_PREFIX}")
+            endif()
+        endif()
+        find_package(JPEG)  # Not REQUIRED: we emit our own actionable error below.
+        if(JPEG_FOUND)
+            message(STATUS "libjpeg found: building torchcodec with JPEG image decoding support.")
+        else()
+            message(FATAL_ERROR
+                "libjpeg not found, but JPEG image decoding is enabled. Install "
+                "libjpeg[-turbo] and its development headers, or set "
+                "TORCHCODEC_BUILD_JPEG=0 to build without JPEG support (decode_jpeg "
+                "will raise at runtime), or TORCHCODEC_BUILD_IMAGE=0 to disable all "
+                "image decoders.")
+        endif()
+    else()
+        message(STATUS "Not building torchcodec with JPEG image decoding support (disabled via TORCHCODEC_BUILD_JPEG/TORCHCODEC_BUILD_IMAGE): decode_jpeg will raise at runtime.")
+    endif()
+
+    resolve_image_codec("${TORCHCODEC_BUILD_PNG}" want_png)
+    if(want_png)
+        if(NOT DEFINED PNG_ROOT AND DEFINED ENV{CONDA_PREFIX})
+            if(WIN32)
+                set(PNG_ROOT "$ENV{CONDA_PREFIX}/Library")
+            else()
+                set(PNG_ROOT "$ENV{CONDA_PREFIX}")
+            endif()
+        endif()
+        find_package(PNG)  # Transitively pulls in ZLIB.
+        if(PNG_FOUND)
+            message(STATUS "libpng found: building torchcodec with PNG image decoding support.")
+        else()
+            message(FATAL_ERROR
+                "libpng not found, but PNG image decoding is enabled. Install libpng "
+                "and its development headers, or set TORCHCODEC_BUILD_PNG=0 to build "
+                "without PNG support (decode_png will raise at runtime), or "
+                "TORCHCODEC_BUILD_IMAGE=0 to disable all image decoders.")
+        endif()
+    else()
+        message(STATUS "Not building torchcodec with PNG image decoding support (disabled via TORCHCODEC_BUILD_PNG/TORCHCODEC_BUILD_IMAGE): decode_png will raise at runtime.")
+    endif()
+
+    resolve_image_codec("${TORCHCODEC_BUILD_WEBP}" want_webp)
+    if(want_webp)
+        if(NOT DEFINED WebP_ROOT AND DEFINED ENV{CONDA_PREFIX})
+            if(WIN32)
+                set(WebP_ROOT "$ENV{CONDA_PREFIX}/Library")
+            else()
+                set(WebP_ROOT "$ENV{CONDA_PREFIX}")
+            endif()
+        endif()
+        find_package(WebP)  # Provides the WebP::webp and WebP::webpdemux targets.
+        if(WebP_FOUND)
+            message(STATUS "libwebp found: building torchcodec with WebP image decoding support.")
+        else()
+            message(FATAL_ERROR
+                "libwebp not found, but WebP image decoding is enabled. Install "
+                "libwebp and its development headers, or set TORCHCODEC_BUILD_WEBP=0 "
+                "to build without WebP support (decode_webp will raise at runtime), "
+                "or TORCHCODEC_BUILD_IMAGE=0 to disable all image decoders.")
+        endif()
+    else()
+        message(STATUS "Not building torchcodec with WebP image decoding support (disabled via TORCHCODEC_BUILD_WEBP/TORCHCODEC_BUILD_IMAGE): decode_webp will raise at runtime.")
+    endif()
+
+    resolve_image_codec("${TORCHCODEC_BUILD_AVIF}" want_avif)
+    if(want_avif)
+        include(${CMAKE_CURRENT_SOURCE_DIR}/fetch_avif_from_s3.cmake)
+        set(libavif_FOUND TRUE)
+        message(STATUS "Building torchcodec with AVIF image decoding support (libavif from S3).")
+    else()
+        message(STATUS "Not building torchcodec with AVIF image decoding support (disabled via TORCHCODEC_BUILD_AVIF/TORCHCODEC_BUILD_IMAGE): decode_avif will raise at runtime.")
+    endif()
+
+    resolve_image_codec("${TORCHCODEC_BUILD_GIF}" want_gif)
+    if(want_gif)
+        message(STATUS "Building torchcodec with GIF image decoding support (vendored giflib).")
+    else()
+        message(STATUS "Not building torchcodec with GIF image decoding support (disabled via TORCHCODEC_BUILD_GIF/TORCHCODEC_BUILD_IMAGE): decode_gif will raise at runtime.")
+    endif()
+
+    # Re-export the resolved want_<codec> booleans and (for Windows) the avif
+    # runtime lib path to make_torchcodec_image_library, our caller.
+    foreach(_codec jpeg png webp avif gif)
+        set(want_${_codec} "${want_${_codec}}" PARENT_SCOPE)
+    endforeach()
+    set(avif_runtime_lib "${avif_runtime_lib}" PARENT_SCOPE)
+endfunction()
 
 # Read a list variable from sources.bzl, the single source of truth for the
 # _core C++ source files shared with the internal Buck build. The .bzl file is
@@ -462,12 +531,18 @@ endfunction()
 # (which also links libpng/libjpeg/... with the same sonames) then live in
 # separate scopes and cannot interpose on each other.
 function(make_torchcodec_image_library)
+    # This will expose the want_<codec> booleans and (for Windows) the avif
+    # runtime lib path
+    discover_image_codecs()
+
     set(image_library_name "libtorchcodec_image")
     set(image_library_sources
         ${TORCHCODEC_IMAGE_SOURCES}
         ${TORCHCODEC_IMAGE_OPS_SOURCES}
-        ${TORCHCODEC_GIFLIB_SOURCES}
     )
+    if(want_gif)
+        list(APPEND image_library_sources ${TORCHCODEC_GIFLIB_SOURCES})
+    endif()
 
     make_torchcodec_sublibrary(
         "${image_library_name}"
@@ -476,26 +551,26 @@ function(make_torchcodec_image_library)
         "${TORCH_LIBRARIES}"
     )
 
-    # Optional image codec support. Each *_FOUND gates both the compile-time code
-    # path (the decoder falls back to an actionable runtime-error stub when
-    # absent) and the link. These are linked here, NOT into core.
-    if(JPEG_FOUND)
-        target_compile_definitions(${image_library_name} PRIVATE JPEG_FOUND=1)
+    if(want_jpeg)
+        target_compile_definitions(${image_library_name} PRIVATE TORCHCODEC_ENABLE_JPEG=1)
         target_link_libraries(${image_library_name} PRIVATE JPEG::JPEG)
     endif()
-    if(PNG_FOUND)
-        target_compile_definitions(${image_library_name} PRIVATE PNG_FOUND=1)
+    if(want_png)
+        target_compile_definitions(${image_library_name} PRIVATE TORCHCODEC_ENABLE_PNG=1)
         target_link_libraries(${image_library_name} PRIVATE PNG::PNG)
     endif()
-    if(WebP_FOUND)
-        target_compile_definitions(${image_library_name} PRIVATE WEBP_FOUND=1)
+    if(want_webp)
+        target_compile_definitions(${image_library_name} PRIVATE TORCHCODEC_ENABLE_WEBP=1)
         # WebP::webpdemux provides the WebPAnimDecoder API used for animated
         # webp files.
         target_link_libraries(${image_library_name} PRIVATE WebP::webp WebP::webpdemux)
     endif()
-    if(libavif_FOUND)
-        target_compile_definitions(${image_library_name} PRIVATE AVIF_FOUND=1)
+    if(want_avif)
+        target_compile_definitions(${image_library_name} PRIVATE TORCHCODEC_ENABLE_AVIF=1)
         target_link_libraries(${image_library_name} PRIVATE avif)
+    endif()
+    if(want_gif)
+        target_compile_definitions(${image_library_name} PRIVATE TORCHCODEC_ENABLE_GIF=1)
     endif()
 
     # Hide our own (and statically linked giflib's) symbols so the only thing
@@ -512,7 +587,7 @@ function(make_torchcodec_image_library)
             LIBRARY_OUTPUT_DIRECTORY "${TORCHCODEC_PACKAGE_DIR}"
             RUNTIME_OUTPUT_DIRECTORY "${TORCHCODEC_PACKAGE_DIR}"  # Windows
         )
-        if(WIN32)
+        if(WIN32 AND want_avif)
             # Windows editable build needs the libavif DLL next to the image
             # lib. Note that the other image codec lib don't, because they are
             # already on the DLL search path. This is speculative and untested,

--- a/src/torchcodec/_core/DecodeAvif.cpp
+++ b/src/torchcodec/_core/DecodeAvif.cpp
@@ -12,7 +12,7 @@
 
 #include "StableABICompat.h"
 
-#if !AVIF_FOUND
+#if !TORCHCODEC_ENABLE_AVIF
 
 namespace facebook::torchcodec {
 
@@ -152,4 +152,4 @@ torch::stable::Tensor decode_avif(
 
 } // namespace facebook::torchcodec
 
-#endif // !AVIF_FOUND
+#endif // !TORCHCODEC_ENABLE_AVIF

--- a/src/torchcodec/_core/DecodeGif.cpp
+++ b/src/torchcodec/_core/DecodeGif.cpp
@@ -10,6 +10,27 @@
 #include <torch/csrc/stable/ops.h>
 #include <torch/headeronly/util/Exception.h>
 
+#include "StableABICompat.h"
+
+#if !TORCHCODEC_ENABLE_GIF
+
+namespace facebook::torchcodec {
+
+torch::stable::Tensor decode_gif(
+    [[maybe_unused]] const torch::stable::Tensor& input,
+    [[maybe_unused]] int64_t mode) {
+  STD_TORCH_CHECK(
+      false,
+      "decode_gif: torchcodec was not compiled with GIF support. Rebuild "
+      "torchcodec with TORCHCODEC_BUILD_GIF=1 (and without TORCHCODEC_BUILD_IMAGE"
+      "=0). If you see this error in a prebuilt wheel, please report it to the "
+      "TorchCodec repo.");
+}
+
+} // namespace facebook::torchcodec
+
+#else
+
 #include <torch/headeronly/core/MemoryFormat.h>
 
 #include <algorithm>
@@ -17,7 +38,6 @@
 #include <optional>
 
 #include "ImageCommon.h"
-#include "StableABICompat.h"
 #include "giflib/gif_lib.h"
 
 namespace facebook::torchcodec {
@@ -311,3 +331,5 @@ torch::stable::Tensor decode_gif(
 }
 
 } // namespace facebook::torchcodec
+
+#endif // !TORCHCODEC_ENABLE_GIF

--- a/src/torchcodec/_core/DecodeJpeg.cpp
+++ b/src/torchcodec/_core/DecodeJpeg.cpp
@@ -12,7 +12,7 @@
 
 #include "StableABICompat.h"
 
-#if !JPEG_FOUND
+#if !TORCHCODEC_ENABLE_JPEG
 
 namespace facebook::torchcodec {
 
@@ -483,4 +483,4 @@ torch::stable::Tensor decode_jpeg(
 
 } // namespace facebook::torchcodec
 
-#endif // !JPEG_FOUND
+#endif // !TORCHCODEC_ENABLE_JPEG

--- a/src/torchcodec/_core/DecodePng.cpp
+++ b/src/torchcodec/_core/DecodePng.cpp
@@ -12,7 +12,7 @@
 
 #include "StableABICompat.h"
 
-#if !PNG_FOUND
+#if !TORCHCODEC_ENABLE_PNG
 
 namespace facebook::torchcodec {
 
@@ -359,4 +359,4 @@ torch::stable::Tensor decode_png(
 
 } // namespace facebook::torchcodec
 
-#endif // !PNG_FOUND
+#endif // !TORCHCODEC_ENABLE_PNG

--- a/src/torchcodec/_core/DecodeWebp.cpp
+++ b/src/torchcodec/_core/DecodeWebp.cpp
@@ -12,7 +12,7 @@
 
 #include "StableABICompat.h"
 
-#if !WEBP_FOUND
+#if !TORCHCODEC_ENABLE_WEBP
 
 namespace facebook::torchcodec {
 
@@ -245,4 +245,4 @@ torch::stable::Tensor decode_webp(
 
 } // namespace facebook::torchcodec
 
-#endif // !WEBP_FOUND
+#endif // !TORCHCODEC_ENABLE_WEBP

--- a/src/torchcodec/_core/sources.bzl
+++ b/src/torchcodec/_core/sources.bzl
@@ -86,8 +86,8 @@ image_ops_sources = [
 ]
 
 # Vendored giflib (decode-only subset, MIT licensed). Compiled directly from
-# source into the core library, so the GIF decoder needs no external dependency
-# and is always available. See giflib/README for the license and local mods.
+# source into the image library, so the GIF decoder needs no external dependency.
+# See giflib/README for the license and local mods.
 giflib_sources = [
     "giflib/dgif_lib.c",
     "giflib/gifalloc.c",

--- a/src/torchcodec/_internally_replaced_utils.py
+++ b/src/torchcodec/_internally_replaced_utils.py
@@ -84,8 +84,6 @@ def load_torchcodec_shared_libraries() -> tuple[int, str, ModuleType]:
          libraries do not meet those conditions.
     """
 
-    # TODO_IMAGE: Maybe we should only load that upon first use of an image
-    # decoder.
     image_library_path = _get_extension_path("libtorchcodec_image")
     torch.ops.load_library(image_library_path)
 

--- a/src/torchcodec/decoders/_image_decoders.py
+++ b/src/torchcodec/decoders/_image_decoders.py
@@ -18,13 +18,8 @@ from torchcodec._core.ops import (
     decode_webp as _decode_webp,
 )
 
-# TODO_IMAGE: we need to make FFmpeg an optional dependency
-
-# TODO_IMAGE: we should allow to build without all the image dependencies
-# (libjpeg etc.), and make sure only the *calls* to decode_*() fail at runtime,
-# not the import of torchcodec.
-
-# TODO_IMAGE We probably need CI jobs for both TODOs above.
+# TODO_IMAGE: we need to make FFmpeg an optional dependency, and probably want a
+# CI job for that.
 
 # TODO_IMAGE Some codecs expose threading options - we should make sure the
 # default is 1 thread and allow the user to override it. (similar to


### PR DESCRIPTION
Users building from source can now opt-out of all image decoders via the catch-all `TORCHCODEC_BUILD_IMAGE` flag, or opt-out of individual decoders via the `TORCHCODEC_BUILD_{JPEG,PNG,WEBP,AVIF,GIF}` flags.

By default, all decoders are expected to be built, hence all their dependencies are expected to be found.

This also changes the Cpp preprocessor variables from `JPEG_FOUND` to the slightly more explicit and accurate `TORCHCODEC_ENABLE_JPEG`. These are *different* from the env vars like `TORCHCODEC_BUILD_JPEG`, they're fundamentally different in nature.

Note that both the gif and avif decoders are treated as the other decoders here: we can disable their build even though they don't require any external dep.