### PR TITLE
Rework public API of image encoders

### DIFF
--- a/benchmarks/encoders/benchmark_image_encoders.py
+++ b/benchmarks/encoders/benchmark_image_encoders.py
@@ -42,9 +42,9 @@ from torch import Tensor
 
 torch.set_num_threads(1)
 
-from torchcodec.encoders._image_encoders import (  # noqa: E402
-    encode_jpeg as tc_encode_jpeg,
-    encode_png as tc_encode_png,
+from torchcodec.encoders import (  # noqa: E402
+    JpegEncoder as TCJpegEncoder,
+    PngEncoder as TCPngEncoder,
 )
 from torchvision.io import (  # noqa: E402
     encode_jpeg as tv_encode_jpeg,
@@ -111,18 +111,18 @@ def load_source_image(override: Path | None) -> Tensor:
 def make_encode_fn(backend, fmt, dest, img, path, param):
     """Return a zero-arg callable that encodes `img` (in `fmt`) to `dest`, or
     None if the backend doesn't support that destination. `param` is the quality
-    (jpeg) or compression_level (png). torchcodec/torchvision take the encode
-    param positionally so this stays format-agnostic."""
+    (jpeg) or compression_level (png)."""
     is_png = fmt == "png"
     if backend == "torchcodec":
-        tc_encode = tc_encode_png if is_png else tc_encode_jpeg
+        Encoder = TCPngEncoder if is_png else TCJpegEncoder
+        kwargs = {"compression_level" if is_png else "quality": param}
         if dest == "file":
-            return lambda: tc_encode(img, path, param)
+            return lambda: Encoder(img).to_file(path, **kwargs)
         if dest == "file_like":
-            return lambda: tc_encode(img, io.BytesIO(), param)
-        # tensor: native dest=None. On CUDA it returns a device tensor
+            return lambda: Encoder(img).to_file_like(io.BytesIO(), **kwargs)
+        # tensor: native to_tensor(). On CUDA it returns a device tensor
         # (zero-copy); .cpu() brings it to host to match torchvision's path.
-        return lambda: tc_encode(img, None, param).cpu()
+        return lambda: Encoder(img).to_tensor(**kwargs).cpu()
 
     if backend == "torchvision":
         if is_png:
@@ -177,7 +177,9 @@ def make_batch_encode_fn(backend, imgs, quality):
     return the encoded bytes on the host (torchvision's live on the input
     device, so we .cpu() them)."""
     if backend == "torchcodec":
-        return lambda: [tc_encode_jpeg(img, quality=quality).cpu() for img in imgs]
+        return lambda: [
+            TCJpegEncoder(img).to_tensor(quality=quality).cpu() for img in imgs
+        ]
 
     if backend == "torchvision":
         return lambda: [t.cpu() for t in tv_encode_jpeg(list(imgs), quality=quality)]

--- a/src/torchcodec/encoders/__init__.py
+++ b/src/torchcodec/encoders/__init__.py
@@ -1,3 +1,4 @@
 from ._audio_encoder import AudioEncoder  # noqa
+from ._image_encoders import JpegEncoder, PngEncoder  # noqa
 from ._multi_stream_encoder import AudioStream, Encoder, VideoStream  # noqa
 from ._video_encoder import VideoEncoder  # noqa

--- a/src/torchcodec/encoders/_image_encoders.py
+++ b/src/torchcodec/encoders/_image_encoders.py
@@ -8,6 +8,7 @@ import io
 from pathlib import Path
 
 import torch
+from torch import Tensor
 
 from torchcodec._core.ops import (
     create_file_like_context,
@@ -19,112 +20,65 @@ from torchcodec._core.ops import (
 )
 
 
-def _encode_to_dest(input, dest, param, *, to_file, to_file_like) -> None:
-    if isinstance(dest, (str, Path)):
-        to_file(input, str(dest), param)
-    else:
-        # Assume file-like, it gets validated in C++ (it's tested).
-        to_file_like(input, create_file_like_context(dest, True), param)
-
-
-def _encode_to_tensor_through_bytesio(input, param, to_file_like) -> torch.Tensor:
+def _encode_to_tensor_through_bytesio(img, param, to_file_like) -> Tensor:
     # Encode into an in-memory BytesIO and wrap its buffer as a 1-D uint8 tensor.
     # getbuffer() (unlike getvalue()) exposes the buffer without copying. We
     # could have native C++ implementation for that in each encoder, but it's
     # not always worth it (based on benchmarks). Currently, the only encoder
     # that really needs a dedicated C++ path is JPEG on CUDA.
     buf = io.BytesIO()
-    to_file_like(input, create_file_like_context(buf, True), param)
+    to_file_like(img, create_file_like_context(buf, True), param)
     return torch.frombuffer(buf.getbuffer(), dtype=torch.uint8)
 
 
-def encode_png(
-    input: torch.Tensor,
-    dest: str | Path | None = None,
-    compression_level: int = 6,
-) -> torch.Tensor | None:
-    """Encode a CHW uint8 image tensor into a PNG.
+class JpegEncoder:
+    def __init__(self, img: Tensor) -> None:
+        self._img = img
 
-    Args:
-        input (``torch.Tensor``): The image to encode, a 3-dimensional uint8
-            tensor in CHW layout with 1 (grayscale) or 3 (RGB) channels.
-        dest (str, ``pathlib.Path``, file-like object, or ``None``): The
-            destination to write the encoded PNG to. Either a path to the output
-            file, or a file-like object that supports
-            ``write(data: bytes) -> int`` and
-            ``seek(offset: int, whence: int = 0) -> int``, such as
-            ``io.BytesIO()`` or an open file in binary write mode. If ``None``
-            (the default), the encoded bytes are returned as a 1-D uint8 tensor
-            instead of being written anywhere.
-        compression_level (int): zlib compression level between 0 (no
-            compression, fastest) and 9 (max compression, slowest). Default: 6.
+    def to_file(self, dest: str | Path, *, quality: int = 75) -> None:
+        self._validate_quality(quality)
+        _encode_jpeg_to_file(self._img, str(dest), quality)
 
-    Returns:
-        ``None`` if ``dest`` is a path or file-like object, otherwise a 1-D uint8
-        tensor of the encoded bytes.
-    """
-    if dest is None:
-        return _encode_to_tensor_through_bytesio(
-            input, compression_level, _encode_png_to_file_like
+    def to_file_like(
+        self, dest: io.RawIOBase | io.BufferedIOBase, *, quality: int = 75
+    ) -> None:
+        self._validate_quality(quality)
+        _encode_jpeg_to_file_like(
+            self._img, create_file_like_context(dest, True), quality
         )
-    else:
-        _encode_to_dest(
-            input,
-            dest,
-            compression_level,
-            to_file=_encode_png_to_file,
-            to_file_like=_encode_png_to_file_like,
-        )
-        return None
 
-
-def encode_jpeg(
-    input: torch.Tensor,
-    dest: str | Path | None = None,
-    quality: int = 75,
-) -> torch.Tensor | None:
-    """Encode a CHW uint8 image tensor into a JPEG.
-
-    Args:
-        input (``torch.Tensor``): The image to encode, a 3-dimensional uint8
-            tensor in CHW layout with 1 (grayscale) or 3 (RGB) channels.
-        dest (str, ``pathlib.Path``, file-like object, or ``None``): The
-            destination to write the encoded JPEG to. Either a path to the output
-            file, or a file-like object that supports
-            ``write(data: bytes) -> int`` and
-            ``seek(offset: int, whence: int = 0) -> int``, such as
-            ``io.BytesIO()`` or an open file in binary write mode. If ``None``
-            (the default), the encoded bytes are returned as a 1-D uint8 tensor
-            instead of being written anywhere.
-        quality (int): Quality of the resulting JPEG, between 1 and 100. Higher
-            means better quality and larger file size. Default: 75.
-
-    Returns:
-        ``None`` if ``dest`` is a path or file-like object. If ``dest`` is
-        ``None``, a 1-D uint8 tensor of the encoded bytes, on the same device as
-        ``input`` (a CUDA input yields a CUDA tensor; call ``.cpu()`` for host
-        bytes).
-
-    If ``input`` is on a CUDA device, encoding is performed on the GPU with
-    nvJPEG. Only 3-channel RGB tensors are supported on CUDA (grayscale must be
-    encoded on the CPU).
-    """
-    if quality < 1 or quality > 100:
-        raise ValueError("Image quality should be a positive number between 1 and 100")
-
-    if dest is None:
-        if input.is_cuda:
-            return _encode_jpeg_to_tensor_cuda(input, quality)
+    def to_tensor(self, *, quality: int = 75) -> Tensor:
+        self._validate_quality(quality)
+        if self._img.is_cuda:
+            return _encode_jpeg_to_tensor_cuda(self._img, quality)
         else:
             return _encode_to_tensor_through_bytesio(
-                input, quality, _encode_jpeg_to_file_like
+                self._img, quality, _encode_jpeg_to_file_like
             )
-    else:
-        _encode_to_dest(
-            input,
-            dest,
-            quality,
-            to_file=_encode_jpeg_to_file,
-            to_file_like=_encode_jpeg_to_file_like,
+
+    @staticmethod
+    def _validate_quality(quality: int) -> None:
+        if quality < 1 or quality > 100:
+            raise ValueError(
+                "Image quality should be a positive number between 1 and 100"
+            )
+
+
+class PngEncoder:
+    def __init__(self, img: Tensor) -> None:
+        self._img = img
+
+    def to_file(self, dest: str | Path, *, compression_level: int = 6) -> None:
+        _encode_png_to_file(self._img, str(dest), compression_level)
+
+    def to_file_like(
+        self, dest: io.RawIOBase | io.BufferedIOBase, *, compression_level: int = 6
+    ) -> None:
+        _encode_png_to_file_like(
+            self._img, create_file_like_context(dest, True), compression_level
         )
-        return None
+
+    def to_tensor(self, *, compression_level: int = 6) -> Tensor:
+        return _encode_to_tensor_through_bytesio(
+            self._img, compression_level, _encode_png_to_file_like
+        )

--- a/test/smoke_test.py
+++ b/test/smoke_test.py
@@ -34,8 +34,13 @@ from torchcodec.decoders import (
     decode_webp,
     VideoDecoder,
 )
-from torchcodec.encoders import AudioEncoder, Encoder, VideoEncoder
-from torchcodec.encoders._image_encoders import encode_jpeg, encode_png
+from torchcodec.encoders import (
+    AudioEncoder,
+    Encoder,
+    JpegEncoder,
+    PngEncoder,
+    VideoEncoder,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -336,22 +341,30 @@ class TestImageDecoder:
         assert img.shape == (3, h, w)
 
 
-# CUDA JPEG encoding is triggered by the input tensor's device, so we wrap
-# encode_jpeg to move the input to the GPU.
-def _encode_jpeg_cuda(input, dest):
-    return encode_jpeg(input.cuda(), dest)
-
-
-# Each backend: (encode_fn, decode_fn, suffix, lossless).
+# Each backend: (Encoder, device, decode_fn, suffix, lossless). CUDA JPEG
+# encoding is triggered by the input tensor's device.
 _IMAGE_ENCODERS = (
     pytest.param(
-        encode_png, decode_png, "png", True, marks=pytest.mark.needs_png, id="png"
+        PngEncoder,
+        "cpu",
+        decode_png,
+        "png",
+        True,
+        marks=pytest.mark.needs_png,
+        id="png",
     ),
     pytest.param(
-        encode_jpeg, decode_jpeg, "jpg", False, marks=pytest.mark.needs_jpeg, id="jpeg"
+        JpegEncoder,
+        "cpu",
+        decode_jpeg,
+        "jpg",
+        False,
+        marks=pytest.mark.needs_jpeg,
+        id="jpeg",
     ),
     pytest.param(
-        _encode_jpeg_cuda,
+        JpegEncoder,
+        "cuda",
         decode_jpeg,
         "jpg",
         False,
@@ -362,26 +375,34 @@ _IMAGE_ENCODERS = (
 
 
 class TestImageEncoder:
-    def _make_image(self):
-        return torch.randint(0, 256, (3, HEIGHT, WIDTH), dtype=torch.uint8)
+    def _make_image(self, device):
+        return torch.randint(
+            0, 256, (3, HEIGHT, WIDTH), dtype=torch.uint8, device=device
+        )
 
-    @pytest.mark.parametrize("encode_fn,decode_fn,suffix,lossless", _IMAGE_ENCODERS)
-    def test_encode_to_file(self, tmp_path, encode_fn, decode_fn, suffix, lossless):
-        img = self._make_image()
+    @pytest.mark.parametrize(
+        "Encoder,device,decode_fn,suffix,lossless", _IMAGE_ENCODERS
+    )
+    def test_encode_to_file(
+        self, tmp_path, Encoder, device, decode_fn, suffix, lossless
+    ):
+        img = self._make_image(device)
         path = tmp_path / f"out.{suffix}"
-        encode_fn(img, path)
+        Encoder(img).to_file(path)
         assert path.stat().st_size > 0
 
         decoded = decode_fn(str(path))
         assert decoded.shape == (3, HEIGHT, WIDTH)
         if lossless:
-            torch.testing.assert_close(decoded, img, atol=0, rtol=0)
+            torch.testing.assert_close(decoded, img.cpu(), atol=0, rtol=0)
 
-    @pytest.mark.parametrize("encode_fn,decode_fn,suffix,lossless", _IMAGE_ENCODERS)
-    def test_encode_to_file_like(self, encode_fn, decode_fn, suffix, lossless):
-        img = self._make_image()
+    @pytest.mark.parametrize(
+        "Encoder,device,decode_fn,suffix,lossless", _IMAGE_ENCODERS
+    )
+    def test_encode_to_file_like(self, Encoder, device, decode_fn, suffix, lossless):
+        img = self._make_image(device)
         buf = io.BytesIO()
-        encode_fn(img, buf)
+        Encoder(img).to_file_like(buf)
         assert buf.getbuffer().nbytes > 0
 
 

--- a/test/test_encoders.py
+++ b/test/test_encoders.py
@@ -15,8 +15,13 @@ from PIL import Image
 from torchcodec import ffmpeg_major_version
 from torchcodec.decoders import AudioDecoder, decode_jpeg, decode_png, VideoDecoder
 
-from torchcodec.encoders import AudioEncoder, Encoder, VideoEncoder
-from torchcodec.encoders._image_encoders import encode_jpeg, encode_png
+from torchcodec.encoders import (
+    AudioEncoder,
+    Encoder,
+    JpegEncoder,
+    PngEncoder,
+    VideoEncoder,
+)
 
 from .utils import (
     assert_tensor_close_on_at_least,
@@ -2371,18 +2376,12 @@ class TestEncoder:
 _cpu_and_cuda = ("cpu", pytest.param("cuda", marks=pytest.mark.needs_cuda))
 
 
-def _encode_jpeg_cuda(input, dest=None, **kwargs):
-    # Encode with the input moved to the GPU, so encode_jpeg dispatches to
-    # nvJPEG. Lets the shared encoder tests below exercise the CUDA path through
-    # the exact same public API as the CPU encoders.
-    return encode_jpeg(input.cuda(), dest, **kwargs)
-
-
-_encoders = (
-    pytest.param(encode_png, marks=pytest.mark.needs_png, id="png"),
-    pytest.param(encode_jpeg, marks=pytest.mark.needs_jpeg, id="jpeg"),
+_image_encoders = (
+    pytest.param(PngEncoder, "cpu", marks=pytest.mark.needs_png, id="png"),
+    pytest.param(JpegEncoder, "cpu", marks=pytest.mark.needs_jpeg, id="jpeg"),
     pytest.param(
-        _encode_jpeg_cuda,
+        JpegEncoder,
+        "cuda",
         marks=(pytest.mark.needs_jpeg, pytest.mark.needs_cuda),
         id="jpeg_cuda",
     ),
@@ -2394,39 +2393,39 @@ class TestImageEncoders:
         # Decode an asset into a CHW uint8 tensor to use as encoder input.
         return decode_png(asset.path, mode=mode)
 
-    def _encode_to_bytes(self, encode, source, **kwargs):
+    def _to_bytes(self, encoder, **kwargs):
         # Encode into an in-memory file-like and return the raw bytes as a 1D
         # uint8 tensor, so the codec-specific tests below can inspect the output.
         buf = io.BytesIO()
-        encode(source, buf, **kwargs)
+        encoder.to_file_like(buf, **kwargs)
         return torch.frombuffer(buf.getvalue(), dtype=torch.uint8)
 
     # ===== destination handling, all codecs =====
 
-    @pytest.mark.parametrize("encode", _encoders)
-    def test_dest_variants_match(self, encode, tmp_path):
+    @pytest.mark.parametrize("Encoder, device", _image_encoders)
+    def test_dest_variants_match(self, Encoder, device, tmp_path):
         # All three destinations must produce identical bytes: a file path, a
         # file-like object, and a tensor
-        source = self._decode(GRADIENT_PNG, "RGB")
+        source = self._decode(GRADIENT_PNG, "RGB").to(device)
 
         path = tmp_path / "out"
-        encode(source, path)
+        Encoder(source).to_file(path)
         from_path = torch.frombuffer(path.read_bytes(), dtype=torch.uint8)
 
-        from_file_like = self._encode_to_bytes(encode, source)
-        from_tensor = encode(source).cpu()  # dest=None
+        from_file_like = self._to_bytes(Encoder(source))
+        from_tensor = Encoder(source).to_tensor().cpu()
 
         torch.testing.assert_close(from_path, from_file_like, rtol=0, atol=0)
         torch.testing.assert_close(from_path, from_tensor, rtol=0, atol=0)
 
-    @pytest.mark.parametrize("encode", _encoders)
-    def test_dest_str_and_pathlib(self, encode, tmp_path):
-        # dest accepts both str and pathlib.Path.
-        source = self._decode(GRADIENT_PNG, "RGB")
+    @pytest.mark.parametrize("Encoder, device", _image_encoders)
+    def test_dest_str_and_pathlib(self, Encoder, device, tmp_path):
+        # to_file accepts both str and pathlib.Path.
+        source = self._decode(GRADIENT_PNG, "RGB").to(device)
         as_str = tmp_path / "str_out"
         as_path = tmp_path / "path_out"
-        encode(source, str(as_str))
-        encode(source, as_path)
+        Encoder(source).to_file(str(as_str))
+        Encoder(source).to_file(as_path)
         torch.testing.assert_close(
             torch.frombuffer(as_str.read_bytes(), dtype=torch.uint8),
             torch.frombuffer(as_path.read_bytes(), dtype=torch.uint8),
@@ -2434,16 +2433,16 @@ class TestImageEncoders:
             atol=0,
         )
 
-    @pytest.mark.parametrize("encode", _encoders)
-    def test_dest_open_file_object(self, encode, tmp_path):
-        # A real open file (in binary write mode) is a valid file-like dest.
-        source = self._decode(GRADIENT_PNG, "RGB")
+    @pytest.mark.parametrize("Encoder, device", _image_encoders)
+    def test_dest_open_file_object(self, Encoder, device, tmp_path):
+        # A real open file (in binary write mode) is a valid to_file_like dest.
+        source = self._decode(GRADIENT_PNG, "RGB").to(device)
         path = tmp_path / "out"
         with open(path, "wb") as f:
-            encode(source, f)
+            Encoder(source).to_file_like(f)
         torch.testing.assert_close(
             torch.frombuffer(path.read_bytes(), dtype=torch.uint8),
-            self._encode_to_bytes(encode, source),
+            self._to_bytes(Encoder(source)),
             rtol=0,
             atol=0,
         )
@@ -2457,8 +2456,8 @@ class TestImageEncoders:
     @pytest.mark.parametrize("compression_level", (0, 6, 9))
     def test_round_trip_png(self, asset, mode, compression_level):
         source = self._decode(asset, mode)
-        encoded = self._encode_to_bytes(
-            encode_png, source, compression_level=compression_level
+        encoded = self._to_bytes(
+            PngEncoder(source), compression_level=compression_level
         )
 
         assert encoded.dtype == torch.uint8
@@ -2474,7 +2473,7 @@ class TestImageEncoders:
     @needs_png
     def test_against_pil_png(self):
         source = self._decode(GRADIENT_PNG, "RGB")
-        encoded = self._encode_to_bytes(encode_png, source)
+        encoded = self._to_bytes(PngEncoder(source))
 
         pil_img = Image.open(io.BytesIO(encoded.numpy().tobytes()))
         assert pil_img.format == "PNG"
@@ -2484,16 +2483,16 @@ class TestImageEncoders:
     @needs_png
     def test_compression_level_affects_size_png(self):
         source = self._decode(GRADIENT_PNG, "RGB")
-        least = self._encode_to_bytes(encode_png, source, compression_level=0).numel()
-        most = self._encode_to_bytes(encode_png, source, compression_level=9).numel()
+        least = self._to_bytes(PngEncoder(source), compression_level=0).numel()
+        most = self._to_bytes(PngEncoder(source), compression_level=9).numel()
         assert least > most
 
     @needs_png
     def test_default_compression_level_png(self):
         source = self._decode(GRADIENT_PNG, "RGB")
         torch.testing.assert_close(
-            self._encode_to_bytes(encode_png, source),
-            self._encode_to_bytes(encode_png, source, compression_level=6),
+            self._to_bytes(PngEncoder(source)),
+            self._to_bytes(PngEncoder(source), compression_level=6),
             rtol=0,
             atol=0,
         )
@@ -2503,14 +2502,16 @@ class TestImageEncoders:
     def test_bad_compression_level_png(self, compression_level):
         source = self._decode(GRADIENT_PNG, "RGB")
         with pytest.raises(RuntimeError, match="between 0 and 9"):
-            encode_png(source, io.BytesIO(), compression_level=compression_level)
+            PngEncoder(source).to_file_like(
+                io.BytesIO(), compression_level=compression_level
+            )
 
     @needs_png
-    def test_dest_none_returns_tensor_png(self):
-        # dest=None returns the encoded bytes as a 1-D uint8 CPU tensor.
+    def test_to_tensor_png(self):
+        # to_tensor returns the encoded bytes as a 1-D uint8 CPU tensor.
         source = self._decode(GRADIENT_PNG, "RGB")
 
-        encoded = encode_png(source)
+        encoded = PngEncoder(source).to_tensor()
         assert isinstance(encoded, torch.Tensor)
         assert encoded.dtype == torch.uint8
         assert encoded.ndim == 1
@@ -2538,7 +2539,7 @@ class TestImageEncoders:
         # then decode it back and check the round trip is faithful
         img = decode_jpeg(GRADIENT_JPEG.path, mode="RGB").to(device)
 
-        encoded = self._encode_to_bytes(encode_jpeg, img, quality=quality)
+        encoded = self._to_bytes(JpegEncoder(img), quality=quality)
         assert encoded.dtype == torch.uint8
         assert encoded.ndim == 1
 
@@ -2575,7 +2576,7 @@ class TestImageEncoders:
         img = decode_jpeg(GRAYSCALE_JPEG.path, mode="UNCHANGED")
         assert img.shape[0] == 1
 
-        encoded = self._encode_to_bytes(encode_jpeg, img, quality=quality)
+        encoded = self._to_bytes(JpegEncoder(img), quality=quality)
         decoded = decode_jpeg(encoded, mode="UNCHANGED")
         assert decoded.shape == img.shape
         assert psnr(decoded, img) > min_psnr
@@ -2584,18 +2585,18 @@ class TestImageEncoders:
     @pytest.mark.parametrize("device", _cpu_and_cuda)
     def test_quality_affects_size_jpeg(self, device):
         img = decode_jpeg(GRADIENT_JPEG.path, mode="RGB").to(device)
-        low = self._encode_to_bytes(encode_jpeg, img, quality=10).numel()
-        high = self._encode_to_bytes(encode_jpeg, img, quality=95).numel()
+        low = self._to_bytes(JpegEncoder(img), quality=10).numel()
+        high = self._to_bytes(JpegEncoder(img), quality=95).numel()
         assert high > low
 
     @needs_jpeg
     @pytest.mark.parametrize("device", _cpu_and_cuda)
-    def test_dest_none_returns_tensor(self, device):
-        # dest=None returns the encoded bytes as a 1-D uint8 tensor on the same
+    def test_to_tensor_jpeg(self, device):
+        # to_tensor returns the encoded bytes as a 1-D uint8 tensor on the same
         # device as the input (CUDA in -> CUDA out, zero-copy).
         img = decode_jpeg(GRADIENT_JPEG.path, mode="RGB").to(device)
 
-        encoded = encode_jpeg(img, quality=90)
+        encoded = JpegEncoder(img).to_tensor(quality=90)
         assert isinstance(encoded, torch.Tensor)
         assert encoded.dtype == torch.uint8
         assert encoded.ndim == 1
@@ -2612,8 +2613,8 @@ class TestImageEncoders:
             ValueError,
             match="Image quality should be a positive number between 1 and 100",
         ):
-            encode_jpeg(
-                torch.zeros(3, 8, 8, dtype=torch.uint8), io.BytesIO(), quality=quality
+            JpegEncoder(torch.zeros(3, 8, 8, dtype=torch.uint8)).to_file_like(
+                io.BytesIO(), quality=quality
             )
 
     @needs_cuda
@@ -2622,32 +2623,35 @@ class TestImageEncoders:
         # nvJPEG encoding only supports 3-channel RGB; grayscale must use the CPU.
         img = torch.zeros(1, 8, 8, dtype=torch.uint8, device="cuda")
         with pytest.raises(RuntimeError, match="number of channels should be 3"):
-            encode_jpeg(img, io.BytesIO())
+            JpegEncoder(img).to_file_like(io.BytesIO())
 
     # ===== shared validation - all codecs =====
 
-    @pytest.mark.parametrize("encode", _encoders)
-    def test_bad_dtype(self, encode):
+    @pytest.mark.parametrize("Encoder, device", _image_encoders)
+    def test_bad_dtype(self, Encoder, device):
+        img = torch.zeros(3, 8, 8, dtype=torch.float32, device=device)
         with pytest.raises(RuntimeError, match="uint8"):
-            encode(torch.zeros(3, 8, 8, dtype=torch.float32), io.BytesIO())
+            Encoder(img).to_file_like(io.BytesIO())
 
-    @pytest.mark.parametrize("encode", _encoders)
+    @pytest.mark.parametrize("Encoder, device", _image_encoders)
     @pytest.mark.parametrize("shape", ((720, 1280), (3, 3, 8, 8)))
-    def test_bad_ndim(self, encode, shape):
+    def test_bad_ndim(self, Encoder, device, shape):
+        img = torch.zeros(shape, dtype=torch.uint8, device=device)
         with pytest.raises(RuntimeError, match="3-dimensional"):
-            encode(torch.zeros(shape, dtype=torch.uint8), io.BytesIO())
+            Encoder(img).to_file_like(io.BytesIO())
 
-    @pytest.mark.parametrize("encode", _encoders)
+    @pytest.mark.parametrize("Encoder, device", _image_encoders)
     @pytest.mark.parametrize("num_channels", (2, 4))
-    def test_bad_num_channels(self, encode, num_channels):
+    def test_bad_num_channels(self, Encoder, device, num_channels):
         # CPU encoders accept 1 or 3 channels; the CUDA (nvJPEG) path is RGB-only,
         # so its message differs. Both reject 2 and 4 channels.
+        img = torch.zeros(num_channels, 8, 8, dtype=torch.uint8, device=device)
         with pytest.raises(RuntimeError, match="number of channels should be"):
-            encode(torch.zeros(num_channels, 8, 8, dtype=torch.uint8), io.BytesIO())
+            Encoder(img).to_file_like(io.BytesIO())
 
-    @pytest.mark.parametrize("encode", _encoders)
-    def test_bad_file_like(self, encode):
-        img = torch.zeros(3, 8, 8, dtype=torch.uint8)
+    @pytest.mark.parametrize("Encoder, device", _image_encoders)
+    def test_bad_file_like(self, Encoder, device):
+        img = torch.zeros(3, 8, 8, dtype=torch.uint8, device=device)
 
         class NoWriteMethod:
             def seek(self, offset, whence=0):
@@ -2656,7 +2660,7 @@ class TestImageEncoders:
         with pytest.raises(
             RuntimeError, match="File like object must implement a write method"
         ):
-            encode(img, NoWriteMethod())
+            Encoder(img).to_file_like(NoWriteMethod())
 
         class NoSeekMethod:
             def write(self, data):
@@ -2665,9 +2669,9 @@ class TestImageEncoders:
         with pytest.raises(
             RuntimeError, match="File like object must implement a seek method"
         ):
-            encode(img, NoSeekMethod())
+            Encoder(img).to_file_like(NoSeekMethod())
 
         with pytest.raises(
             RuntimeError, match="File like object must implement a write method"
         ):
-            encode(img, dest=3)
+            Encoder(img).to_file_like(3)


### PR DESCRIPTION
We landed on the following public API with per-codec encoding classes:

```py
  class JpegEncoder:
      def __init__(self, img: Tensor) -> None
      def to_file(self, dest: str | Path, *, quality: int = 75) -> None
      def to_file_like(self, dest: FileLike, *, quality: int = 75) -> None
      def to_tensor(self, *, quality: int = 75) -> Tensor

  class PngEncoder:
      def __init__(self, img: Tensor) -> None
      def to_file(self, dest, *, compression_level: int = 6) -> None
      def to_file_like(self, dest, *, compression_level: int = 6) -> None
      def to_tensor(self, *, compression_level: int = 6) -> Tensor

```

We wanted:

- first-class support for to-tensor (it's critical for the CUDA jpeg encoder which needs output tensors on CUDA)
- first-class support for to-file and to-file-like: it's consistent with the existing encoders we have in TC, and it's much faster than going through a tensor of bytes which is what TC was doing. See benchmarks in https://github.com/meta-pytorch/torchcodec/pull/1578

This made it difficult to cleanly support through single-entry-point pure functions like in TV: `encode_jpeg(...)`, etc.

The per-class encoders are consistent with the existing `AudioEncoder` and `VideoEncoder` which expose the same methods. 

I'm dropping batch-input support that was supported by torchvision for the JPEG encoder: benchmarks showed no improvement, so this doesn't appear to be necessary


<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>