### PR TITLE
Add native 'to-tensor' output to NVJPEG encoder

### DIFF
--- a/src/torchcodec/_core/EncodeJpegCuda.cpp
+++ b/src/torchcodec/_core/EncodeJpegCuda.cpp
@@ -67,40 +67,10 @@ PerGpuCache<CUDAJpegEncoder>& encoder_cache() {
   return *cache;
 }
 
-} // namespace
-
-void encode_jpeg_cuda(
+torch::stable::Tensor encode_to_tensor(
     const torch::stable::Tensor& image,
     int64_t quality,
-    IOInterface& interface) {
-  STD_TORCH_CHECK(
-      image.device().is_cuda(),
-      "Input tensor must be on a CUDA device, got a tensor on ",
-      device_type_name(image.device().type()),
-      ".");
-
-  torch::stable::Device device = image.device();
-  int device_index = get_device_index(device);
-  StableDeviceGuard device_guard(device_index);
-
-  cudaStream_t current_stream = get_current_cuda_stream(device_index);
-
-  PerGpuCache<CUDAJpegEncoder>& cache = encoder_cache();
-  std::unique_ptr<CUDAJpegEncoder> encoder = cache.get(device);
-  if (encoder == nullptr) {
-    encoder = std::make_unique<CUDAJpegEncoder>(device);
-  }
-
-  std::vector<uint8_t> encoded =
-      encoder->encode_to_host_vector(image, quality, current_stream);
-  cache.add_if_cache_has_capacity(device, std::move(encoder));
-
-  interface.write(encoded.data(), static_cast<int>(encoded.size()));
-}
-
-torch::stable::Tensor encode_jpeg_to_tensor_cuda(
-    const torch::stable::Tensor& image,
-    int64_t quality) {
+    const torch::stable::Device& output_device) {
   STD_TORCH_CHECK(
       image.device().is_cuda(),
       "Input tensor must be on a CUDA device, got a tensor on ",
@@ -120,10 +90,35 @@ torch::stable::Tensor encode_jpeg_to_tensor_cuda(
   }
 
   torch::stable::Tensor output =
-      encoder->encode_to_device_tensor(image, quality, current_stream);
+      encoder->encode_to_tensor(image, quality, current_stream, output_device);
   cache.add_if_cache_has_capacity(device, std::move(encoder));
 
   return output;
+}
+
+} // namespace
+
+// This one is for to_file and to_file_like while encode_jpeg_to_tensor_cuda is
+// a dedicated path to encode to tensor. We have a dedicated path for encoding
+// to tensor, instead of relying on the generic BytesIO().getbuffer() solution,
+// because here the output tensor is on CUDA! And going through BytesIO() would
+// require to send it to the CPU.
+// There are good reasons one would want to keep the encoded data on CUDA, e.g.
+// to use cuFile.
+void encode_jpeg_cuda(
+    const torch::stable::Tensor& image,
+    int64_t quality,
+    IOInterface& interface) {
+  torch::stable::Tensor encoded =
+      encode_to_tensor(image, quality, torch::stable::Device(kStableCPU));
+  interface.write(
+      encoded.const_data_ptr<uint8_t>(), static_cast<int>(encoded.numel()));
+}
+
+torch::stable::Tensor encode_jpeg_to_tensor_cuda(
+    const torch::stable::Tensor& image,
+    int64_t quality) {
+  return encode_to_tensor(image, quality, image.device());
 }
 
 CUDAJpegEncoder::CUDAJpegEncoder(const torch::stable::Device& target_device)
@@ -161,10 +156,11 @@ CUDAJpegEncoder::~CUDAJpegEncoder() {
   nvjpegDestroy(nvjpeg_handle_);
 }
 
-size_t CUDAJpegEncoder::encode_and_get_length(
+torch::stable::Tensor CUDAJpegEncoder::encode_to_tensor(
     const torch::stable::Tensor& image,
     int64_t quality,
-    cudaStream_t stream) {
+    cudaStream_t stream,
+    const torch::stable::Device& output_device) {
   STD_TORCH_CHECK(
       image.scalar_type() == kStableUInt8,
       "Input tensor dtype should be uint8");
@@ -223,8 +219,8 @@ size_t CUDAJpegEncoder::encode_and_get_length(
   STD_TORCH_CHECK(
       status == NVJPEG_STATUS_SUCCESS, "Failed to encode image: ", status);
 
-  // Query the encoded bitstream length (with a null buffer); the bitstream
-  // stays in nvjpeg_enc_state_ for the caller to retrieve.
+  // Query the encoded bitstream length (with a null buffer), then allocate the
+  // output on `output_device` and retrieve into it.
   size_t length = 0;
   status = nvjpegEncodeRetrieveBitstream(
       nvjpeg_handle_, nvjpeg_enc_state_, nullptr, &length, stream);
@@ -238,53 +234,24 @@ size_t CUDAJpegEncoder::encode_and_get_length(
       cuda_status == cudaSuccess,
       "Failed to synchronize CUDA stream: ",
       cuda_status);
-  return length;
-}
 
-std::vector<uint8_t> CUDAJpegEncoder::encode_to_host_vector(
-    const torch::stable::Tensor& image,
-    int64_t quality,
-    cudaStream_t stream) {
-  size_t length = encode_and_get_length(image, quality, stream);
-
-  std::vector<uint8_t> output(length);
-  nvjpegStatus_t status = nvjpegEncodeRetrieveBitstream(
-      nvjpeg_handle_, nvjpeg_enc_state_, output.data(), &length, stream);
-  STD_TORCH_CHECK(
-      status == NVJPEG_STATUS_SUCCESS,
-      "Failed to retrieve encoded bitstream: ",
-      status);
-
-  // Host-synchronize before returning: the encoder (and its internal nvJPEG
-  // buffers) goes back to the pool and may be reused immediately by the next
-  // call, so the copy into `output` must complete first.
-  cudaError_t cuda_status = cudaStreamSynchronize(stream);
-  STD_TORCH_CHECK(
-      cuda_status == cudaSuccess,
-      "Failed to synchronize CUDA stream: ",
-      cuda_status);
-
-  return output;
-}
-
-torch::stable::Tensor CUDAJpegEncoder::encode_to_device_tensor(
-    const torch::stable::Tensor& image,
-    int64_t quality,
-    cudaStream_t stream) {
-  size_t length = encode_and_get_length(image, quality, stream);
-
-  // Retrieve straight into a device tensor (no device-to-host copy).
   auto output = torch::stable::empty(
       {static_cast<int64_t>(length)},
       kStableUInt8,
       std::nullopt,
-      target_device_);
-  nvjpegStatus_t status = nvjpegEncodeRetrieveBitstreamDevice(
-      nvjpeg_handle_,
-      nvjpeg_enc_state_,
-      output.mutable_data_ptr<uint8_t>(),
-      &length,
-      stream);
+      output_device);
+  status = output_device.is_cuda() ? nvjpegEncodeRetrieveBitstreamDevice(
+                                         nvjpeg_handle_,
+                                         nvjpeg_enc_state_,
+                                         output.mutable_data_ptr<uint8_t>(),
+                                         &length,
+                                         stream)
+                                   : nvjpegEncodeRetrieveBitstream(
+                                         nvjpeg_handle_,
+                                         nvjpeg_enc_state_,
+                                         output.mutable_data_ptr<uint8_t>(),
+                                         &length,
+                                         stream);
   STD_TORCH_CHECK(
       status == NVJPEG_STATUS_SUCCESS,
       "Failed to retrieve encoded bitstream: ",
@@ -292,7 +259,7 @@ torch::stable::Tensor CUDAJpegEncoder::encode_to_device_tensor(
 
   // Sync before returning the encoder to the pool: its internal nvJPEG buffers
   // may be reused by the next call, so the retrieve into `output` must finish.
-  cudaError_t cuda_status = cudaStreamSynchronize(stream);
+  cuda_status = cudaStreamSynchronize(stream);
   STD_TORCH_CHECK(
       cuda_status == cudaSuccess,
       "Failed to synchronize CUDA stream: ",

--- a/src/torchcodec/_core/EncodeJpegCuda.cpp
+++ b/src/torchcodec/_core/EncodeJpegCuda.cpp
@@ -275,7 +275,10 @@ torch::stable::Tensor CUDAJpegEncoder::encode_to_device_tensor(
 
   // Retrieve straight into a device tensor (no device-to-host copy).
   auto output = torch::stable::empty(
-      {static_cast<int64_t>(length)}, kStableUInt8, std::nullopt, target_device_);
+      {static_cast<int64_t>(length)},
+      kStableUInt8,
+      std::nullopt,
+      target_device_);
   nvjpegStatus_t status = nvjpegEncodeRetrieveBitstreamDevice(
       nvjpeg_handle_,
       nvjpeg_enc_state_,

--- a/src/torchcodec/_core/EncodeJpegCuda.cpp
+++ b/src/torchcodec/_core/EncodeJpegCuda.cpp
@@ -15,10 +15,8 @@
 
 namespace facebook::torchcodec {
 
-void encode_jpeg_cuda(
-    [[maybe_unused]] const torch::stable::Tensor& image,
-    [[maybe_unused]] int64_t quality,
-    [[maybe_unused]] IOInterface& interface) {
+namespace {
+[[noreturn]] void raise_no_nvjpeg() {
   STD_TORCH_CHECK(
       false,
       "encode_jpeg: torchcodec was not compiled with nvJPEG support, so JPEG "
@@ -26,6 +24,20 @@ void encode_jpeg_cuda(
       "ENABLE_CUDA=1 in an environment where the CUDA toolkit (which provides "
       "nvJPEG) is available. If you see this error in a prebuilt wheel, please "
       "report it to the TorchCodec repo.");
+}
+} // namespace
+
+void encode_jpeg_cuda(
+    [[maybe_unused]] const torch::stable::Tensor& image,
+    [[maybe_unused]] int64_t quality,
+    [[maybe_unused]] IOInterface& interface) {
+  raise_no_nvjpeg();
+}
+
+torch::stable::Tensor encode_jpeg_to_tensor_cuda(
+    [[maybe_unused]] const torch::stable::Tensor& image,
+    [[maybe_unused]] int64_t quality) {
+  raise_no_nvjpeg();
 }
 
 } // namespace facebook::torchcodec
@@ -80,10 +92,38 @@ void encode_jpeg_cuda(
   }
 
   std::vector<uint8_t> encoded =
-      encoder->encode_image(image, quality, current_stream);
+      encoder->encode_to_host_vector(image, quality, current_stream);
   cache.add_if_cache_has_capacity(device, std::move(encoder));
 
   interface.write(encoded.data(), static_cast<int>(encoded.size()));
+}
+
+torch::stable::Tensor encode_jpeg_to_tensor_cuda(
+    const torch::stable::Tensor& image,
+    int64_t quality) {
+  STD_TORCH_CHECK(
+      image.device().is_cuda(),
+      "Input tensor must be on a CUDA device, got a tensor on ",
+      device_type_name(image.device().type()),
+      ".");
+
+  torch::stable::Device device = image.device();
+  int device_index = get_device_index(device);
+  StableDeviceGuard device_guard(device_index);
+
+  cudaStream_t current_stream = get_current_cuda_stream(device_index);
+
+  PerGpuCache<CUDAJpegEncoder>& cache = encoder_cache();
+  std::unique_ptr<CUDAJpegEncoder> encoder = cache.get(device);
+  if (encoder == nullptr) {
+    encoder = std::make_unique<CUDAJpegEncoder>(device);
+  }
+
+  torch::stable::Tensor output =
+      encoder->encode_to_device_tensor(image, quality, current_stream);
+  cache.add_if_cache_has_capacity(device, std::move(encoder));
+
+  return output;
 }
 
 CUDAJpegEncoder::CUDAJpegEncoder(const torch::stable::Device& target_device)
@@ -121,7 +161,7 @@ CUDAJpegEncoder::~CUDAJpegEncoder() {
   nvjpegDestroy(nvjpeg_handle_);
 }
 
-std::vector<uint8_t> CUDAJpegEncoder::encode_image(
+size_t CUDAJpegEncoder::encode_and_get_length(
     const torch::stable::Tensor& image,
     int64_t quality,
     cudaStream_t stream) {
@@ -183,8 +223,8 @@ std::vector<uint8_t> CUDAJpegEncoder::encode_image(
   STD_TORCH_CHECK(
       status == NVJPEG_STATUS_SUCCESS, "Failed to encode image: ", status);
 
-  // Retrieve the encoded bitstream directly into host memory. First query the
-  // length (with a null buffer), then allocate the output and fill it.
+  // Query the encoded bitstream length (with a null buffer); the bitstream
+  // stays in nvjpeg_enc_state_ for the caller to retrieve.
   size_t length = 0;
   status = nvjpegEncodeRetrieveBitstream(
       nvjpeg_handle_, nvjpeg_enc_state_, nullptr, &length, stream);
@@ -198,9 +238,17 @@ std::vector<uint8_t> CUDAJpegEncoder::encode_image(
       cuda_status == cudaSuccess,
       "Failed to synchronize CUDA stream: ",
       cuda_status);
+  return length;
+}
+
+std::vector<uint8_t> CUDAJpegEncoder::encode_to_host_vector(
+    const torch::stable::Tensor& image,
+    int64_t quality,
+    cudaStream_t stream) {
+  size_t length = encode_and_get_length(image, quality, stream);
 
   std::vector<uint8_t> output(length);
-  status = nvjpegEncodeRetrieveBitstream(
+  nvjpegStatus_t status = nvjpegEncodeRetrieveBitstream(
       nvjpeg_handle_, nvjpeg_enc_state_, output.data(), &length, stream);
   STD_TORCH_CHECK(
       status == NVJPEG_STATUS_SUCCESS,
@@ -210,7 +258,38 @@ std::vector<uint8_t> CUDAJpegEncoder::encode_image(
   // Host-synchronize before returning: the encoder (and its internal nvJPEG
   // buffers) goes back to the pool and may be reused immediately by the next
   // call, so the copy into `output` must complete first.
-  cuda_status = cudaStreamSynchronize(stream);
+  cudaError_t cuda_status = cudaStreamSynchronize(stream);
+  STD_TORCH_CHECK(
+      cuda_status == cudaSuccess,
+      "Failed to synchronize CUDA stream: ",
+      cuda_status);
+
+  return output;
+}
+
+torch::stable::Tensor CUDAJpegEncoder::encode_to_device_tensor(
+    const torch::stable::Tensor& image,
+    int64_t quality,
+    cudaStream_t stream) {
+  size_t length = encode_and_get_length(image, quality, stream);
+
+  // Retrieve straight into a device tensor (no device-to-host copy).
+  auto output = torch::stable::empty(
+      {static_cast<int64_t>(length)}, kStableUInt8, std::nullopt, target_device_);
+  nvjpegStatus_t status = nvjpegEncodeRetrieveBitstreamDevice(
+      nvjpeg_handle_,
+      nvjpeg_enc_state_,
+      output.mutable_data_ptr<uint8_t>(),
+      &length,
+      stream);
+  STD_TORCH_CHECK(
+      status == NVJPEG_STATUS_SUCCESS,
+      "Failed to retrieve encoded bitstream: ",
+      status);
+
+  // Sync before returning the encoder to the pool: its internal nvJPEG buffers
+  // may be reused by the next call, so the retrieve into `output` must finish.
+  cudaError_t cuda_status = cudaStreamSynchronize(stream);
   STD_TORCH_CHECK(
       cuda_status == cudaSuccess,
       "Failed to synchronize CUDA stream: ",

--- a/src/torchcodec/_core/EncodeJpegCuda.h
+++ b/src/torchcodec/_core/EncodeJpegCuda.h
@@ -45,11 +45,6 @@ class CUDAJpegEncoder {
   ~CUDAJpegEncoder();
 
   // Encodes `image` and returns the JPEG bitstream as host (CPU) bytes.
-<<<<<<< Updated upstream
-  std::vector<uint8_t> encode_image(
-||||||| Stash base
-  std::vector<uint8_t> encode_image(
-=======
   std::vector<uint8_t> encode_to_host_vector(
       const torch::stable::Tensor& image,
       int64_t quality,
@@ -58,14 +53,13 @@ class CUDAJpegEncoder {
   // Encodes `image` and returns the JPEG bitstream as a 1-D uint8 tensor on the
   // encoder's CUDA device (no device-to-host copy).
   torch::stable::Tensor encode_to_device_tensor(
->>>>>>> Stashed changes
       const torch::stable::Tensor& image,
       int64_t quality,
       cudaStream_t stream);
 
  private:
-  // Runs nvjpegEncodeImage for `image` and returns the encoded bitstream length,
-  // leaving the bitstream in nvjpeg_enc_state_ for retrieval.
+  // Runs nvjpegEncodeImage for `image` and returns the encoded bitstream
+  // length, leaving the bitstream in nvjpeg_enc_state_ for retrieval.
   size_t encode_and_get_length(
       const torch::stable::Tensor& image,
       int64_t quality,

--- a/src/torchcodec/_core/EncodeJpegCuda.h
+++ b/src/torchcodec/_core/EncodeJpegCuda.h
@@ -10,7 +10,6 @@
 #include <torch/csrc/stable/tensor.h>
 
 #include <cstdint>
-#include <vector>
 
 #include "IOInterface.h"
 #include "StableABICompat.h"
@@ -22,17 +21,11 @@
 
 namespace facebook::torchcodec {
 
-// Encodes a single CHW uint8 CUDA image tensor into a JPEG, writing the encoded
-// bytes to `interface` (a file or file-like), mirroring the CPU encode_jpeg.
 FORCE_PUBLIC_VISIBILITY void encode_jpeg_cuda(
     const torch::stable::Tensor& image,
     int64_t quality,
     IOInterface& interface);
 
-// Encodes a single CHW uint8 CUDA image tensor into a JPEG and returns the
-// bitstream as a 1-D uint8 tensor on the *same CUDA device* as the input. This
-// is zero-copy (the bytes never leave the GPU); callers wanting host bytes can
-// .cpu() the result.
 FORCE_PUBLIC_VISIBILITY torch::stable::Tensor encode_jpeg_to_tensor_cuda(
     const torch::stable::Tensor& image,
     int64_t quality);
@@ -44,27 +37,13 @@ class CUDAJpegEncoder {
   explicit CUDAJpegEncoder(const torch::stable::Device& target_device);
   ~CUDAJpegEncoder();
 
-  // Encodes `image` and returns the JPEG bitstream as host (CPU) bytes.
-  std::vector<uint8_t> encode_to_host_vector(
+  torch::stable::Tensor encode_to_tensor(
       const torch::stable::Tensor& image,
       int64_t quality,
-      cudaStream_t stream);
-
-  // Encodes `image` and returns the JPEG bitstream as a 1-D uint8 tensor on the
-  // encoder's CUDA device (no device-to-host copy).
-  torch::stable::Tensor encode_to_device_tensor(
-      const torch::stable::Tensor& image,
-      int64_t quality,
-      cudaStream_t stream);
+      cudaStream_t stream,
+      const torch::stable::Device& output_device);
 
  private:
-  // Runs nvjpegEncodeImage for `image` and returns the encoded bitstream
-  // length, leaving the bitstream in nvjpeg_enc_state_ for retrieval.
-  size_t encode_and_get_length(
-      const torch::stable::Tensor& image,
-      int64_t quality,
-      cudaStream_t stream);
-
   const torch::stable::Device target_device_;
 
   nvjpegHandle_t nvjpeg_handle_;

--- a/src/torchcodec/_core/EncodeJpegCuda.h
+++ b/src/torchcodec/_core/EncodeJpegCuda.h
@@ -29,6 +29,14 @@ FORCE_PUBLIC_VISIBILITY void encode_jpeg_cuda(
     int64_t quality,
     IOInterface& interface);
 
+// Encodes a single CHW uint8 CUDA image tensor into a JPEG and returns the
+// bitstream as a 1-D uint8 tensor on the *same CUDA device* as the input. This
+// is zero-copy (the bytes never leave the GPU); callers wanting host bytes can
+// .cpu() the result.
+FORCE_PUBLIC_VISIBILITY torch::stable::Tensor encode_jpeg_to_tensor_cuda(
+    const torch::stable::Tensor& image,
+    int64_t quality);
+
 #if TORCHCODEC_ENABLE_NVJPEG
 
 class CUDAJpegEncoder {
@@ -37,12 +45,32 @@ class CUDAJpegEncoder {
   ~CUDAJpegEncoder();
 
   // Encodes `image` and returns the JPEG bitstream as host (CPU) bytes.
+<<<<<<< Updated upstream
   std::vector<uint8_t> encode_image(
+||||||| Stash base
+  std::vector<uint8_t> encode_image(
+=======
+  std::vector<uint8_t> encode_to_host_vector(
+      const torch::stable::Tensor& image,
+      int64_t quality,
+      cudaStream_t stream);
+
+  // Encodes `image` and returns the JPEG bitstream as a 1-D uint8 tensor on the
+  // encoder's CUDA device (no device-to-host copy).
+  torch::stable::Tensor encode_to_device_tensor(
+>>>>>>> Stashed changes
       const torch::stable::Tensor& image,
       int64_t quality,
       cudaStream_t stream);
 
  private:
+  // Runs nvjpegEncodeImage for `image` and returns the encoded bitstream length,
+  // leaving the bitstream in nvjpeg_enc_state_ for retrieval.
+  size_t encode_and_get_length(
+      const torch::stable::Tensor& image,
+      int64_t quality,
+      cudaStream_t stream);
+
   const torch::stable::Device target_device_;
 
   nvjpegHandle_t nvjpeg_handle_;

--- a/src/torchcodec/_core/image_custom_ops.cpp
+++ b/src/torchcodec/_core/image_custom_ops.cpp
@@ -103,6 +103,7 @@ STABLE_TORCH_LIBRARY_FRAGMENT(torchcodec_ns, m) {
   m.def("encode_jpeg_to_file(Tensor img, str filename, int quality) -> ()");
   m.def(
       "encode_jpeg_to_file_like(Tensor img, int file_like_context, int quality) -> ()");
+  m.def("encode_jpeg_to_tensor_cuda(Tensor img, int quality) -> Tensor");
 }
 
 STABLE_TORCH_LIBRARY_IMPL(torchcodec_ns, CPU, m) {
@@ -122,6 +123,7 @@ STABLE_TORCH_LIBRARY_IMPL(torchcodec_ns, CompositeExplicitAutograd, m) {
   m.impl("decode_jpegs_cuda", TORCH_BOX(&decode_jpegs_cuda));
   m.impl("encode_jpeg_to_file", TORCH_BOX(&encode_jpeg_to_file));
   m.impl("encode_jpeg_to_file_like", TORCH_BOX(&encode_jpeg_to_file_like));
+  m.impl("encode_jpeg_to_tensor_cuda", TORCH_BOX(&encode_jpeg_to_tensor_cuda));
 }
 
 } // namespace facebook::torchcodec

--- a/src/torchcodec/_core/ops.py
+++ b/src/torchcodec/_core/ops.py
@@ -47,6 +47,7 @@ encode_png_to_file = torch.ops.torchcodec_ns.encode_png_to_file.default
 encode_png_to_file_like = torch.ops.torchcodec_ns.encode_png_to_file_like.default
 encode_jpeg_to_file = torch.ops.torchcodec_ns.encode_jpeg_to_file.default
 encode_jpeg_to_file_like = torch.ops.torchcodec_ns.encode_jpeg_to_file_like.default
+encode_jpeg_to_tensor_cuda = torch.ops.torchcodec_ns.encode_jpeg_to_tensor_cuda.default
 
 
 def get_decode_heic():

--- a/src/torchcodec/encoders/_image_encoders.py
+++ b/src/torchcodec/encoders/_image_encoders.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import io
 from pathlib import Path
 
 import torch
@@ -12,6 +13,7 @@ from torchcodec._core.ops import (
     create_file_like_context,
     encode_jpeg_to_file as _encode_jpeg_to_file,
     encode_jpeg_to_file_like as _encode_jpeg_to_file_like,
+    encode_jpeg_to_tensor_cuda as _encode_jpeg_to_tensor_cuda,
     encode_png_to_file as _encode_png_to_file,
     encode_png_to_file_like as _encode_png_to_file_like,
 )
@@ -54,21 +56,30 @@ def encode_png(
 
 def encode_jpeg(
     input: torch.Tensor,
-    dest: str | Path,
+    dest: str | Path | None = None,
     quality: int = 75,
-) -> None:
-    """Encode a CHW uint8 image tensor into a JPEG file.
+) -> torch.Tensor | None:
+    """Encode a CHW uint8 image tensor into a JPEG.
 
     Args:
         input (``torch.Tensor``): The image to encode, a 3-dimensional uint8
             tensor in CHW layout with 1 (grayscale) or 3 (RGB) channels.
-        dest (str, ``pathlib.Path`` or file-like object): The destination to
-            write the encoded JPEG to. Either a path to the output file, or a
-            file-like object that supports ``write(data: bytes) -> int`` and
+        dest (str, ``pathlib.Path``, file-like object, or ``None``): The
+            destination to write the encoded JPEG to. Either a path to the output
+            file, or a file-like object that supports
+            ``write(data: bytes) -> int`` and
             ``seek(offset: int, whence: int = 0) -> int``, such as
-            ``io.BytesIO()`` or an open file in binary write mode.
+            ``io.BytesIO()`` or an open file in binary write mode. If ``None``
+            (the default), the encoded bytes are returned as a 1-D uint8 tensor
+            instead of being written anywhere.
         quality (int): Quality of the resulting JPEG, between 1 and 100. Higher
             means better quality and larger file size. Default: 75.
+
+    Returns:
+        ``None`` if ``dest`` is a path or file-like object. If ``dest`` is
+        ``None``, a 1-D uint8 tensor of the encoded bytes, on the same device as
+        ``input`` (a CUDA input yields a CUDA tensor; call ``.cpu()`` for host
+        bytes).
 
     If ``input`` is on a CUDA device, encoding is performed on the GPU with
     nvJPEG. Only 3-channel RGB tensors are supported on CUDA (grayscale must be
@@ -76,6 +87,18 @@ def encode_jpeg(
     """
     if quality < 1 or quality > 100:
         raise ValueError("Image quality should be a positive number between 1 and 100")
+
+    if dest is None:
+        if input.is_cuda:
+            # Zero-copy: the encoded bytes are retrieved straight into a CUDA
+            # tensor and never leave the GPU.
+            return _encode_jpeg_to_tensor_cuda(input, quality)
+        # On CPU, encode into a BytesIO and wrap its buffer without an extra copy
+        # (getbuffer() doesn't copy, unlike getvalue()).
+        buf = io.BytesIO()
+        _encode_jpeg_to_file_like(input, create_file_like_context(buf, True), quality)
+        return torch.frombuffer(buf.getbuffer(), dtype=torch.uint8)
+
     _encode_to_dest(
         input,
         dest,
@@ -83,3 +106,4 @@ def encode_jpeg(
         to_file=_encode_jpeg_to_file,
         to_file_like=_encode_jpeg_to_file_like,
     )
+    return None

--- a/src/torchcodec/encoders/_image_encoders.py
+++ b/src/torchcodec/encoders/_image_encoders.py
@@ -89,6 +89,10 @@ def encode_jpeg(
         raise ValueError("Image quality should be a positive number between 1 and 100")
 
     if dest is None:
+        # TODO_IMAGE since we're going to expose to-tensor support, we should
+        # probably see if we can benefit for custom implementations like this
+        # one with nvjpeg, but for the other 'backends' (png CPU and jpeg CPU)
+        # vs the currently-recommended way to go through BytesIO + getbuffer().
         if input.is_cuda:
             # Zero-copy: the encoded bytes are retrieved straight into a CUDA
             # tensor and never leave the GPU.

--- a/test/test_encoders.py
+++ b/test/test_encoders.py
@@ -2570,6 +2570,33 @@ class TestImageEncoders:
         assert high > low
 
     @needs_jpeg
+    @pytest.mark.parametrize("device", _cpu_and_cuda)
+    def test_dest_none_returns_tensor(self, device):
+        # dest=None returns the encoded bytes as a 1-D uint8 tensor on the same
+        # device as the input (CUDA in -> CUDA out, zero-copy).
+        img = decode_jpeg(GRADIENT_JPEG.path, mode="RGB").to(device)
+
+        encoded = encode_jpeg(img, quality=90)
+        assert isinstance(encoded, torch.Tensor)
+        assert encoded.dtype == torch.uint8
+        assert encoded.ndim == 1
+        assert encoded.device.type == device
+
+        pil_decoded = Image.open(io.BytesIO(encoded.cpu().numpy().tobytes()))
+        assert pil_decoded.format == "JPEG"
+        assert decode_jpeg(encoded.cpu(), mode="RGB").shape == img.shape
+
+    @needs_jpeg
+    @pytest.mark.parametrize("device", _cpu_and_cuda)
+    def test_dest_none_matches_file_like(self, device):
+        # The dest=None bytes must be identical to the file-like path's bytes.
+        img = decode_jpeg(GRADIENT_JPEG.path, mode="RGB").to(device)
+
+        from_none = encode_jpeg(img, quality=90).cpu()
+        from_file_like = self._encode_to_bytes(encode_jpeg, img, quality=90)
+        torch.testing.assert_close(from_none, from_file_like, rtol=0, atol=0)
+
+    @needs_jpeg
     @pytest.mark.parametrize("quality", (-1, 101))
     def test_bad_quality_jpeg(self, quality):
         with pytest.raises(


### PR DESCRIPTION
This is much faster than relying on `BytesIO + getbuffer()` and importantly, this is the only way to actually get the encoded bytes while they are *still* on CUDA memory. All the APIs in main send it back to the CPU(), but users may want to use cuFile or that kind of stuff.


We still need to figure out how to expose this publicly.