### PR TITLE
Add benchmark for image decoders

### DIFF
--- a/benchmarks/decoders/benchmark_image_decoders.py
+++ b/benchmarks/decoders/benchmark_image_decoders.py
@@ -1,0 +1,294 @@
+"""Benchmark torchcodec's dedicated image decoders against PIL, torchvision, and
+torchcodec's FFmpeg video-decoder path, across formats and resolutions.
+
+All backends are pinned to a single thread and decode to a comparable
+(C, H, W) uint8 RGB tensor. Run:
+
+    python benchmarks/decoders/benchmark_image_decoders.py --num-exp 50
+
+See --help for options.
+"""
+
+import os
+
+for _var in (
+    "OMP_NUM_THREADS",
+    "OPENBLAS_NUM_THREADS",
+    "MKL_NUM_THREADS",
+    "NUMEXPR_NUM_THREADS",
+):
+    os.environ.setdefault(_var, "1")
+
+import io
+import tempfile
+from argparse import ArgumentParser
+from pathlib import Path
+from time import perf_counter_ns
+
+import numpy as np
+import torch
+from PIL import Image
+from torch import Tensor
+
+torch.set_num_threads(1)
+
+try:
+    from PIL import AvifImagePlugin
+
+    AvifImagePlugin.DEFAULT_MAX_THREADS = 1
+except ImportError:
+    pass
+
+from torchcodec._core.ops import (  # noqa: E402
+    add_video_stream,
+    create_from_tensor,
+    get_next_frame,
+)
+from torchcodec.decoders._image_decoders import (  # noqa: E402
+    decode_avif,
+    decode_gif,
+    decode_heic,
+    decode_jpeg,
+    decode_png,
+    decode_webp,
+)
+
+from torchvision.io import (  # noqa: E402
+    decode_gif as tv_decode_gif,
+    decode_jpeg as tv_decode_jpeg,
+    decode_png as tv_decode_png,
+    decode_webp as tv_decode_webp,
+)
+from torchvision.transforms.v2.functional import pil_to_tensor  # noqa: E402
+
+DEFAULT_NUM_EXP = 50
+
+RESOLUTIONS = {
+    "320p": (568, 320),
+    "480p": (854, 480),
+    "720p": (1280, 720),
+    "1080p": (1920, 1080),
+}
+
+_TC_DECODERS = {
+    "jpeg": decode_jpeg,
+    "png": decode_png,
+    "webp": decode_webp,
+    "gif": decode_gif,
+    "avif": decode_avif,
+    "heic": decode_heic,
+}
+
+# torchvision has no avif/heic decoder, they're in torchvision-extra-decoders,
+# but we don't bother (they're broken anyway). decode_gif is RGB-only and takes
+# no mode argument.
+_TV_DECODERS = {
+    "jpeg": lambda d: tv_decode_jpeg(d, "RGB"),
+    "png": lambda d: tv_decode_png(d, "RGB"),
+    "webp": lambda d: tv_decode_webp(d, "RGB"),
+    "gif": lambda d: tv_decode_gif(d),
+}
+
+_EXT = {
+    "jpeg": "jpg",
+    "png": "png",
+    "webp": "webp",
+    "gif": "gif",
+    "avif": "avif",
+    "heic": "heic",
+}
+
+
+def bench(f, *args, num_exp=DEFAULT_NUM_EXP, warmup=5, **kwargs) -> Tensor:
+    for _ in range(warmup):
+        f(*args, **kwargs)
+    times = []
+    for _ in range(num_exp):
+        start = perf_counter_ns()
+        f(*args, **kwargs)
+        end = perf_counter_ns()
+        times.append(end - start)
+    return torch.tensor(times).float()
+
+
+def _median_ms(times: Tensor) -> float:
+    return (times * 1e-6).median().item()
+
+
+# ---------------------------------------------------------------------------
+# Test image generation
+# ---------------------------------------------------------------------------
+def load_source_image(override: Path | None) -> Image.Image:
+    if override is not None:
+        return Image.open(override).convert("RGB")
+    try:
+        import scipy.datasets
+
+        arr = scipy.datasets.face()  # (768, 1024, 3) real photo, cached
+        return Image.fromarray(arr, mode="RGB")
+    except Exception as e:
+        print(
+            f"scipy.datasets.face() unavailable ({e}); using textured synthetic image."
+        )
+        rng = np.random.RandomState(0)
+        h, w = 768, 1024
+        base = np.linspace(0, 255, w, dtype=np.float32)[None, :].repeat(h, 0)
+        noise = rng.randn(h, w) * 40
+        chan = np.clip(base + noise, 0, 255).astype(np.uint8)
+        return Image.fromarray(
+            np.stack([chan, np.roll(chan, 30, 1), np.roll(chan, 60, 0)], -1), "RGB"
+        )
+
+
+def encode_images(image: Image.Image, resolutions, out_dir: Path) -> dict:
+    """Encode the same image at each resolution into every format. Returns
+    {(fmt, res_label): path}."""
+    import pillow_heif
+
+    pillow_heif.register_heif_opener()  # needed to save HEIC via PIL
+
+    paths = {}
+    for res_label in resolutions:
+        w, h = RESOLUTIONS[res_label]
+        resized = image.resize((w, h), Image.LANCZOS)
+        for fmt in _EXT:
+            path = out_dir / f"img_{res_label}.{_EXT[fmt]}"
+            if fmt == "jpeg":
+                resized.save(path, format="JPEG", quality=90)
+            elif fmt == "png":
+                resized.save(path, format="PNG")
+            elif fmt == "webp":
+                resized.save(path, format="WEBP", quality=90)
+            elif fmt == "gif":
+                resized.convert("P", palette=Image.ADAPTIVE).save(path, format="GIF")
+            elif fmt == "avif":
+                resized.save(path, format="AVIF", quality=90)
+            elif fmt == "heic":
+                resized.save(path, format="HEIF", quality=90)
+            paths[(fmt, res_label)] = path
+    return paths
+
+
+# ---------------------------------------------------------------------------
+# Backends: each takes preloaded uint8 byte tensor -> (C, H, W) uint8 RGB tensor
+# ---------------------------------------------------------------------------
+def decode_torchcodec(data: Tensor, fmt: str) -> Tensor:
+    return _TC_DECODERS[fmt](data, mode="RGB")
+
+
+def decode_torchvision(data: Tensor, fmt: str) -> Tensor:
+    return _TV_DECODERS[fmt](data)
+
+
+def decode_pil(raw: bytes) -> Tensor:
+    img = Image.open(io.BytesIO(raw)).convert("RGB")
+    return pil_to_tensor(img)
+
+
+def decode_ffmpeg(data: Tensor) -> Tensor:
+    # Equivalent to the file-based path:
+    #   dec = create_from_file(path, "approximate"); add_video_stream(dec, num_threads=1)
+    #   frame, _, _ = get_next_frame(dec)
+    # create_from_tensor keeps bytes in memory so we time pure decode.
+    dec = create_from_tensor(data, "approximate")
+    add_video_stream(dec, num_threads=1)
+    frame, _, _ = get_next_frame(dec)
+    return frame
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+def main():
+    parser = ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--resolutions", nargs="+", default=list(RESOLUTIONS), choices=list(RESOLUTIONS)
+    )
+    parser.add_argument("--num-exp", type=int, default=DEFAULT_NUM_EXP)
+    parser.add_argument(
+        "--image",
+        type=Path,
+        default=None,
+        help="override source image (default: scipy.datasets.face())",
+    )
+    args = parser.parse_args()
+
+    print(
+        f"torch.get_num_threads()={torch.get_num_threads()}, OMP_NUM_THREADS={os.environ.get('OMP_NUM_THREADS')}"
+    )
+    print(
+        "Note: libavif/dav1d internal threading is not exposed by decode_avif (library default)."
+    )
+
+    image = load_source_image(args.image)
+    tmp = tempfile.TemporaryDirectory()
+    paths = encode_images(image, args.resolutions, Path(tmp.name))
+
+    backends = ["torchcodec", "PIL", "torchvision", "FFmpeg"]
+    rows = []  # (fmt, res, sizes_kb, {backend: median_ms})
+
+    for fmt in _EXT:
+        for res_label in args.resolutions:
+            path = paths[(fmt, res_label)]
+            raw = path.read_bytes()
+            data = torch.frombuffer(bytearray(raw), dtype=torch.uint8)
+            size_kb = len(raw) / 1024.0
+            results = {}
+            for backend in backends:
+                # torchvision has no avif/heic decoder; leave those cells blank.
+                if backend == "torchvision" and fmt not in _TV_DECODERS:
+                    results[backend] = None
+                    continue
+                try:
+                    if backend == "torchcodec":
+                        fn = lambda: decode_torchcodec(data, fmt)  # noqa: E731
+                    elif backend == "PIL":
+                        fn = lambda: decode_pil(raw)  # noqa: E731
+                    elif backend == "torchvision":
+                        fn = lambda: decode_torchvision(data, fmt)  # noqa: E731
+                    else:
+                        fn = lambda: decode_ffmpeg(data)  # noqa: E731
+                    fn()  # smoke
+                    times = bench(fn, num_exp=args.num_exp)
+                    results[backend] = _median_ms(times)
+                except Exception as e:
+                    results[backend] = None
+                    print(f"  [skip] {fmt} {res_label} {backend}: {str(e)[:80]}")
+            rows.append((fmt, res_label, size_kb, results))
+
+    # ---- results table ----
+    print(f"\n## Decode-to-tensor median latency (ms), 1 thread, {args.num_exp} runs\n")
+    hdr = (
+        f"{'format':<7}{'res':<7}{'size KB':>9}{'torchcodec':>12}{'PIL':>9}"
+        f"{'tv':>9}{'FFmpeg':>9}{'PIL/tc':>9}{'tv/tc':>9}{'FFmpeg/tc':>11}"
+    )
+    print(hdr)
+    print("-" * len(hdr))
+
+    def fmt_ms(v):
+        return f"{v:.3f}" if v is not None else "N/A"
+
+    def ratio(num, den):
+        if num is None or den is None or den == 0:
+            return "N/A"
+        return f"{num / den:.2f}x"
+
+    for fmt, res_label, size_kb, r in rows:
+        tc, pil, tv, ff = (
+            r["torchcodec"],
+            r["PIL"],
+            r["torchvision"],
+            r["FFmpeg"],
+        )
+        print(
+            f"{fmt:<7}{res_label:<7}{size_kb:>9.1f}{fmt_ms(tc):>12}{fmt_ms(pil):>9}"
+            f"{fmt_ms(tv):>9}{fmt_ms(ff):>9}{ratio(pil, tc):>9}{ratio(tv, tc):>9}"
+            f"{ratio(ff, tc):>11}"
+        )
+
+    print("\n(PIL/tc, tv/tc and FFmpeg/tc > 1.0 mean torchcodec is faster.)")
+    tmp.cleanup()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/decoders/benchmark_image_decoders.py
+++ b/benchmarks/decoders/benchmark_image_decoders.py
@@ -22,6 +22,7 @@ for _var in (
 import io
 import tempfile
 from argparse import ArgumentParser
+from functools import partial
 from pathlib import Path
 from time import perf_counter_ns
 
@@ -41,6 +42,7 @@ except ImportError:
 
 from torchcodec._core.ops import (  # noqa: E402
     add_video_stream,
+    create_from_file,
     create_from_tensor,
     get_next_frame,
 )
@@ -58,6 +60,7 @@ from torchvision.io import (  # noqa: E402
     decode_jpeg as tv_decode_jpeg,
     decode_png as tv_decode_png,
     decode_webp as tv_decode_webp,
+    read_file as tv_read_file,
 )
 from torchvision.transforms.v2.functional import pil_to_tensor  # noqa: E402
 
@@ -170,27 +173,28 @@ def encode_images(image: Image.Image, resolutions, out_dir: Path) -> dict:
 
 
 # ---------------------------------------------------------------------------
-# Backends: each takes preloaded uint8 byte tensor -> (C, H, W) uint8 RGB tensor
+# Backends: decode to a (C, H, W) uint8 RGB tensor, either from a preloaded
+# uint8 byte tensor (from_file=False, timing pure decode) or straight from a
+# file path (from_file=True, timing decode + I/O).
 # ---------------------------------------------------------------------------
-def decode_torchcodec(data: Tensor, fmt: str) -> Tensor:
-    return _TC_DECODERS[fmt](data, mode="RGB")
+def decode_torchcodec(fmt: str, path: Path, data: Tensor, from_file: bool) -> Tensor:
+    return _TC_DECODERS[fmt](path if from_file else data, mode="RGB")
 
 
-def decode_torchvision(data: Tensor, fmt: str) -> Tensor:
-    return _TV_DECODERS[fmt](data)
+def decode_torchvision(fmt: str, path: Path, data: Tensor, from_file: bool) -> Tensor:
+    return _TV_DECODERS[fmt](tv_read_file(str(path)) if from_file else data)
 
 
-def decode_pil(raw: bytes) -> Tensor:
-    img = Image.open(io.BytesIO(raw)).convert("RGB")
+def decode_pil(path: Path, raw: bytes, from_file: bool) -> Tensor:
+    img = Image.open(path if from_file else io.BytesIO(raw)).convert("RGB")
     return pil_to_tensor(img)
 
 
-def decode_ffmpeg(data: Tensor) -> Tensor:
-    # Equivalent to the file-based path:
-    #   dec = create_from_file(path, "approximate"); add_video_stream(dec, num_threads=1)
-    #   frame, _, _ = get_next_frame(dec)
-    # create_from_tensor keeps bytes in memory so we time pure decode.
-    dec = create_from_tensor(data, "approximate")
+def decode_ffmpeg(path: Path, data: Tensor, from_file: bool) -> Tensor:
+    if from_file:
+        dec = create_from_file(str(path), "approximate")
+    else:
+        dec = create_from_tensor(data, "approximate")
     add_video_stream(dec, num_threads=1)
     frame, _, _ = get_next_frame(dec)
     return frame
@@ -211,6 +215,20 @@ def main():
         default=None,
         help="override source image (default: scipy.datasets.face())",
     )
