### PR TITLE
Align jpeg CMYK ouptput with PIL

### DIFF
--- a/src/torchcodec/_core/DecodeJpeg.cpp
+++ b/src/torchcodec/_core/DecodeJpeg.cpp
@@ -466,6 +466,16 @@ torch::stable::Tensor decode_jpeg(
 
   decode_rows(jpeg_ctx, error_ctx, output_ptr, stride, cmyk_helper);
 
+  // Flip raw CMYK samples so our output matches PIL.
+  if (static_cast<ImageReadMode>(mode) == ImageReadMode::UNCHANGED &&
+      (jpeg_ctx.jpeg_color_space == JCS_CMYK ||
+       jpeg_ctx.jpeg_color_space == JCS_YCCK)) {
+    int64_t num_bytes = output.numel();
+    for (int64_t i = 0; i < num_bytes; ++i) {
+      output_ptr[i] = static_cast<uint8_t>(255 - output_ptr[i]);
+    }
+  }
+
   // EXIF markers were parsed during jpeg_read_header so this is just an
   // in-memory lookup (i.e. we're not going back to the beginning of the file)
   ExifOrientation exif_orientation = fetch_jpeg_exif_orientation(&jpeg_ctx);

--- a/test/test_decoders.py
+++ b/test/test_decoders.py
@@ -3673,9 +3673,6 @@ class TestImageDecoder:
         decoded = decode_jpeg(asset.path, mode=mode)
 
         reference = self._pil_to_tensor(Image.open(asset.path).convert(pil_mode))
-        if asset is CMYK_JPEG and mode == "UNCHANGED":
-            # libjpeg returns raw (inverted) CMYK samples; flip to match PIL.
-            reference = 255 - reference
 
         assert decoded.shape == reference.shape
         assert_tensor_close_on_at_least(decoded, reference, percentage=99, atol=2)
@@ -3746,10 +3743,6 @@ class TestImageDecoder:
         assert decoded.dtype == torch.uint8
 
         reference = self._pil_to_tensor(Image.open(path).convert(pil_mode))
-        if output_mode == "UNCHANGED" and fmt == "JPEG" and source_mode == "CMYK":
-            # libjpeg returns raw (inverted) CMYK samples; flip to match PIL.
-            # TODO_IMAGE: is this a bug? Should we fix it?
-            reference = 255 - reference
 
         if output_mode == "UNCHANGED":
             num_expected_channels = reference.shape[0]


### PR DESCRIPTION
We return raw CMYK samples from libjpeg but PIL switches them. For consistency, we now switch them too.