### PR TITLE
Add encode_png scaffolding (build wiring + stub)

### DIFF
--- a/src/torchcodec/_core/EncodePng.cpp
+++ b/src/torchcodec/_core/EncodePng.cpp
@@ -1,0 +1,44 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "EncodePng.h"
+
+#include <torch/csrc/stable/library.h>
+#include <torch/csrc/stable/ops.h>
+#include <torch/headeronly/util/Exception.h>
+
+#include "StableABICompat.h"
+
+#if !TORCHCODEC_ENABLE_PNG
+
+namespace facebook::torchcodec {
+
+torch::stable::Tensor encode_png(
+    [[maybe_unused]] const torch::stable::Tensor& data,
+    [[maybe_unused]] int64_t compression_level) {
+  STD_TORCH_CHECK(
+      false,
+      "encode_png: torchcodec was not compiled with libpng support. "
+      "Rebuild torchcodec in an environment where libpng (and its development "
+      "headers) are available. If you see this error in a prebuilt wheel, "
+      "please report it to the TorchCodec repo.");
+}
+
+} // namespace facebook::torchcodec
+
+#else
+
+namespace facebook::torchcodec {
+
+torch::stable::Tensor encode_png(
+    [[maybe_unused]] const torch::stable::Tensor& data,
+    [[maybe_unused]] int64_t compression_level) {
+  STD_TORCH_CHECK(false, "encode_png: not yet implemented.");
+}
+
+} // namespace facebook::torchcodec
+
+#endif // !TORCHCODEC_ENABLE_PNG

--- a/src/torchcodec/_core/EncodePng.h
+++ b/src/torchcodec/_core/EncodePng.h
@@ -1,0 +1,17 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include "StableABICompat.h"
+
+namespace facebook::torchcodec {
+
+FORCE_PUBLIC_VISIBILITY torch::stable::Tensor encode_png(
+    const torch::stable::Tensor& data,
+    int64_t compression_level);
+
+} // namespace facebook::torchcodec

--- a/src/torchcodec/_core/image_custom_ops.cpp
+++ b/src/torchcodec/_core/image_custom_ops.cpp
@@ -16,6 +16,7 @@
 #include "DecodeJpegCuda.h"
 #include "DecodePng.h"
 #include "DecodeWebp.h"
+#include "EncodePng.h"
 #include "StableABICompat.h"
 
 namespace facebook::torchcodec {
@@ -29,6 +30,7 @@ STABLE_TORCH_LIBRARY_FRAGMENT(torchcodec_ns, m) {
       "decode_avif(Tensor input, int mode, int output_dtype=0, int num_threads=1) -> Tensor");
   m.def(
       "decode_jpegs_cuda(Tensor[] encoded_images, int mode, Device device) -> Tensor[]");
+  m.def("encode_png(Tensor data, int compression_level) -> Tensor");
 }
 
 STABLE_TORCH_LIBRARY_IMPL(torchcodec_ns, CPU, m) {
@@ -37,6 +39,7 @@ STABLE_TORCH_LIBRARY_IMPL(torchcodec_ns, CPU, m) {
   m.impl("decode_webp", TORCH_BOX(&decode_webp));
   m.impl("decode_gif", TORCH_BOX(&decode_gif));
   m.impl("decode_avif", TORCH_BOX(&decode_avif));
+  m.impl("encode_png", TORCH_BOX(&encode_png));
 }
 
 STABLE_TORCH_LIBRARY_IMPL(torchcodec_ns, CompositeExplicitAutograd, m) {

--- a/src/torchcodec/_core/ops.py
+++ b/src/torchcodec/_core/ops.py
@@ -39,6 +39,7 @@ decode_png = torch.ops.torchcodec_ns.decode_png.default
 decode_webp = torch.ops.torchcodec_ns.decode_webp.default
 decode_gif = torch.ops.torchcodec_ns.decode_gif.default
 decode_avif = torch.ops.torchcodec_ns.decode_avif.default
+encode_png = torch.ops.torchcodec_ns.encode_png.default
 
 
 def get_decode_heic():

--- a/src/torchcodec/_core/sources.bzl
+++ b/src/torchcodec/_core/sources.bzl
@@ -80,6 +80,7 @@ image_sources = [
     "DecodeWebp.cpp",
     "DecodeGif.cpp",
     "DecodeAvif.cpp",
+    "EncodePng.cpp",
 ]
 
 image_ops_sources = [

--- a/src/torchcodec/encoders/_image_encoders.py
+++ b/src/torchcodec/encoders/_image_encoders.py
@@ -1,0 +1,25 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+
+from torchcodec._core.ops import encode_png as _encode_png
+
+
+def encode_png(input: torch.Tensor, compression_level: int = 6) -> torch.Tensor:
+    """Encode a CHW uint8 image tensor into the bytes of a PNG file.
+
+    Args:
+        input (``torch.Tensor``): The image to encode, a 3-dimensional uint8
+            tensor in CHW layout with 1 (grayscale) or 3 (RGB) channels.
+        compression_level (int): zlib compression level between 0 (no
+            compression, fastest) and 9 (max compression, slowest). Default: 6.
+
+    Returns:
+        torch.Tensor: A 1-dimensional uint8 tensor holding the raw bytes of the
+            encoded PNG file.
+    """
+    return _encode_png(input, compression_level)


### PR DESCRIPTION
Wire up an encode_png custom op end-to-end with a stub C++ implementation. Implem will come later. Trying out `gh stack`.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>