+    source = parser.add_mutually_exclusive_group()
+    source.add_argument(
+        "--from-bytes",
+        dest="from_file",
+        action="store_false",
+        default=False,
+        help="decode from preloaded in-memory bytes; times pure decode (default)",
+    )
+    source.add_argument(
+        "--from-file",
+        dest="from_file",
+        action="store_true",
+        help="decode straight from a file path; times decode + I/O",
+    )
     args = parser.parse_args()
 
     print(
@@ -219,6 +237,7 @@ def main():
     print(
         "Note: libavif/dav1d internal threading is not exposed by decode_avif (library default)."
     )
+    print(f"Source: {'file path' if args.from_file else 'in-memory bytes'}")
 
     image = load_source_image(args.image)
     tmp = tempfile.TemporaryDirectory()
@@ -240,14 +259,15 @@ def main():
                     results[backend] = None
                     continue
                 try:
+                    ff = args.from_file
                     if backend == "torchcodec":
-                        fn = lambda: decode_torchcodec(data, fmt)  # noqa: E731
+                        fn = partial(decode_torchcodec, fmt, path, data, ff)
                     elif backend == "PIL":
-                        fn = lambda: decode_pil(raw)  # noqa: E731
+                        fn = partial(decode_pil, path, raw, ff)
                     elif backend == "torchvision":
-                        fn = lambda: decode_torchvision(data, fmt)  # noqa: E731
+                        fn = partial(decode_torchvision, fmt, path, data, ff)
                     else:
-                        fn = lambda: decode_ffmpeg(data)  # noqa: E731
+                        fn = partial(decode_ffmpeg, path, data, ff)
                     fn()  # smoke
                     times = bench(fn, num_exp=args.num_exp)
                     results[backend] = _median_ms(times)


### PR DESCRIPTION
Adds a benchmark to compare our new image decoders against PIL, TorchVision, and our own hacky FFmpeg-backed path (not optimized).

Result on my laptop:

- Good to see that we're on par with TorchVision: the 'format sniffing' logic is now in Python instead of Cpp, but that doesn't impact perf at all.
- we're faster than PIL and FFmpeg on jpeg / png / webp / avif. We mainly care about jpeg and png, but good to know. Not sure what PIL links against for jpeg (whether it's libjpeg or libjpeg-turbo).[1]  
- We're slower than both on gif and heic. FFmpeg especially seems a lot faster - worth looking into if we really care about those codecs.


