### PR TITLE
Add to-tensor output to encode_png and encode_jpeg

### DIFF
--- a/src/torchcodec/encoders/_image_encoders.py
+++ b/src/torchcodec/encoders/_image_encoders.py
@@ -27,31 +27,55 @@ def _encode_to_dest(input, dest, param, *, to_file, to_file_like) -> None:
         to_file_like(input, create_file_like_context(dest, True), param)
 
 
+def _encode_to_tensor_through_bytesio(input, param, to_file_like) -> torch.Tensor:
+    # Encode into an in-memory BytesIO and wrap its buffer as a 1-D uint8 tensor.
+    # getbuffer() (unlike getvalue()) exposes the buffer without copying. We
+    # could have native C++ implementation for that in each encoder, but it's
+    # not always worth it (based on benchmarks). Currently, the only encoder
+    # that really needs a dedicated C++ path is JPEG on CUDA.
+    buf = io.BytesIO()
+    to_file_like(input, create_file_like_context(buf, True), param)
+    return torch.frombuffer(buf.getbuffer(), dtype=torch.uint8)
+
+
 def encode_png(
     input: torch.Tensor,
-    dest: str | Path,
+    dest: str | Path | None = None,
     compression_level: int = 6,
-) -> None:
-    """Encode a CHW uint8 image tensor into a PNG file.
+) -> torch.Tensor | None:
+    """Encode a CHW uint8 image tensor into a PNG.
 
     Args:
         input (``torch.Tensor``): The image to encode, a 3-dimensional uint8
             tensor in CHW layout with 1 (grayscale) or 3 (RGB) channels.
-        dest (str, ``pathlib.Path`` or file-like object): The destination to
-            write the encoded PNG to. Either a path to the output file, or a
-            file-like object that supports ``write(data: bytes) -> int`` and
+        dest (str, ``pathlib.Path``, file-like object, or ``None``): The
+            destination to write the encoded PNG to. Either a path to the output
+            file, or a file-like object that supports
+            ``write(data: bytes) -> int`` and
             ``seek(offset: int, whence: int = 0) -> int``, such as
-            ``io.BytesIO()`` or an open file in binary write mode.
+            ``io.BytesIO()`` or an open file in binary write mode. If ``None``
+            (the default), the encoded bytes are returned as a 1-D uint8 tensor
+            instead of being written anywhere.
         compression_level (int): zlib compression level between 0 (no
             compression, fastest) and 9 (max compression, slowest). Default: 6.
