### PR TITLE
Add FFmpeg-free image pybind module for file-like output

### DIFF
--- a/packaging/repair_wheel.py
+++ b/packaging/repair_wheel.py
@@ -447,7 +447,8 @@ def check_bundling():
     - the compressed wheel is larger than MAX_WHEEL_BYTES: the slim decode-only
       libavif should keep us under it.
     - (Linux only) the bundled libjpeg isn't libjpeg-turbo.
-    - (Linux only) libtorchcodec_image.so links FFmpeg.
+    - (Linux only) libtorchcodec_image.so or libtorchcodec_pybind_ops.so links
+      FFmpeg.
     """
 
     def _is_shared_lib(name):
@@ -534,29 +535,30 @@ def check_bundling():
         "libpostproc",
     )
 
-    def _assert_linux_image_lib_no_ffmpeg(zf):
-        """Enforce that libtorchcodec_image.so NOT link FFmpeg (no FFmpeg
-        soname in DT_NEEDED; see _FFMPEG_SONAME_PREFIXES).
+    def _assert_linux_lib_no_ffmpeg(zf, lib_name):
+        """Enforce that `lib_name` does NOT link FFmpeg (no FFmpeg soname in
+        DT_NEEDED; see _FFMPEG_SONAME_PREFIXES).
 
-        We built libtorchcodec_image.so separately from the FFmpeg-dependent
-        core{4,5,6,7,8}.so libraries: the whole point is to avoid symbol
-        interposition between the bundled image codec libs
-        (libjpeg/libpng/libwebp) and the user's FFmpeg: FFmpeg may come with its
-        own libjpeg/libpng too!
+        Both libtorchcodec_image.so (the image decoders/encoders) and
+        libtorchcodec_pybind_ops.so (the Python file-like bridge) are built
+        separately from the FFmpeg-dependent core{4,5,6,7,8}.so libraries and
+        must stay FFmpeg-free:
+        - the image lib, to avoid symbol interposition between the bundled image
+          codec libs (libjpeg/libpng/libwebp) and the user's FFmpeg, which may
+          come with its own libjpeg/libpng too;
+        - the pybind lib, so it can be loaded (and image encoding used) even when
+          FFmpeg isn't installed.
 
-        This check ensures that we didn't accidentally link FFmpeg into
-        libtorchcodec_image.so, which would defeat the purpose of building it
-        separately.
+        This check ensures we didn't accidentally link FFmpeg into them, which
+        would defeat the purpose of building them separately.
         """
         from elftools.elf.elffile import ELFFile
 
-        members = [
-            n for n in zf.namelist() if n.rsplit("/", 1)[-1] == "libtorchcodec_image.so"
-        ]
+        members = [n for n in zf.namelist() if n.rsplit("/", 1)[-1] == lib_name]
         if not members:
             raise RuntimeError(
-                "libtorchcodec_image.so not found in wheel; the image decoders "
-                "are expected to live in their own shared library."
+                f"{lib_name} not found in wheel; it's expected to live in its "
+                "own shared library."
             )
         elf = ELFFile(io.BytesIO(zf.read(members[0])))
         dynamic = elf.get_section_by_name(".dynamic")
@@ -564,8 +566,8 @@ def check_bundling():
         ffmpeg_needed = [n for n in needed if n.startswith(_FFMPEG_SONAME_PREFIXES)]
         if ffmpeg_needed:
             raise RuntimeError(
-                "libtorchcodec_image.so must not link FFmpeg, but its DT_NEEDED "
-                "lists: " + " ".join(ffmpeg_needed)
+                f"{lib_name} must not link FFmpeg, but its DT_NEEDED lists: "
+                + " ".join(ffmpeg_needed)
             )
 
     def _assert_linux_libjpeg_is_turbo(zf):
@@ -673,7 +675,8 @@ def check_bundling():
                 )
             if platform.system() == "Linux":
                 _assert_linux_libjpeg_is_turbo(zf)