(PIL/tc, tv/tc and FFmpeg/tc > 1.0 mean torchcodec is faster.)
```
~/dev/torchcodec (rgba*) » python benchmarks/decoders/benchmark_image_decoders.py                                                       nicolashug@nicolashug-fedora-PW0H326Y
torch.get_num_threads()=1, OMP_NUM_THREADS=1
Note: libavif/dav1d internal threading is not exposed by decode_avif (library default).

## Decode-to-tensor median latency (ms), 1 thread, 50 runs

format res      size KB  torchcodec      PIL       tv   FFmpeg   PIL/tc    tv/tc  FFmpeg/tc
-------------------------------------------------------------------------------------------
jpeg   320p        71.1       0.778    1.087    0.775    1.402    1.40x    1.00x      1.80x
jpeg   480p       138.0       1.571    2.089    1.575    2.567    1.33x    1.00x      1.63x
jpeg   720p       251.4       3.069    4.191    3.056    4.334    1.37x    1.00x      1.41x
jpeg   1080p      446.4       5.974    9.457    5.968    8.227    1.58x    1.00x      1.38x
png    320p       372.5       4.451    5.107    4.441    7.627    1.15x    1.00x      1.71x
png    480p       753.3       9.762   11.362    9.795   16.765    1.16x    1.00x      1.72x
png    720p      1431.0      21.049   24.191   20.881   35.133    1.15x    0.99x      1.67x
png    1080p     2634.8      44.586   52.122   44.385   75.339    1.17x    1.00x      1.69x
webp   320p        66.2       3.682    4.227    3.668    9.640    1.15x    1.00x      2.62x
webp   480p       124.1       7.248    8.462    7.252   18.488    1.17x    1.00x      2.55x
webp   720p       202.1      12.686   15.184   12.672   31.339    1.20x    1.00x      2.47x
webp   1080p      327.6      23.041   30.606   22.886   55.907    1.33x    0.99x      2.43x
gif    320p       157.7       2.286    1.618    2.346    1.883    0.71x    1.03x      0.82x
gif    480p       325.3       5.149    3.711    5.504    3.907    0.72x    1.07x      0.76x
gif    720p       656.5      11.526    8.351   12.183    7.854    0.72x    1.06x      0.68x
gif    1080p     1292.4      25.198   17.245   26.211   16.558    0.68x    1.04x      0.66x
avif   320p        78.9       5.823    6.261      N/A   11.645    1.08x      N/A      2.00x
avif   480p       145.2      10.844   12.691      N/A   21.287    1.17x      N/A      1.96x
avif   720p       233.6      17.498   19.497      N/A   32.671    1.11x      N/A      1.87x
avif   1080p      333.5      25.636   31.600      N/A   48.529    1.23x      N/A      1.89x
heic   320p       136.4      19.521   18.233      N/A   12.363    0.93x      N/A      0.63x
heic   480p       273.8      38.012   33.974      N/A   25.103    0.89x      N/A      0.66x
heic   720p       509.5      74.491   64.072      N/A   48.408    0.86x      N/A      0.65x
heic   1080p      899.0     135.496  119.776      N/A   90.867    0.88x      N/A      0.67x
```

[1] We force PIL to convert from numpy to torch.tensor, which involves a copy. This is fair: users should convert to tensor after decoding anyway, so they can benefit from torch SIMD transforms (like `torchvision.transforms.v2.Resize` which is ~4x faster.)