+
+    Returns:
+        ``None`` if ``dest`` is a path or file-like object, otherwise a 1-D uint8
+        tensor of the encoded bytes.
     """
-    _encode_to_dest(
-        input,
-        dest,
-        compression_level,
-        to_file=_encode_png_to_file,
-        to_file_like=_encode_png_to_file_like,
-    )
+    if dest is None:
+        return _encode_to_tensor_through_bytesio(
+            input, compression_level, _encode_png_to_file_like
+        )
+    else:
+        _encode_to_dest(
+            input,
+            dest,
+            compression_level,
+            to_file=_encode_png_to_file,
+            to_file_like=_encode_png_to_file_like,
+        )
+        return None
 
 
 def encode_jpeg(
@@ -89,25 +113,18 @@ def encode_jpeg(
         raise ValueError("Image quality should be a positive number between 1 and 100")
 
     if dest is None:
-        # TODO_IMAGE since we're going to expose to-tensor support, we should
-        # probably see if we can benefit for custom implementations like this
-        # one with nvjpeg, but for the other 'backends' (png CPU and jpeg CPU)
-        # vs the currently-recommended way to go through BytesIO + getbuffer().
         if input.is_cuda:
-            # Zero-copy: the encoded bytes are retrieved straight into a CUDA
-            # tensor and never leave the GPU.
             return _encode_jpeg_to_tensor_cuda(input, quality)
-        # On CPU, encode into a BytesIO and wrap its buffer without an extra copy
-        # (getbuffer() doesn't copy, unlike getvalue()).
-        buf = io.BytesIO()
-        _encode_jpeg_to_file_like(input, create_file_like_context(buf, True), quality)
-        return torch.frombuffer(buf.getbuffer(), dtype=torch.uint8)
-
-    _encode_to_dest(
-        input,
-        dest,
-        quality,
-        to_file=_encode_jpeg_to_file,
-        to_file_like=_encode_jpeg_to_file_like,
-    )
-    return None
+        else:
+            return _encode_to_tensor_through_bytesio(
+                input, quality, _encode_jpeg_to_file_like
+            )
+    else:
+        _encode_to_dest(
+            input,
+            dest,
+            quality,
+            to_file=_encode_jpeg_to_file,
+            to_file_like=_encode_jpeg_to_file_like,
+        )
+        return None

--- a/test/test_encoders.py
+++ b/test/test_encoders.py
@@ -2372,7 +2372,7 @@ class TestEncoder:
 _cpu_and_cuda = ("cpu", pytest.param("cuda", marks=pytest.mark.needs_cuda))
 
 
-def _encode_jpeg_cuda(input, dest, **kwargs):
+def _encode_jpeg_cuda(input, dest=None, **kwargs):
     # Encode with the input moved to the GPU, so encode_jpeg dispatches to
     # nvJPEG. Lets the shared encoder tests below exercise the CUDA path through
     # the exact same public API as the CPU encoders.
@@ -2405,9 +2405,9 @@ class TestImageEncoders:
     # ===== destination handling, all codecs =====
 
     @pytest.mark.parametrize("encode", _encoders)
-    def test_dest_path_matches_file_like(self, encode, tmp_path):
-        # Encoding to a file path and to a file-like object must produce
-        # identical bytes (encoding is deterministic for a given input).
+    def test_dest_variants_match(self, encode, tmp_path):
+        # All three destinations must produce identical bytes: a file path, a
+        # file-like object, and a tensor
         source = self._decode(GRADIENT_PNG, "RGB")
 
         path = tmp_path / "out"
@@ -2415,7 +2415,10 @@ class TestImageEncoders:
         from_path = torch.frombuffer(path.read_bytes(), dtype=torch.uint8)
 
         from_file_like = self._encode_to_bytes(encode, source)
+        from_tensor = encode(source).cpu()  # dest=None
+
         torch.testing.assert_close(from_path, from_file_like, rtol=0, atol=0)
+        torch.testing.assert_close(from_path, from_tensor, rtol=0, atol=0)
 
     @pytest.mark.parametrize("encode", _encoders)
     def test_dest_str_and_pathlib(self, encode, tmp_path):
@@ -2503,6 +2506,23 @@ class TestImageEncoders:
         with pytest.raises(RuntimeError, match="between 0 and 9"):
             encode_png(source, io.BytesIO(), compression_level=compression_level)
 
+    @needs_png
+    def test_dest_none_returns_tensor_png(self):
+        # dest=None returns the encoded bytes as a 1-D uint8 CPU tensor.
+        source = self._decode(GRADIENT_PNG, "RGB")
+
+        encoded = encode_png(source)
+        assert isinstance(encoded, torch.Tensor)
+        assert encoded.dtype == torch.uint8
+        assert encoded.ndim == 1
+        assert encoded.device.type == "cpu"
+
+        assert encoded[:8].tolist() == [137, 80, 78, 71, 13, 10, 26, 10]
+        # PNG is lossless, so the round trip is exact.
+        torch.testing.assert_close(
+            decode_png(encoded, mode="RGB"), source, rtol=0, atol=0
+        )
+
     # ===== JPEG =====
 
     # (quality, min_psnr): minimum acceptable round-trip PSNR (dB) per JPEG
@@ -2585,16 +2605,6 @@ class TestImageEncoders:
         pil_decoded = Image.open(io.BytesIO(encoded.cpu().numpy().tobytes()))
         assert pil_decoded.format == "JPEG"
         assert decode_jpeg(encoded.cpu(), mode="RGB").shape == img.shape
-
-    @needs_jpeg
-    @pytest.mark.parametrize("device", _cpu_and_cuda)
-    def test_dest_none_matches_file_like(self, device):
-        # The dest=None bytes must be identical to the file-like path's bytes.
-        img = decode_jpeg(GRADIENT_JPEG.path, mode="RGB").to(device)
-
-        from_none = encode_jpeg(img, quality=90).cpu()
-        from_file_like = self._encode_to_bytes(encode_jpeg, img, quality=90)
-        torch.testing.assert_close(from_none, from_file_like, rtol=0, atol=0)
 
     @needs_jpeg
     @pytest.mark.parametrize("quality", (-1, 101))


### PR DESCRIPTION
We could have a dedicated C++ path for that but it turns out relying on `BytesIO` is just as fast, and much simpler.