-                _assert_linux_image_lib_no_ffmpeg(zf)
+                _assert_linux_lib_no_ffmpeg(zf, "libtorchcodec_image.so")
+                _assert_linux_lib_no_ffmpeg(zf, "libtorchcodec_pybind_ops.so")
         print("OK: only libjpeg (and allowed libs) bundled.")
 
 

--- a/src/torchcodec/_core/CMakeLists.txt
+++ b/src/torchcodec/_core/CMakeLists.txt
@@ -185,6 +185,7 @@ endfunction()
 
 read_sources_from_bzl(TORCHCODEC_DECODER_CORE_SOURCES decoder_core_sources)
 read_sources_from_bzl(TORCHCODEC_FFMPEG_COMMON_SOURCES ffmpeg_common_sources)
+read_sources_from_bzl(TORCHCODEC_IO_SOURCES io_sources)
 read_sources_from_bzl(TORCHCODEC_DECODER_CORE_CUDA_SOURCES decoder_core_cuda_sources)
 read_sources_from_bzl(TORCHCODEC_FILE_LIKE_CONTEXT_SOURCES file_like_context_sources)
 read_sources_from_bzl(TORCHCODEC_CUSTOM_OPS_SOURCES custom_ops_sources)
@@ -323,6 +324,7 @@ function(make_torchcodec_libraries
     set(core_sources
         ${TORCHCODEC_DECODER_CORE_SOURCES}
         ${TORCHCODEC_FFMPEG_COMMON_SOURCES}
+        ${TORCHCODEC_IO_SOURCES}
     )
 
     if(ENABLE_CUDA)
@@ -379,56 +381,15 @@ function(make_torchcodec_libraries
         "${custom_ops_dependencies}"
     )
 
-    # 3. Create libtorchcodec_pybind_opsN.so.
-    set(pybind_ops_library_name "libtorchcodec_pybind_ops${ffmpeg_major_version}")
-    set(pybind_ops_sources
-        ${TORCHCODEC_FILE_LIKE_CONTEXT_SOURCES}
-        ${TORCHCODEC_PYBIND_OPS_SOURCES}
-    )
-    set(pybind_ops_dependencies
-       ${core_library_name}
-       pybind11::module # This library dependency makes sure we have the right
-                        # Python libraries included as well as all of the right
-                        # settings so that we can successfully load the shared
-                        # library as a Python module on Mac. If we instead use
-                        # ${Python3_LIBRARIES}, it works on Linux but not on
-                        # Mac.
-    )
-    make_torchcodec_sublibrary(
-        "${pybind_ops_library_name}"
-        MODULE # Note that this not SHARED; otherwise we build the wrong kind
-               # of library on Mac. On Mac, SHARED becomes .dylib and MODULE becomes
-               # a .so. We want pybind11 libraries to become .so. If this is
-               # changed to SHARED, we will be able to succesfully compile a
-               # .dylib, but we will not be able to succesfully import that as
-               # a Python module on Mac.
-        "${pybind_ops_sources}"
-        "${pybind_ops_dependencies}"
-    )
-
-    if(WIN32)
-      # On Windows, we need to set the suffix to .pyd so that Python can
-      # import the shared library as a module. Just setting the MODULE type
-      # isn't enough.
-      set_target_properties(${pybind_ops_library_name} PROPERTIES SUFFIX ".pyd")
-    endif()
-
     # pybind11 limits the visibility of symbols in the shared library to prevent
     # stray initialization of py::objects. The rest of the object code must
     # match. See:
     #   https://pybind11.readthedocs.io/en/stable/faq.html#someclass-declared-with-greater-visibility-than-the-type-of-its-field-someclass-member-wattributes
-    # We have to do this for both pybind_ops and custom_ops because they include
-    # some of the same headers.
     #
     # Note that this is Linux only. It's not necessary on Windows, and on Mac
     # hiding visibility can actually break dyanmic casts across share libraries
     # because the type infos don't get exported.
     if(LINUX)
-        target_compile_options(
-            ${pybind_ops_library_name}
-            PUBLIC
-            "-fvisibility=hidden"
-        )
         target_compile_options(
             ${custom_ops_library_name}
             PUBLIC
@@ -464,33 +425,11 @@ function(make_torchcodec_libraries
         )
     endif()
 
-    # The value we use here must match _PYBIND_OPS_MODULE_NAME in
-    # torchcodec/_internally_replaced_utils.py. If the values do not
-    # match, then we will be unable to import the C++ shared library as a
-    # Python module at runtime.
-    target_compile_definitions(
-        ${pybind_ops_library_name}
-        PRIVATE
-        PYBIND_OPS_MODULE_NAME=core_pybind_ops
-    )
-
-    if(APPLE)
-        # If we don't make sure this flag is set, we run into segfauls at import
-        # time on Mac. See:
-        # https://github.com/pybind/pybind11/issues/3907#issuecomment-1170412764
-        target_link_options(
-            ${pybind_ops_library_name}
-            PUBLIC
-            "LINKER:-undefined,dynamic_lookup"
-        )
-    endif()
-
     # Install all libraries.
     set(
         all_libraries
         ${core_library_name}
         ${custom_ops_library_name}
-        ${pybind_ops_library_name}
     )
 
     # We want the built libraries to end up in [src/]torchcodec so that the
@@ -541,6 +480,7 @@ function(make_torchcodec_image_library)
     set(image_library_sources
         ${TORCHCODEC_IMAGE_SOURCES}
         ${TORCHCODEC_IMAGE_OPS_SOURCES}
+        ${TORCHCODEC_IO_SOURCES}
     )
     if(want_gif)
         list(APPEND image_library_sources ${TORCHCODEC_GIFLIB_SOURCES})
@@ -609,6 +549,68 @@ function(make_torchcodec_image_library)
     else()
         install(
             TARGETS ${image_library_name}
+            LIBRARY DESTINATION torchcodec
+            RUNTIME DESTINATION torchcodec  # For Windows
+        )
+    endif()
+endfunction()
+
+# Create libtorchcodec_pybind_ops, the single pybind11 module providing file-like
+# support (create_file_like_context). It links NO FFmpeg (only pybind11 + torch)
+# and is version-independent, so it's built once and shared by both the
+# FFmpeg-free image encoders and the FFmpeg encoders/decoders. Being FFmpeg-free
+# lets it load eagerly, so importing torchcodec and encoding images works even
+# without FFmpeg installed.
+function(make_torchcodec_pybind_library)
+    set(pybind_ops_library_name "libtorchcodec_pybind_ops")
+    set(pybind_ops_sources
+        ${TORCHCODEC_IO_SOURCES}
+        ${TORCHCODEC_FILE_LIKE_CONTEXT_SOURCES}
+        ${TORCHCODEC_PYBIND_OPS_SOURCES}
+    )
+    make_torchcodec_sublibrary(
+        "${pybind_ops_library_name}"
+        MODULE # Not SHARED; see the note in make_torchcodec_libraries. On Mac,
+               # MODULE becomes .so (importable), SHARED becomes .dylib.
+        "${pybind_ops_sources}"
+        "pybind11::module;${TORCH_LIBRARIES}"
+    )
+
+    if(WIN32)
+        set_target_properties(
+            ${pybind_ops_library_name} PROPERTIES SUFFIX ".pyd")
+    endif()
+
+    # See the matching comment in make_torchcodec_libraries: pybind11 hides
+    # symbols, and the rest of the object code must match.
+    if(LINUX)
+        target_compile_options(
+            ${pybind_ops_library_name} PUBLIC "-fvisibility=hidden")
+    endif()
+
+    # Must match _PYBIND_OPS_MODULE_NAME in _internally_replaced_utils.py.
+    target_compile_definitions(
+        ${pybind_ops_library_name}
+        PRIVATE
+        PYBIND_OPS_MODULE_NAME=core_pybind_ops)
+
+    if(APPLE)
+        target_link_options(
+            ${pybind_ops_library_name}
+            PUBLIC
+            "LINKER:-undefined,dynamic_lookup")
+    endif()
+
+    if(SKBUILD_STATE STREQUAL "editable")
+        get_filename_component(
+            TORCHCODEC_PACKAGE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/.." ABSOLUTE)
+        set_target_properties(${pybind_ops_library_name} PROPERTIES
+            LIBRARY_OUTPUT_DIRECTORY "${TORCHCODEC_PACKAGE_DIR}"
+            RUNTIME_OUTPUT_DIRECTORY "${TORCHCODEC_PACKAGE_DIR}"  # Windows
+        )
+    else()
+        install(
+            TARGETS ${pybind_ops_library_name}
             LIBRARY DESTINATION torchcodec
             RUNTIME DESTINATION torchcodec  # For Windows
         )
@@ -700,6 +702,7 @@ function(make_torchcodec_heic_library)
 endfunction()
 
 make_torchcodec_image_library()
+make_torchcodec_pybind_library()
 make_torchcodec_heic_library()
 
 if(DEFINED ENV{BUILD_AGAINST_ALL_FFMPEG_FROM_S3})

--- a/src/torchcodec/_core/CMakeLists.txt
+++ b/src/torchcodec/_core/CMakeLists.txt
@@ -558,9 +558,7 @@ endfunction()
 # Create libtorchcodec_pybind_ops, the single pybind11 module providing file-like
 # support (create_file_like_context). It links NO FFmpeg (only pybind11 + torch)
 # and is version-independent, so it's built once and shared by both the
-# FFmpeg-free image encoders and the FFmpeg encoders/decoders. Being FFmpeg-free
-# lets it load eagerly, so importing torchcodec and encoding images works even
-# without FFmpeg installed.
+# FFmpeg-free image encoders and the FFmpeg encoders/decoders.
 function(make_torchcodec_pybind_library)
     set(pybind_ops_library_name "libtorchcodec_pybind_ops")
     set(pybind_ops_sources
@@ -570,7 +568,7 @@ function(make_torchcodec_pybind_library)
     )
     make_torchcodec_sublibrary(
         "${pybind_ops_library_name}"
-        MODULE # Not SHARED; see the note in make_torchcodec_libraries. On Mac,
+        MODULE # Not SHARED. On Mac,
                # MODULE becomes .so (importable), SHARED becomes .dylib.
         "${pybind_ops_sources}"
         "pybind11::module;${TORCH_LIBRARIES}"

--- a/src/torchcodec/_core/_ffmpeg_ops.py
+++ b/src/torchcodec/_core/_ffmpeg_ops.py
@@ -16,13 +16,11 @@ import warnings
 import torch
 from torch.library import get_ctx, register_fake
 from torchcodec._core._ffmpeg_op_names import FFMPEG_OP_NAMES
-from torchcodec._internally_replaced_utils import load_core_libraries
+from torchcodec._internally_replaced_utils import load_pybind_ops
 
 __all__ = sorted(FFMPEG_OP_NAMES)
 
-# Only imported when FFmpeg is available, so this always succeeds; it's @cache'd
-# so it's instant. We need _pybind_ops for the file-like helpers below.
-_, _, _pybind_ops = load_core_libraries()
+_pybind_ops = load_pybind_ops()
 
 
 # Note: We use disallow_in_graph because PyTorch does constant propagation of

--- a/src/torchcodec/_core/ops.py
+++ b/src/torchcodec/_core/ops.py
@@ -17,6 +17,7 @@ from torchcodec._internally_replaced_utils import (  # @manual=//pytorch/torchco
     load_core_libraries,
     load_heic_library,
     load_image_library,
+    load_pybind_ops,
 )
 
 expose_ffmpeg_dlls = nullcontext
@@ -32,6 +33,9 @@ if sys.platform == "win32" and hasattr(os, "add_dll_directory"):
 
 
 load_image_library()
+
+_pybind_ops = load_pybind_ops()
+create_file_like_context = _pybind_ops.create_file_like_context
 
 decode_jpeg = torch.ops.torchcodec_ns.decode_jpeg.default
 decode_jpegs_cuda = torch.ops.torchcodec_ns.decode_jpegs_cuda.default
@@ -69,7 +73,7 @@ def get_decode_heic():
 # will raise a proper error when called.
 try:
     with expose_ffmpeg_dlls():
-        ffmpeg_major_version, core_library_path, _ = load_core_libraries()
+        ffmpeg_major_version, core_library_path = load_core_libraries()
     _FFMPEG_AVAILABLE = True
 except Exception:
     _FFMPEG_AVAILABLE = False

--- a/src/torchcodec/_core/sources.bzl
+++ b/src/torchcodec/_core/sources.bzl
@@ -51,11 +51,6 @@ ffmpeg_common_sources = [
     "FFMPEGCommon.cpp",
 ]
 
-# FFmpeg-free on-disk file I/O (FileIO, an IOInterface). Compiled into the
-# FFmpeg core library, the FFmpeg-free image library, and the (also FFmpeg-free)
-# pybind-ops library so the image encoders can write to files without pulling in
-# FFmpeg. IOInterface itself is header-only, and the Python file-like bridge
-# (FileLikeIO) is in file_like_context_sources.
 io_sources = [
     "FileIO.cpp",
 ]
@@ -71,7 +66,6 @@ decoder_core_cuda_sources = [
     "color_conversion.cu",
 ]
 
-# The FFmpeg-free Python file-like bridge. Compiled into the pybind-ops library.
 file_like_context_sources = [
     "FileLikeIO.cpp",
 ]

--- a/src/torchcodec/_core/sources.bzl
+++ b/src/torchcodec/_core/sources.bzl
@@ -27,7 +27,6 @@
 decoder_core_sources = [
     "AVIOContextHolder.cpp",
     "TensorIO.cpp",
-    "FileIO.cpp",
     "FilterGraph.cpp",
     "Frame.cpp",
     "DeviceInterface.cpp",
@@ -52,6 +51,15 @@ ffmpeg_common_sources = [
     "FFMPEGCommon.cpp",
 ]
 
+# FFmpeg-free on-disk file I/O (FileIO, an IOInterface). Compiled into the
+# FFmpeg core library, the FFmpeg-free image library, and the (also FFmpeg-free)
+# pybind-ops library so the image encoders can write to files without pulling in
+# FFmpeg. IOInterface itself is header-only, and the Python file-like bridge
+# (FileLikeIO) is in file_like_context_sources.
+io_sources = [
+    "FileIO.cpp",
+]
+
 # CUDA sources, added to the core library only for CUDA-enabled builds.
 decoder_core_cuda_sources = [
     "CudaDeviceInterface.cpp",
@@ -63,7 +71,7 @@ decoder_core_cuda_sources = [
     "color_conversion.cu",
 ]
 
-# Shared by both the custom-ops and pybind-ops libraries.
+# The FFmpeg-free Python file-like bridge. Compiled into the pybind-ops library.
 file_like_context_sources = [
     "FileLikeIO.cpp",
 ]
@@ -106,7 +114,9 @@ giflib_sources = [
     "giflib/openbsd-reallocarray.c",
 ]
 
-# pybind11 bindings.
+# pybind11 bindings (file-like support). Built into the single, FFmpeg-free
+# libtorchcodec_pybind_ops (alongside io_sources and file_like_context_sources)
+# and used by both the image encoders and the FFmpeg encoders/decoders.
 pybind_ops_sources = [
     "pybind_ops.cpp",
 ]

--- a/src/torchcodec/_internally_replaced_utils.py
+++ b/src/torchcodec/_internally_replaced_utils.py
@@ -121,9 +121,7 @@ def load_core_libraries() -> tuple[int, str]:
     we have succeeded and we stop.
 
     We load them via torch.ops.load_library(), which registers the custom ops
-    with PyTorch's runtime so they're accessible through torch.ops. The pybind
-    file-like module is FFmpeg-independent and loaded separately; see
-    load_pybind_ops().
+    with PyTorch's runtime so they're accessible through torch.ops.
     """
     exceptions = []
     for ffmpeg_major_version in (8, 7, 6, 5, 4):

--- a/src/torchcodec/_internally_replaced_utils.py
+++ b/src/torchcodec/_internally_replaced_utils.py
@@ -72,6 +72,18 @@ def load_image_library() -> None:
 
 
 @functools.cache
+def load_pybind_ops() -> ModuleType:
+    """Load the pybind module providing file-like support (create_file_like_context).
+
+    This module links no FFmpeg, so it's loaded eagerly (regardless of whether
+    FFmpeg is available) and shared by both the image encoders and the FFmpeg
+    encoders/decoders.
+    """
+    library_path = _get_extension_path("libtorchcodec_pybind_ops")
+    return _load_pybind11_module(_PYBIND_OPS_MODULE_NAME, library_path)
+
+
+@functools.cache
 def load_heic_library() -> None:
     """Load the HEIC library (libtorchcodec_heic).
 
@@ -83,7 +95,7 @@ def load_heic_library() -> None:
 
 
 @functools.cache
-def load_core_libraries() -> tuple[int, str, ModuleType]:
+def load_core_libraries() -> tuple[int, str]:
     """Load the FFmpeg-dependent shared libraries, memoizing the result.
 
       This raises if the libraries cannot be loaded, typically because FFmpeg
@@ -105,36 +117,23 @@ def load_core_libraries() -> tuple[int, str, ModuleType]:
 
     We successively try to load the shared libraries for each version of FFmpeg
     that we support, starting with the highest version and working our way down.
-    Once we can load ALL shared libraries for a version of FFmpeg, we have
-    succeeded and we stop.
+    Once we can load the core and custom-ops libraries for a version of FFmpeg,
+    we have succeeded and we stop.
 
-    Note that we use two different methods for loading shared libraries:
-
-      1. torch.ops.load_library(): For PyTorch custom ops and the C++ only
-         libraries the custom ops depend on. Loading libraries through PyTorch
-         registers the custom ops with PyTorch's runtime and the ops can be
-         accessed through torch.ops after loading.
-
-      2. importlib: For pybind11 modules. We load them dynamically, rather
-         than using a plain import statement. A plain import statement only
-         works when the module name and file name match exactly. Our shared
-         libraries do not meet those conditions.
+    We load them via torch.ops.load_library(), which registers the custom ops
+    with PyTorch's runtime so they're accessible through torch.ops. The pybind
+    file-like module is FFmpeg-independent and loaded separately; see
+    load_pybind_ops().
     """
     exceptions = []
     for ffmpeg_major_version in (8, 7, 6, 5, 4):
         core_library_name = f"libtorchcodec_core{ffmpeg_major_version}"
         custom_ops_library_name = f"libtorchcodec_custom_ops{ffmpeg_major_version}"
-        pybind_ops_library_name = f"libtorchcodec_pybind_ops{ffmpeg_major_version}"
         try:
             core_library_path = _get_extension_path(core_library_name)
             torch.ops.load_library(core_library_path)
             torch.ops.load_library(_get_extension_path(custom_ops_library_name))
-
-            pybind_ops_library_path = _get_extension_path(pybind_ops_library_name)
-            pybind_ops = _load_pybind11_module(
-                _PYBIND_OPS_MODULE_NAME, pybind_ops_library_path
-            )
-            return (ffmpeg_major_version, core_library_path, pybind_ops)
+            return (ffmpeg_major_version, core_library_path)
         except Exception:
             # Capture the full traceback for this exception
             exc_traceback = traceback.format_exc()


### PR DESCRIPTION
See https://github.com/meta-pytorch/torchcodec/pull/1568 for context on why we want this. https://github.com/meta-pytorch/torchcodec/pull/1568 separated the code, this is about the build. It separates the actual libraries so the pybind_ops lib is truely FFmpeg free.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>